### PR TITLE
manifest: Add CAHC repo

### DIFF
--- a/atomic-centos-continuous.repo
+++ b/atomic-centos-continuous.repo
@@ -1,4 +1,4 @@
-[ostree-master]
+[atomic-centos-continuous]
 name=CentOS OSTree bleeding edge
 baseurl=https://ci.centos.org/artifacts/sig-atomic/centos-continuous/rdgo/build/
 enabled=1

--- a/host-base.json
+++ b/host-base.json
@@ -3,7 +3,7 @@
     "osname": "openshift-host",
     "ref": "openshift/3.10/x86_64/os",
     "repos": [
-        "ostree-master",
+        "atomic-centos-continuous",
         "origin-repo",
         "dustymabe-ignition"
     ],


### PR DESCRIPTION
In preparation for adding more of the packages of interest there[1]. But
even right now, this will allow us to track ostree and rpm-ostree git
master.

[1] https://github.com/CentOS/sig-atomic-buildscripts/pull/326