### PR TITLE
rdgo: Fix branch for ignition

### DIFF
--- a/overlay.yml
+++ b/overlay.yml
@@ -27,6 +27,7 @@ components:
         src: https://github.com/ashcrow/ignition-specs.git
         name: ignition
         patches: drop
+        branch: master
 
   # Required as a cri-o dependency
   - src: https://github.com/containernetworking/plugins.git


### PR DESCRIPTION
Followup fix to https://github.com/openshift/os/pull/51
The problem was changing the dist-git branch globally to `f28`.