### PR TITLE
host: Explicitly include container-storage-setup and growpart

### DIFF
--- a/host.yaml
+++ b/host.yaml
@@ -62,6 +62,7 @@ packages:
  - bridge-utils nfs-utils biosdevname iptables-services
  - NetworkManager dnsmasq
  # Storage
+ - container-storage-setup cloud-utils-growpart
  - lvm2 iscsi-initiator-utils sg3_utils
  - device-mapper-multipath
  - xfsprogs e2fsprogs mdadm


### PR DESCRIPTION
We lost `cloud-utils-growpart` when we dropped `cloud-init`.
Should help with https://github.com/openshift/os/issues/133
although I haven't had time to test yet, but it's what we need to do now.