### PR TITLE
Makefile: s/coreos-assembler/rpm-ostree compose tree/

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM quay.io/cgwalters/coreos-assembler AS build
 COPY RPM-GPG-KEY-* /etc/pki/rpm-gpg/
 COPY . /srv/build/
 
-RUN cd /srv/build && make repo-refresh && make rpmostree-compose && \
+RUN rpm -q rpm-ostree && rpm-ostree --version && \
+    cd /srv/build && make repo-refresh && make rpmostree-compose && \
     rm -rf build-repo
 
 # Now inject this content into a new container

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,6 @@ init-ostree-repo:
 rpmostree-compose: ${ROOT_DIR}/openshift.repo init-ostree-repo
 	if test -d cache; then cachedir='--cachedir $(shell pwd)/cache'; fi && \
 	  cd ${ROOT_DIR} && set -x && \
-	  coreos-assembler $(COMPOSEFLAGS) $${cachedir:-} --repo=$(shell pwd)/build-repo host.yaml
+	  rpm-ostree compose tree $(COMPOSEFLAGS) $${cachedir:-} --repo=$(shell pwd)/build-repo host.yaml
 	ostree --repo=repo pull-local build-repo
 	ostree --repo=repo summary -u


### PR DESCRIPTION
Now that https://github.com/cgwalters/coreos-assembler/pull/5 has
landed, there's no need to use the wrapper command.

That said, we may revisit this more later, but for now it makes
things more painful when working in e.g. an existing pet container.