### PR TITLE
manifest: Explicitly set tmp-is-dir: false

### DIFF
--- a/host.yaml
+++ b/host.yaml
@@ -11,6 +11,9 @@ repos:
 install_langs:
  - en_US
 documentation: false
+# Doesn't quite work out of the box yet in RHEL7,
+# but see https://pagure.io/fedora-atomic/pull-request/62/edit
+tmp-is-dir: false
 initramfs-args:
   - "--no-hostonly"
   - "--add"


### PR DESCRIPTION
I plan to change the YAML to imply more modern defaults; I tried
enabling it here and it didn't quite work, I don't want to debug
it now.  We'll figure it out when we rebase to newer host content.