### PR TITLE
Set timer interval directly from pipeline

### DIFF
--- a/Jenkinsfile.cloud
+++ b/Jenkinsfile.cloud
@@ -1,3 +1,4 @@
+def TIMER = "H H/3 * * *"
 def NODE = "rhcos-imgfac-jslave"
 def DOCKER_IMG = "quay.io/cgwalters/coreos-assembler"
 def DOCKER_ARGS = "--net=host -v /srv:/srv --privileged"
@@ -13,7 +14,7 @@ node(NODE) {
 
     checkout scm
     utils = load("pipeline-utils.groovy")
-    utils.define_parameters()
+    utils.define_properties(TIMER)
 
     stage("Provision") {
         sh """

--- a/Jenkinsfile.oscontainer
+++ b/Jenkinsfile.oscontainer
@@ -1,3 +1,4 @@
+def TIMER = "H/30 * * * *"
 def NODE = "atomic-jslave-autobrew"
 def DOCKER_IMG = "quay.io/cgwalters/coreos-assembler"
 // Turns out the Jenkins docker stuff totally breaks with SELinux
@@ -8,7 +9,7 @@ node(NODE) {
 
     checkout scm
     utils = load("pipeline-utils.groovy")
-    utils.define_parameters()
+    utils.define_properties(TIMER)
 
     stage("Prepare Dockerfile") {
         docker.image(DOCKER_IMG).inside(DOCKER_ARGS) {

--- a/Jenkinsfile.rdgo
+++ b/Jenkinsfile.rdgo
@@ -1,3 +1,4 @@
+def TIMER = "H/30 * * * *"
 def NODE = "atomic-jslave-autobrew"
 def DOCKER_IMG = "quay.io/cgwalters/coreos-assembler"
 def DOCKER_ARGS = "--net=host -v /srv:/srv --privileged"
@@ -11,7 +12,7 @@ node(NODE) {
 
     checkout scm
     utils = load("pipeline-utils.groovy")
-    utils.define_parameters()
+    utils.define_properties(TIMER)
 
     try {
     docker.image(DOCKER_IMG).inside(DOCKER_ARGS) {

--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -1,3 +1,4 @@
+def TIMER = "H/30 * * * *"
 def NODE = "rhcos-imgfac-jslave"
 def DOCKER_IMG = "quay.io/cgwalters/coreos-assembler"
 def DOCKER_ARGS = "--net=host -v /srv:/srv --privileged"
@@ -14,7 +15,7 @@ node(NODE) {
 
     checkout scm
     utils = load("pipeline-utils.groovy")
-    utils.define_parameters()
+    utils.define_properties(TIMER)
 
     docker.image(DOCKER_IMG).inside(DOCKER_ARGS) {
         stage("Sync In") {

--- a/pipeline-utils.groovy
+++ b/pipeline-utils.groovy
@@ -6,13 +6,14 @@
 // let's try not to use env vars here to keep things
 // decoupled and easier to grok
 
-def define_parameters() {
+def define_properties(timer) {
     /* There's a subtle gotcha here. Don't use `env.$PARAM`, but `params.$PARAM`
      * instead. The former will *not* be set on the first run, since the
      * parameters are not set yet. The latter will be set on the first run as
      * soon as the below is executed. See:
      * https://issues.jenkins-ci.org/browse/JENKINS-40574 */
     properties([
+      pipelineTriggers([cron(timer)]),
       parameters([
         credentials(name: 'ARTIFACT_SERVER',
                     credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl',


### PR DESCRIPTION
This moves the last bit of configuration from the internal JJB to the
pipeline. Another reason for doing this now is that I've noticed the
timer set by JJB is actually getting overwritten by the `properties`
call we do here. The end result is that the timers were completely
turned off.