### PR TITLE
Don't wait for triggered jobs to finish

### DIFF
--- a/Jenkinsfile.rdgo
+++ b/Jenkinsfile.rdgo
@@ -79,7 +79,7 @@ node(NODE) {
             currentBuild.description = 'rdgo build+sync done'
         }
 
-        build("coreos-rhcos-treecompose")
+        build job: 'coreos-rhcos-treecompose', wait: false
     }
 
     } finally {

--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -89,6 +89,6 @@ node(NODE) {
             }
         }
 
-        build("coreos-rhcos-cloud")
+        build job: 'coreos-rhcos-cloud', wait: false
     }
 }


### PR DESCRIPTION
Let's make the `treecompose` pipeline simply trigger new `cloud` jobs
instead of also waiting for it to finish. Similarly for `rdgo` and
`treecompose.