### PR TITLE
treecompose: Use $WORKSPACE

### DIFF
--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -37,8 +37,8 @@ node(env.NODE) {
         }
 
         stage("Check for Changes") {
-            sh "rm -f build.stamp"
-            sh "rpm-ostree compose tree --dry-run --repo=${repo} --touch-if-changed=build.stamp ${manifest}"
+            sh "rm -f $WORKSPACE/build.stamp"
+            sh "rpm-ostree compose tree --dry-run --repo=${repo} --touch-if-changed=$WORKSPACE/build.stamp ${manifest}"
         }
 
         if (!fileExists('build.stamp')) {


### PR DESCRIPTION
I'm not sure what's going on here, but the same thing we hit with the
rdgo job is happening with the treecompose. I think it might have to do
with the fact that pipelines can have workspaces across e.g. multiple
places. Anyway, this fixed it for rdgo, so let's try it.