### PR TITLE
Fix ConditionFirstBoot= by removing /etc/machine-id

### DIFF
--- a/compose-post.sh
+++ b/compose-post.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
 
-set -e
+set -xe
+
+# See machineid-compat in host.yaml.
+# Since that makes presets run on boot, we need to have our defaults in /usr
+ln -sfr /usr/lib/systemd/system/{multi-user,default}.target
 
 # The loops below are too spammy otherwise...
 set +x

--- a/host.yaml
+++ b/host.yaml
@@ -17,6 +17,8 @@ initramfs-args:
   - "iscsi"
 automatic_version_prefix: "3.10-7.5"
 mutate-os-release: "7"
+# https://github.com/projectatomic/rpm-ostree/pull/1425
+machineid-compat: false
 postprocess-script: "compose-post.sh"
 etc-group-members:
   - wheel
@@ -91,8 +93,3 @@ remove-from-packages:
     - "/usr/bin/.*"
   - - filesystem
     - "/usr/share/backgrounds"
-units:
-  - "docker.service"
-  - "tuned.service"
-  - "docker-storage-setup.service"
-default_target: "multi-user.target"


### PR DESCRIPTION
Requires: https://github.com/projectatomic/rpm-ostree/pull/1425

We want systemd's ConditionFirstBoot to fire. The
primary rationale here is that we're adopting Ignition for Fedora CoreOS,
and having ConditionFirstBoot= function will help a lot, as the idea
is it only runs once.  Further, this ensures that any presets generated
in the initramfs work.