### PR TITLE
overlay.yml: Add origin to be one of the packages

### DIFF
--- a/overlay.yml
+++ b/overlay.yml
@@ -23,3 +23,8 @@ components:
 
 #   - src: github:coreos/ignition
 #   TODO: use copr for distgit here OR get spec in the ignition repo
+
+    # Use the internal spec specified in origin repo
+    # so we don't pull content from dist-git
+  - src: github:openshift/origin
+    spec: internal


### PR DESCRIPTION
Add origin and uses its repo's spec file for rpmdistro-gitoverlay(building rpms).

One thing to note that, origin repo switched to hyperkube since commit
https://github.com/openshift/origin/commit/1116e0579edb226b70c693c42e61a77ad2c33503,
kubelet is no longer included in the origin.spec.

Environment is a docker container with https://github.com/cgwalters/rpmdistro-gitoverlay/pull/43 's steps
The output for build is as the following: 
```
[root@a20e073781a4 origin-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3]# ls
build.log                                                                                            origin-master-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.x86_64.rpm
hw_info.log                                                                                          origin-node-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.x86_64.rpm
installed_pkgs.log                                                                                   origin-pod-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.x86_64.rpm
origin-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.src.rpm                     origin-sdn-ovs-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.x86_64.rpm
origin-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.x86_64.rpm                  origin-template-service-broker-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.x86_64.rpm
origin-clients-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.x86_64.rpm          origin-tests-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.x86_64.rpm
origin-docker-excluder-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.noarch.rpm  root.log
origin-excluder-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.noarch.rpm         srpm
origin-hyperkube-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.x86_64.rpm        state.log
origin-hypershift-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.x86_64.rpm       status.json
```

The end of the buildlog
```
Checking for unpackaged file(s): /usr/lib/rpm/check-files /builddir/build/BUILDROOT/origin-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.x86_64
Wrote: /builddir/build/RPMS/origin-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.x86_64.rpm
Wrote: /builddir/build/RPMS/origin-hypershift-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.x86_64.rpm
Wrote: /builddir/build/RPMS/origin-hyperkube-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.x86_64.rpm
Wrote: /builddir/build/RPMS/origin-master-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.x86_64.rpm
Wrote: /builddir/build/RPMS/origin-tests-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.x86_64.rpm
Wrote: /builddir/build/RPMS/origin-node-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.x86_64.rpm
Wrote: /builddir/build/RPMS/origin-clients-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.x86_64.rpm
Wrote: /builddir/build/RPMS/origin-pod-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.x86_64.rpm
Wrote: /builddir/build/RPMS/origin-sdn-ovs-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.x86_64.rpm
Wrote: /builddir/build/RPMS/origin-template-service-broker-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.x86_64.rpm
Wrote: /builddir/build/RPMS/origin-excluder-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.noarch.rpm
Wrote: /builddir/build/RPMS/origin-docker-excluder-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.noarch.rpm
Executing(%clean): /bin/sh -e /var/tmp/rpm-tmp.CQPyLs
+ umask 022
+ cd /builddir/build/BUILD
+ cd origin-v3.10.0-alpha.0-1088-9fd79442c18ddcc6de67ca6610d797def83635d3
+ /usr/bin/rm -rf /builddir/build/BUILDROOT/origin-3.10.0.alpha.0.1088-9fd79442c18ddcc6de67ca6610d797def83635d3.fc28.x86_64
+ exit 0
Child return code was: 0
```
