### PR TITLE
host: Add origin* packages

### DIFF
--- a/host-base.json
+++ b/host-base.json
@@ -110,7 +110,9 @@
         "glusterfs-fuse",
         "dnsmasq",
         "oci-umount",
-        "origin-node"
+        "origin-node",
+        "origin-hyperkube",
+        "origin-clients"
     ],
     "remove-from-packages": [
         [


### PR DESCRIPTION
We need hyperkube which contains the kubelet, and we really
might as well ship the clients.