### PR TITLE
base: Enable ostree-remount

### DIFF
--- a/host-base.json
+++ b/host-base.json
@@ -125,6 +125,7 @@
     "units": [
         "docker.service",
         "tuned.service",
+        "ostree-remount.service",
         "docker-storage-setup.service"
     ],
     "default_target": "multi-user.target"


### PR DESCRIPTION
See https://src.fedoraproject.org/rpms/ostree/c/82d1f941ed1504840a63b5635e1051ccd2774b07?branch=master
We need a new `-release` package, in the meantime let's do this
quick hack.