### PR TITLE
container: Fix locations, tweak README.md

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,17 @@
 FROM quay.io/cgwalters/coreos-assembler AS build
 
 COPY RPM-GPG-KEY-* /etc/pki/rpm-gpg/
-COPY . /srv/tree/
+COPY . /srv/build/
 
-RUN cd /srv/tree && make repo-refresh && make rpmostree-compose && \
+RUN cd /srv/build && make repo-refresh && make rpmostree-compose && \
     rm -rf build-repo
 
 # Now inject this content into a new container
 FROM registry.centos.org/centos/centos:7
 RUN yum install -y epel-release && yum -y install nginx && yum clean all
 # Keep this in sync with Dockerfile.rollup.in
-COPY --from=build /srv/tree /srv/tree
+COPY --from=build /srv/build/repo /srv/repo/
 COPY nginx.conf /etc/nginx/nginx.conf
-COPY index.html subdomain.css /srv/tree/repo/
+COPY index.html subdomain.css /srv/repo/
 EXPOSE 8080
 CMD ["nginx", "-c", "/etc/nginx/nginx.conf"]

--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ $ lvm lvextend -r -l +25%FREE atomicos/root
 
 ```
 $ docker run --network host -d -w /srv/tree/repo $REGISTRY/os:latest
-$ ostree remote add --no-gpg-verify local http://localhost:8080 openshift/3.10/x86_64/os
-$ rpm-ostree rebase -r local:openshift/3.10/x86_64/os
+$ ostree remote add --no-gpg-verify oscontainer http://localhost:8080/repo
+$ rpm-ostree rebase -r oscontainer:openshift/3.10/x86_64/os
 
 # wait, SSH back in
 $ openshift version
@@ -38,8 +38,8 @@ $ kubectl run os-content --image=$REGISTRY/os:latest
 $ kubectl expose os-content --port 8080
 
 $ ssh root@NODE_HOST
-$ ostree remote add --no-gpg-verify local http://os-content.namespace.svc:8080 openshift/3.10/x86_64/os
-$ rpm-ostree rebase -r local:openshift/3.10/x86_64/os
+$ ostree remote add --no-gpg-verify oscontainer http://os-content.namespace.svc:8080/repo
+$ rpm-ostree rebase -r oscontainer:openshift/3.10/x86_64/os
 
 # wait, SSH back in
 $ openshift version

--- a/index.html
+++ b/index.html
@@ -16,24 +16,15 @@
             This service provides the latest OSTree repo within an OpenShift cluster. You may also view the
             <a href="/repo/">OSTree repo directly</a>.
         </p>
-        <h2>Examples</h2>
-        <h3>In a cluster</h3>
+        <h2>Using this container in a cluster</h2>
         <pre>
         $ ssh root@NODE_HOST
-        $ ostree remote add --no-gpg-verify local http://os-content.namespace.svc:8080 openshift/3.10/x86_64/os
-        $ rpm-ostree rebase -r local:openshift/3.10/x86_64/os
+        $ ostree remote add --no-gpg-verify os-svc http://os-content.namespace.svc:8080/repo
+        $ rpm-ostree rebase -r os-svc:openshift/3.10/x86_64/os
 
         # wait, SSH back in
-        $ openshift version</pre>
-
-        <h3>Locally</h3>
-        <pre>
-        $ docker run --network host -d -w /srv/tree/repo $REGISTRY/os:latest
-        $ ostree remote add --no-gpg-verify local http://localhost:8080 openshift/3.10/x86_64/os
-        $ rpm-ostree rebase -r local:openshift/3.10/x86_64/os
-
-        # wait, SSH back in
-        $ openshift version</pre>
+        $ openshift version
+        </pre>
 
         <h2>Found a bug?</h2>
         If so, please report it using <a href="https://github.com/openshift/os/issues/new?labels=bug">this link</a>.

--- a/nginx.conf
+++ b/nginx.conf
@@ -36,7 +36,7 @@ http {
         listen       8080 default_server;
         listen       [::]:8080 default_server;
         server_name  _;
-        root         /srv/tree/repo;
+        root         /srv/repo;
 
         # Load configuration files for the default server block.
         include /etc/nginx/default.d/*.conf;


### PR DESCRIPTION
This broke when reworking the build system.  At some point we'll
have tests for this.  While here I cleaned up the naming a bit - I
like consistently having an OSTree repo named `repo`, and `oscontainer`
is way clearer than `local`.

And to reduce duplication, change the `index.html` to just talk about the
in-cluster service.