### PR TITLE
Initial how to build info and Make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@ COMPOSEFLAGS ?=
 ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 CACHE_ARGS := $(shell if test -d cache; then echo $(shell pwd)/cache; fi)
 
+REPO ?= /srv/rhcos/repo
+INSTALLER_TREE_URL ?= https://dl.fedoraproject.org/pub/fedora/linux/releases/28/Everything/x86_64/os
+OSTREE_INSTALL_URL ?= ${REPO}
+REF ?= openshift/3.10/x86_64/os
+
 all: rpmostree-compose
 
 .PHONY: syntax-check
@@ -22,10 +27,52 @@ init-ostree-repo:
 	ostree --repo=build-repo init --mode=bare-user
 	ostree --repo=repo init --mode=archive
 
+.PHONY: check-tools
+check-tools:
+	which ostree
+	which rpm-ostree
+	which rpmdistro-gitoverlay
+	which imagefactory
+	which qemu-img
+	which mock
+
+
+# Runs all targets needed to create an image
+.PHONY: build-rhcos
+build-rhcos: check-tools clean repo-refresh rdgo rpmostree-compose os-image
+
+# Cleans up
+.PHONY: clean
+clean:
+	rm -rf build build-0 build-1 src snapshot ${REPO}
+
+# Pulls sources, builds packages, and creates a dnf repo for use
+.PHONY: rdgo
+rdgo:
+	rpmdistro-gitoverlay init
+	rpmdistro-gitoverlay resolve --fetch-all
+	rpmdistro-gitoverlay build
+
+
+# Composes an ostree
 .PHONY: rpmostree-compose
 rpmostree-compose: ${ROOT_DIR}/openshift.repo init-ostree-repo
+	mkdir -p ${REPO}
+	ostree init --repo=${REPO} --mode=archive
 	if test -d cache; then cachedir='--cachedir $(shell pwd)/cache'; fi && \
 	  cd ${ROOT_DIR} && set -x && \
 	  rpm-ostree compose tree $(COMPOSEFLAGS) $${cachedir:-} --repo=$(shell pwd)/build-repo host.yaml
 	ostree --repo=repo pull-local build-repo
 	ostree --repo=repo summary -u
+
+# Makes an image using the ostree
+.PHONY: os-image
+os-image:
+	ostree --repo=repo remote add rhcos --no-gpg-verify ${OSTREE_INSTALL_URL}
+	ostree --repo=repo pull --mirror --commit-metadata-only rhcos
+	sed -i 's,\(<url>\).*\(<\/url\),\1${INSTALLER_TREE_URL}\2,' rhcos.tdl
+	sed -i 's,@@OSTREE_INSTALL_URL@@,${OSTREE_INSTALL_URL},' cloud.ks
+	sed -i 's,@@OSTREE_INSTALL_REF@@,${REF},' cloud.ks
+	imagefactory --debug base_image --file-parameter install_script cloud.ks --parameter offline_icicle True rhcos.tdl
+	export IMAGE=`ls /var/lib/imagefactory/storage/*.body`
+	qemu-img convert -f raw -O qcow2 ${IMAGE} rhcos-devel.qcow2

--- a/README-development.md
+++ b/README-development.md
@@ -1,3 +1,30 @@
+# Operating System
+
+## Prerequisites
+
+### Usually packaged by operating systems
+- git
+- ostree
+- rpm-ostree
+- qemu-img
+- fedpkg
+- mock
+
+### May need to be built from source
+- [coreos-assembler](https://github.com/cgwalters/coreos-assembler/): [container](http://quay.io/cgwalters/coreos-assembler)
+- [rpmdistro-gitoverlay](https://github.com/projectatomic/rpmdistro-gitoverlay)
+- [imagefactory-plugins-TinMan](https://github.com/redhat-imaging/imagefactory)
+
+## Building
+
+- Clone ``openshift/os``
+- Move into the cloned repo
+- Build packages from source repos: ``make rdgo``
+- Make the ostree: ``make rpmostree-compose``
+- Make the qcow2: ``make os-image OSTREE_INSTALL_URL=<OSTREE_INSTALL_URL_HERE>``
+
+# Container Image
+
 This repository uses [https://docs.docker.com/develop/develop-images/multistage-build/](multi-stage) builds.
 If you're using Project Atomic/RHEL Docker, your best bet is to build [OpenShift imagebuilder](https://github.com/openshift/imagebuilder)
 docker.

--- a/README-development.md
+++ b/README-development.md
@@ -11,11 +11,12 @@
 - mock
 
 ### May need to be built from source
-- [coreos-assembler](https://github.com/cgwalters/coreos-assembler/): [container](http://quay.io/cgwalters/coreos-assembler)
 - [rpmdistro-gitoverlay](https://github.com/projectatomic/rpmdistro-gitoverlay)
 - [imagefactory-plugins-TinMan](https://github.com/redhat-imaging/imagefactory)
 
 ## Building
+
+Choose a local mirror to use for OSTREE_INSTALL_URL from [the list](https://admin.fedoraproject.org/mirrormanager/mirrors/Fedora/28/x86_64)
 
 - Clone ``openshift/os``
 - Move into the cloned repo


### PR DESCRIPTION
A question has come up over how one would build RHCOS. The original Container Linux has [this](https://coreos.com/os/docs/latest/sdk-modifying-coreos.html) document explaining how to do so. Today the closest we have is for one to look at ``Jenkinsfile.*``s.

This would let people run one or more ``make`` targets locally to build a local development version of RHCOS.

See https://github.com/openshift/os/issues/108