### PR TITLE
Add a "rollup" task that does ostreerepo → container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN cd /srv/tree && make repo-refresh && make rpmostree-compose && \
 # Now inject this content into a new container
 FROM registry.centos.org/centos/centos:7
 RUN yum install -y epel-release && yum -y install nginx && yum clean all
+# Keep this in sync with Dockerfile.rollup.in
 COPY --from=build /srv/tree /srv/tree
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY index.html subdomain.css /srv/tree/repo/

--- a/Dockerfile.rollup.in
+++ b/Dockerfile.rollup.in
@@ -1,0 +1,10 @@
+FROM registry.fedoraproject.org/fedora:28
+RUN yum -y install ostree nginx && yum clean all
+# These variables are templated 
+ADD rollup.sh /root
+RUN env OSTREE_REPO_URL=@OSTREE_REPO_URL@ /root/rollup.sh && rm -f /root/rollup.sh
+# Keep this in sync with Dockerfile
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY index.html subdomain.css /srv/tree/repo/
+EXPOSE 8080
+CMD ["nginx", "-c", "/etc/nginx/nginx.conf"]

--- a/Jenkinsfile.oscontainer
+++ b/Jenkinsfile.oscontainer
@@ -1,0 +1,23 @@
+def DOCKER_IMG = "quay.io/cgwalters/coreos-assembler"
+// Turns out the Jenkins docker stuff totally breaks with SELinux
+def DOCKER_ARGS = "--privileged"
+
+node(env.NODE) {
+    checkout scm
+
+    stage("Prepare Dockerfile") {
+        docker.image(DOCKER_IMG).pull()
+        docker.image(DOCKER_IMG).inside(DOCKER_ARGS) {
+          sh """sed -e 's,@OSTREE_REPO_URL@,${env.OSTREE_INSTALL_URL},' < Dockerfile.rollup.in > Dockerfile.rollup"""
+        }
+    }
+    docker.withRegistry("${env.REGISTRY}", "${env.REGISTRY_CREDENTIALS}") {
+        def img;
+        stage("Build container") {
+           img = docker.build("${env.IMAGE_NAME}", "-f Dockerfile.rollup .")
+        }
+        stage("Push container") {
+           img.push()
+        }
+    }
+}

--- a/rollup.sh
+++ b/rollup.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/bash
+# This script aggregates content
+set -xeuo pipefail
+mkdir -p /srv/tree
+cd /srv/tree
+ostree --repo=repo init --mode=archive
+ostree --repo=repo remote add remote --set=gpg-verify=false ${OSTREE_REPO_URL:-}
+ostree --repo=repo pull --mirror --depth=3 remote


### PR DESCRIPTION
This repository's initial `Dockerfile` runs rpm-ostree inside
a container, generating a container as a result.  But to generate e.g.
`qcow2` with the target content (as opposed to bootstrap), we also
today are doing a path where we have a "traditional" split out repo.

This closes the loop and generates a container that just "rolls up"
the existing ostree repo - so we'll have the same commits in both.