### PR TITLE
scripts: don't hardcode path to bash

### DIFF
--- a/scripts/coreos-oemid
+++ b/scripts/coreos-oemid
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -xeuo pipefail
 
 # Usage: coreos-oemid <input image> <output image> OEMID


### PR DESCRIPTION
`env bash` is a more portable invocation since not all distros package
bash in the same location.