### PR TITLE
ci: Re-enable container building on PRs

### DIFF
--- a/.prow.sh
+++ b/.prow.sh
@@ -3,5 +3,4 @@ set -xeuo pipefail
 
 yum -y install jq
 make syntax-check
-# https://github.com/openshift/os/pull/32#issuecomment-389523058
-# make container
+make container


### PR DESCRIPTION
The rdgo job has run and produced its first containernetworking-cni
package. Let's try turning this back on!

If we hit this often, we could also start running rdgo as part of the
tests.