### PR TITLE
cloud: escape Groovy's string interpolation

### DIFF
--- a/Jenkinsfile.cloud
+++ b/Jenkinsfile.cloud
@@ -86,7 +86,7 @@ node(env.NODE) {
             rpm-ostree db diff --repo=${repo} \
                 ${prev_commit} ${commit} > ${dirpath}/${commit}.pkgdiff
         """
-        sh "sha256sum ${qcow}.gz | awk '{print $1}' > ${qcow}.gz.sha256sum"
+        sh "sha256sum ${qcow}.gz | awk '{print \$1}' > ${qcow}.gz.sha256sum"
     }
 
     stage("Sync Out") {


### PR DESCRIPTION
@cgwalters was nice enough to figure out how strings are handled in
Groovy and teach us all.  See:

https://github.com/openshift/os/pull/46#discussion_r189708068