### PR TITLE
prow: Stop building container for now

### DIFF
--- a/.prow.sh
+++ b/.prow.sh
@@ -3,4 +3,5 @@ set -xeuo pipefail
 
 yum -y install jq
 make syntax-check
-make container
+# https://github.com/openshift/os/pull/32#issuecomment-389523058
+# make container


### PR DESCRIPTION
Circular dependency issues.
We should make it a separate optional test most likely.