### PR TITLE
cloud: Run `docker pull` on the node, not master

### DIFF
--- a/Jenkinsfile.cloud
+++ b/Jenkinsfile.cloud
@@ -1,6 +1,5 @@
 def DOCKER_IMG = "quay.io/cgwalters/coreos-assembler"
 def DOCKER_ARGS = "--net=host -v /srv:/srv --privileged"
-docker.image(DOCKER_IMG).pull()
 
 // this var conveniently refers to a location on the server as well as the local dir we sync to/from
 def server_dir = "${env.ARTIFACT_SERVER_DIR}"
@@ -10,6 +9,7 @@ def ref = "openshift/3.10/x86_64/os";
 
 node(env.NODE) {
     checkout scm
+    docker.image(DOCKER_IMG).pull()
 
     stage("Provision") {
         sh """


### PR DESCRIPTION
Since that's where we'll actually be running that image.