### PR TITLE
jenkins/rdgo: Allow empty artifacts

### DIFF
--- a/Jenkinsfile.rdgo
+++ b/Jenkinsfile.rdgo
@@ -76,7 +76,7 @@ node(env.NODE) {
     }
 
     } finally {
-        archiveArtifacts artifacts: "log/**"
+        archiveArtifacts artifacts: "log/**", allowEmptyArchive: true
     }
 }
 


### PR DESCRIPTION
The no-op case won't generate any.