### PR TITLE
Default to rhcos, move host-origin to contrib/

### DIFF
--- a/.prow.sh
+++ b/.prow.sh
@@ -3,4 +3,5 @@ set -xeuo pipefail
 
 yum -y install jq
 make syntax-check
-make container
+# And disable the container again until we figure out about Prow -> internal
+# make container

--- a/Jenkinsfile.cloud
+++ b/Jenkinsfile.cloud
@@ -1,14 +1,7 @@
 // this var conveniently refers to a location on the server as well as the local dir we sync to/from
 def output = "${env.ARTIFACT_SERVER_DIR}/images"
 
-def ref
-if (env.BUILD_TYPE == 'origin') {
-    ref = "origin/3.10/x86_64/os"
-} else if (env.BUILD_TYPE == 'rhcos') {
-    ref = "openshift/3.10/x86_64/os"
-} else {
-    assert false
-}
+def ref = "openshift/3.10/x86_64/os";
 
 node(env.NODE) {
     checkout scm

--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -4,10 +4,7 @@ def DOCKER_ARGS = "--net=host -v /srv:/srv --privileged"
 // this var conveniently refers to a location on the server as well as the local dir we sync to/from
 def repo = "${env.ARTIFACT_SERVER_DIR}/repo"
 
-if (env.BUILD_TYPE != 'origin' && env.BUILD_TYPE != 'rhcos') {
-    assert false
-}
-def manifest = "host-${env.BUILD_TYPE}.json"
+def manifest = "host-rhcos.json"
 
 node(env.NODE) {
     checkout scm

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-OS_FLAVOR ?= origin
+OS_FLAVOR ?= rhcos
 # Use for e.g. --cache-only
 COMPOSEFLAGS ?=
 ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))

--- a/README.md
+++ b/README.md
@@ -11,22 +11,21 @@ $ docker build .
 $ docker push SOME_IMAGE
 ```
 
-Turn a CentOS Atomic AWS AMI booted machine into this OS:
+Turn a [CentOS Atomic](https://wiki.centos.org/SpecialInterestGroup/Atomic/Download) booted machine into this OS:
 
-1. Launch an AMI for CentOS 7 (ami-a06447da) with at least 20GB disk (10GB is too small for now)
+1. Provision a machine (e.g. an `ami-a06447da` in AWS us-east-1) with at least 20GB disk (10GB is too small for now)
 2. Resize the disk:
 
 ```
-$ lvextend -l +25%FREE atomicos/root
-$ xfs_growfs /
+$ lvm lvextend -r -l +25%FREE atomicos/root
 ```
 
 3. SSH to the machine and run:
 
 ```
 $ docker run --network host -d -w /srv/tree/repo $REGISTRY/os:latest
-$ ostree remote add --no-gpg-verify local http://localhost:8080 origin/3.10/x86_64/os
-$ rpm-ostree rebase -r local:origin/3.10/x86_64/os
+$ ostree remote add --no-gpg-verify local http://localhost:8080 openshift/3.10/x86_64/os
+$ rpm-ostree rebase -r local:openshift/3.10/x86_64/os
 
 # wait, SSH back in
 $ openshift version
@@ -39,8 +38,8 @@ $ kubectl run os-content --image=$REGISTRY/os:latest
 $ kubectl expose os-content --port 8080
 
 $ ssh root@NODE_HOST
-$ ostree remote add --no-gpg-verify local http://os-content.namespace.svc:8080 origin/3.10/x86_64/os
-$ rpm-ostree rebase -r local:origin/3.10/x86_64/os
+$ ostree remote add --no-gpg-verify local http://os-content.namespace.svc:8080 openshift/3.10/x86_64/os
+$ rpm-ostree rebase -r local:openshift/3.10/x86_64/os
 
 # wait, SSH back in
 $ openshift version

--- a/contrib/host-origin.json
+++ b/contrib/host-origin.json
@@ -1,4 +1,5 @@
 {
+    "00comment": "This file isn't maintained anymore",
     "include": "host-base.json",
     "ref": "origin/3.10/x86_64/os",
     "repos": [

--- a/host-base.json
+++ b/host-base.json
@@ -1,6 +1,6 @@
 {
     "comment": "OpenShift Host",
-    "osname": "openshift-host",
+    "osname": "rhcos",
     "ref": "openshift/3.10/x86_64/os",
     "repos": [
         "atomic-centos-continuous",


### PR DESCRIPTION
This will be the focus, let's ensure the `Makefile` defaults
to it.  And since we don't have a lot of bandwidth to maintain
multiple things here, let's move the origin one to contrib/ for now.