### PR TITLE
Use Makefile to separate responsibilities a bit more

### DIFF
--- a/.prow.sh
+++ b/.prow.sh
@@ -2,9 +2,5 @@
 set -xeuo pipefail
 
 yum -y install jq
-for jsonfile in *.json; do
-    echo "Checking JSON syntax for $jsonfile"
-    jq < $jsonfile . >/dev/null
-done
-
-imagebuild -privileged .
+make syntax-check
+make container

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,11 @@
-refresh:
-	curl -q "https://storage.googleapis.com/origin-ci-test/releases/openshift/origin/master/origin.repo" 2>/dev/null >openshift.repo
-.PHONY: refresh
+.PHONY: syntax-check
+syntax-check:
+	@set -e; for jsonfile in $$(find . -name '*.json'); do \
+		echo -n "Checking JSON syntax for $${jsonfile}... "; \
+		jq < $${jsonfile} . >/dev/null; \
+		echo "OK"; \
+	done
+
+.PHONY: container
+container:
+	imagebuild -privileged .

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Demonstration of building a host OSTree as a container image
+# Demonstration of delivering OSTree host updates as a container image
 
 This project does an [rpm-ostree](https://github.com/projectatomic/rpm-ostree)
 build inside a container; that container can then be pulled and run in a cluster,


### PR DESCRIPTION
Let's standardize on the `Makefile` as the CLI-friendly approach for
local development. E.g. `make syntax-check` to verify that the JSON
files are sane, and `make container` to build an update-in-container.
OTOH, `.prow.sh` still does `yum -y install jq`.

My goal is to then add more Makefile targets that can be used by humans
as well as by various CIs.