### PR TITLE
jenkins/treecompose: Add version to build description too

### DIFF
--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -60,7 +60,8 @@ node(NODE) {
             sh "coreos-assembler --repo=${repo} ${manifest}"
             sh "ostree --repo=${repo} rev-parse ${ref} > commit.txt"
             def commit = readFile('commit.txt').trim();
-            currentBuild.description = '🆕 commit ' + commit;
+            version = utils.get_rev_version("repo", commit)
+            currentBuild.description = '🆕 ${version} (commit ${commit})';
             sh "rpm-ostree --repo=${repo} db diff ${commit}^ ${commit}"
         }
 


### PR DESCRIPTION
This is what the cloud bits do; should help in lining up
treecompose vs images.

(Though I don't know why there are two checksums appearing both
 in treecompose and cloud today)