### PR TITLE
Add developmentPipeline, DRY_RUN

### DIFF
--- a/Jenkinsfile.cloud
+++ b/Jenkinsfile.cloud
@@ -137,6 +137,13 @@ node(NODE) {
         }
     }
 
+   if (params.DRY_RUN) {
+       echo "DRY_RUN set, skipping push"
+       currentBuild.result = 'SUCCESS'
+       currentBuild.description = '(dry run)'
+       return
+   }
+
     stage("Sync Out") {
         withCredentials([
             string(credentialsId: params.ARTIFACT_SERVER, variable: 'ARTIFACT_SERVER'),

--- a/Jenkinsfile.oscontainer
+++ b/Jenkinsfile.oscontainer
@@ -29,8 +29,14 @@ node(NODE) {
             stage("Build container") {
                img = docker.build("coreos/openshift-redhat-coreos:3.10", "-f Dockerfile.rollup .")
             }
+            if (params.DRY_RUN) {
+                echo "DRY_RUN set, skipping push"
+                currentBuild.result = 'SUCCESS'
+                currentBuild.description = '(dry run)'
+                return
+            }
             stage("Push container") {
-               img.push()
+                img.push()
             }
         }
     }

--- a/Jenkinsfile.rdgo
+++ b/Jenkinsfile.rdgo
@@ -57,6 +57,13 @@ node(NODE) {
             return
         }
 
+        if (params.DRY_RUN) {
+            echo "DRY_RUN set, skipping push"
+            currentBuild.result = 'SUCCESS'
+            currentBuild.description = '(dry run)'
+            return
+        }
+
         stage("Sync Out") {
             withCredentials([
                 string(credentialsId: params.ARTIFACT_SERVER, variable: 'ARTIFACT_SERVER'),

--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -64,6 +64,13 @@ node(NODE) {
             sh "rpm-ostree --repo=${repo} db diff ${commit}^ ${commit}"
         }
 
+        if (params.DRY_RUN) {
+            echo "DRY_RUN set, skipping push"
+            currentBuild.result = 'SUCCESS'
+            currentBuild.description = '(dry run)'
+            return
+        }
+
         stage("Sync Out") {
             withCredentials([
                 string(credentialsId: params.ARTIFACT_SERVER, variable: 'ARTIFACT_SERVER'),

--- a/pipeline-utils.groovy
+++ b/pipeline-utils.groovy
@@ -2,19 +2,23 @@
  * provides some commonly used functions.
  */
 
-
 // let's try not to use env vars here to keep things
 // decoupled and easier to grok
 
 def define_properties(timer) {
+
+    // Set this to TRUE to disable the timer, and set DRY_RUN=true by default
+    def developmentPipeline = false;
+
     /* There's a subtle gotcha here. Don't use `env.$PARAM`, but `params.$PARAM`
      * instead. The former will *not* be set on the first run, since the
      * parameters are not set yet. The latter will be set on the first run as
      * soon as the below is executed. See:
      * https://issues.jenkins-ci.org/browse/JENKINS-40574 */
     properties([
-      pipelineTriggers([cron(timer)]),
+      pipelineTriggers(developmentPipeline ? [] : [cron(timer)]),
       parameters([
+        booleanParam(name: 'DRY_RUN', defaultValue: developmentPipeline, description: 'If true, do not push changes'),
         credentials(name: 'ARTIFACT_SERVER',
                     credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl',
                     description: "Server used to push/receive built artifacts.",


### PR DESCRIPTION
This makes it easier to set up a development instance; fork
the repo, add a commit which sets `developmentPipeline=true`, then
your work commits on top.  The build timers will be disabled, and
you won't push artifacts over the production ones.