### PR TITLE
treecompose: Add missing --repo arg

### DIFF
--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -50,7 +50,7 @@ node(env.NODE) {
             sh "ostree --repo=${repo} rev-parse ${ref} > commit.txt"
             def commit = readFile('commit.txt');
             currentBuild.description = '🆕 commit ' + commit;
-            sh "rpm-ostree db diff ${commit}^ ${commit}"
+            sh "rpm-ostree --repo=${repo} db diff ${commit}^ ${commit}"
         }
 
         stage("Sync Out") {


### PR DESCRIPTION
So this has been a learning experience, I think what I really
want to do is spin up a container that does all the rpm-ostree stuff
that can be more easily shared across projects so I can use it
for FAHC too and not keep hitting bugs like this.