### PR TITLE
oscontainer: Fix Jenkinsfile syntax

### DIFF
--- a/Jenkinsfile.oscontainer
+++ b/Jenkinsfile.oscontainer
@@ -22,8 +22,8 @@ node(NODE) {
 
     withCredentials([
         string(credentialsId: params.REGISTRY, variable: 'REGISTRY'),
-        string(credentialsId: params.REGISTRY_CREDENTIALS, variable: 'REGISTRY_CREDENTIALS')]),
-    {
+        string(credentialsId: params.REGISTRY_CREDENTIALS, variable: 'REGISTRY_CREDENTIALS'),
+    ]) {
         docker.withRegistry("${REGISTRY}", "${REGISTRY_CREDENTIALS}") {
             def img;
             stage("Build container") {


### PR DESCRIPTION
Minor regression from #64. Fix syntax error by using the same code style
as everywhere else.