### PR TITLE
host: drop kexec-tools

### DIFF
--- a/host.yaml
+++ b/host.yaml
@@ -68,7 +68,7 @@ packages:
  # Time sync
  - chrony
  # Extra runtime
- - authconfig sssd shadow-utils kexec-tools
+ - authconfig sssd shadow-utils
  - logrotate
  # tuned
  - tuned tuned-profiles-atomic


### PR DESCRIPTION
The `kdump` service was failing to start because there was no
`crashkernel` option passed to the kernel.  @cgwalters suggested we
drop it, so let's just remove all of the `kexec-tools` package.
Nothing depends on the package, so I don't believe this should break
anything.