### PR TITLE
RFC: Add strace to the host

### DIFF
--- a/host.yaml
+++ b/host.yaml
@@ -83,7 +83,7 @@ packages:
  - tuned tuned-profiles-atomic
  # Used by admins interactively
  - sudo coreutils less tar xz gzip bzip2 rsync tmux
- - nmap-ncat net-tools bind-utils
+ - nmap-ncat net-tools bind-utils strace
  - bash-completion
  # Editors
  - vim-minimal nano


### PR DESCRIPTION
I was surprised to find that `strace` wasn't already included. For comparison, both Fedora Atomic Host and Container Linux ship with `strace` today. It's one of those tools that have a really nice value/size ratio. We're looking at 1.6M on disk for `/usr/bin/strace` + `libunwind` libs. This is related to #78, though in my opinion it's useful enough to be directly in the tree.

Thoughts?