### PR TITLE
compose-post: Remove network.service

### DIFF
--- a/compose-post.sh
+++ b/compose-post.sh
@@ -29,3 +29,8 @@ set -x
 
 cp -f /usr/lib/locale/locale-archive /usr/lib/locale/locale-archive.tmpl
 build-locale-archive
+
+# Nuke network.service from orbit
+# https://github.com/openshift/os/issues/117
+rm /etc/rc.d/init.d/network
+rm /etc/rc.d/rc*.d/*network


### PR DESCRIPTION
I still didn't debug why this is getting enabled, but there's
no reason to ship it, so let's delete it, then it can't be enabled.

Closes: https://github.com/openshift/os/issues/117