### PR TITLE
Build cni plugins

### DIFF
--- a/overlay.yml
+++ b/overlay.yml
@@ -27,3 +27,8 @@ components:
         name: ignition
         patches: drop
 
+  # Required as a cri-o dependency
+  - src: https://github.com/containernetworking/plugins.git
+    distgit:
+        name: containernetworking-cni
+        patches: drop


### PR DESCRIPTION
Add ``containernetworking-cni`` which provides ``containernetworking-pluigins`` for ``cri-o``.