### PR TITLE
cloud: remove sha256sum generation

### DIFF
--- a/Jenkinsfile.cloud
+++ b/Jenkinsfile.cloud
@@ -86,7 +86,6 @@ node(env.NODE) {
             rpm-ostree db diff --repo=${repo} \
                 ${prev_commit} ${commit} > ${dirpath}/${commit}.pkgdiff
         """
-        sh "sha256sum ${qcow}.gz | awk '{print $1}' > ${qcow}.gz.sha256sum"
     }
 
     stage("Sync Out") {


### PR DESCRIPTION
I don't want to block any pipeline progress, so let's remove the
`sha256sum` stuff for now.

I'll figure out a better way to do this in a separate PR.