### PR TITLE
cloud: fix sha256sum generation

### DIFF
--- a/Jenkinsfile.cloud
+++ b/Jenkinsfile.cloud
@@ -86,7 +86,7 @@ node(env.NODE) {
             rpm-ostree db diff --repo=${repo} \
                 ${prev_commit} ${commit} > ${dirpath}/${commit}.pkgdiff
         """
-        sh "sha256sum ${qcow}.gz | awk "{print $1}" > ${qcow}.gz.sha256sum"
+        sh "sha256sum ${qcow}.gz | awk '{print $1}' > ${qcow}.gz.sha256sum"
     }
 
     stage("Sync Out") {


### PR DESCRIPTION
When the 'metadata' stage went to production, it blew up on the
generating `sha256sum` step with an error like this:

```
java.lang.NoSuchMethodError: No such DSL method 'sha256sum
/srv/rhcos/output/images/cloud/...
```

Since it worked on my test Jenkins, I'm just taking a guess that the
use of double-quotes around the `awk` command confused the DSL parser.

So this might fix it, but it might continue to fail...