### PR TITLE
treecompose: Generate openshift repo before composing

### DIFF
--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -14,8 +14,9 @@ node(env.NODE) {
 
     docker.image(DOCKER_IMG).inside(DOCKER_ARGS) {
         stage("Provision") {
-            sh "dnf install -y git rpm-ostree rsync openssh-clients"
+            sh "dnf install -y git make rpm-ostree rsync openssh-clients"
             sh "cp RPM-GPG-* /etc/pki/rpm-gpg/"
+            sh "make repo-refresh"
         }
 
         stage("Sync In") {

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ syntax-check:
 	done
 
 .PHONY: container
-container:
+container: repo-refresh
 	imagebuild -privileged .
 
-.PHONY: refresh
-refresh:
+.PHONY: repo-refresh
+repo-refresh:
 	./generate-openshift-repo

--- a/generate-openshift-repo
+++ b/generate-openshift-repo
@@ -9,4 +9,4 @@ name=openshift
 baseurl=${LATEST_OPENSHIFT_REPO}
 type=rpm
 enabled=1
-gpgcheck=0" > latest_openshift.repo
+gpgcheck=0" > openshift.repo

--- a/host-base.json
+++ b/host-base.json
@@ -4,7 +4,6 @@
     "ref": "openshift/3.10/x86_64/os",
     "repos": [
         "atomic-centos-continuous",
-        "origin-repo",
         "openshift",
         "dustymabe-ignition"
     ],

--- a/openshift.repo
+++ b/openshift.repo
@@ -1,5 +1,0 @@
-[origin-repo]
-name=Origin RPMs
-baseurl=https://storage.googleapis.com/origin-ci-test/logs/test_branch_origin_extended_conformance_azure/64/artifacts/rpms
-enabled=1
-gpgcheck=0


### PR DESCRIPTION
The treecompose has been erroring out on the fact that it's not finding
an "openshift" repo. Fix this by running `repo-refresh` during the
provisioning phase.