### PR TITLE
oscontainer: Fix credentials passing for registry

### DIFF
--- a/Jenkinsfile.oscontainer
+++ b/Jenkinsfile.oscontainer
@@ -22,9 +22,8 @@ node(NODE) {
 
     withCredentials([
         string(credentialsId: params.REGISTRY, variable: 'REGISTRY'),
-        string(credentialsId: params.REGISTRY_CREDENTIALS, variable: 'REGISTRY_CREDENTIALS'),
     ]) {
-        docker.withRegistry("${REGISTRY}", "${REGISTRY_CREDENTIALS}") {
+        docker.withRegistry("${REGISTRY}", params.REGISTRY_CREDENTIALS) {
             def img;
             stage("Build container") {
                img = docker.build("coreos/openshift-redhat-coreos:3.10", "-f Dockerfile.rollup .")


### PR DESCRIPTION
The `docker.withRegistry` syntax already expects a credential ID rather
than a username/password. So skip wrapping it with `withCredentials` and
just pass the ID directly to `docker.withRegistry` instead.