### PR TITLE
Remove cloud-init

### DIFF
--- a/cloud.ks
+++ b/cloud.ks
@@ -14,7 +14,7 @@ user --name=core --groups='wheel,adm,systemd-journal'
 firewall --disabled
 
 network --bootproto=dhcp --onboot=on
-services --enabled=sshd,cloud-init,cloud-init-local,cloud-config,cloud-final
+services --enabled=sshd
 services --disabled=network,avahi-daemon
 
 zerombr

--- a/host.yaml
+++ b/host.yaml
@@ -47,7 +47,7 @@ packages:
  - selinux-policy-targeted policycoreutils-python
  - setools-console
  # System setup
- - ignition ignition-dracut cloud-init cloud-utils-growpart
+ - ignition ignition-dracut
  - dracut-network
  # Bootloader
  - grub2 grub2-efi ostree-grub2 efibootmgr shim


### PR DESCRIPTION
I did a test build locally, set up a mock metadata service that
had a small Ignition config, and it worked.