### PR TITLE
Add redhat-release-coreos

### DIFF
--- a/host-base.json
+++ b/host-base.json
@@ -129,7 +129,6 @@
     "units": [
         "docker.service",
         "tuned.service",
-        "ostree-remount.service",
         "docker-storage-setup.service"
     ],
     "default_target": "multi-user.target"

--- a/host-rhcos.json
+++ b/host-rhcos.json
@@ -6,5 +6,6 @@
         "rhel-7.5-server-extras",
         "rhel-7.5-atomic"
     ],
+    "packages": ["redhat-release-coreos"],
     "automatic_version_prefix": "3.10-7.5.0"
 }

--- a/overlay.yml
+++ b/overlay.yml
@@ -32,3 +32,6 @@ components:
     distgit:
         name: containernetworking-cni
         patches: drop
+
+  - src: github:openshift/redhat-release-coreos
+    spec: internal


### PR DESCRIPTION
We want to have our own release for many reasons.  This also
fixes the issue with having `ostree-remount.service` enabled,
so drop our treefile change for it.