### PR TITLE
treecompose: Add db-diff

### DIFF
--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -5,6 +5,7 @@ def DOCKER_ARGS = "--net=host -v /srv:/srv --privileged"
 def repo = "${env.ARTIFACT_SERVER_DIR}/repo"
 
 def manifest = "host-rhcos.json"
+def ref = "openshift/3.10/x86_64/os";
 
 node(env.NODE) {
     checkout scm
@@ -45,8 +46,11 @@ node(env.NODE) {
         }
 
         stage("Compose Tree") {
-            sh "rpm-ostree compose tree --repo=${repo} ${manifest} --write-commitid-to $WORKSPACE/commit.txt"
-            currentBuild.description = '🆕 commit ' + readFile('commit.txt');
+            sh "rpm-ostree compose tree --repo=${repo} ${manifest}"
+            sh "ostree --repo=${repo} rev-parse ${ref} > commit.txt"
+            def commit = readFile('commit.txt');
+            currentBuild.description = '🆕 commit ' + commit;
+            sh "rpm-ostree db diff ${commit}^ ${commit}"
         }
 
         stage("Sync Out") {


### PR DESCRIPTION
I found this useful for FAHC.  Also...Groovy quoting vs shell
quoting is a huge mess.  I found
http://mrhaki.blogspot.com/2009/08/groovy-goodness-string-strings-strings.html
https://gist.github.com/Faheetah/e11bd0315c34ed32e681616e41279ef4
etc. very useful.

We should probably change our pipelines to use `chdir` and avoid
using source directories as strings.  Or maybe inject them
into the real environment?  Basically it feels saner to me if
we always use `sh('command')` and not `sh("command")`.