### PR TITLE
overlay: Rebuild cri-o from Fedora dist-git, not git master

### DIFF
--- a/overlay.yml
+++ b/overlay.yml
@@ -19,11 +19,8 @@ components:
     override-version: "1.13.1"
     branch: docker-1.13.1-rhel
 
-  - src: github:kubernetes-incubator/cri-o
-    branch: release-1.10
-
-  - src: github:kubernetes-incubator/cri-tools
-    branch: release-1.10
+  - distgit: cri-o
+  - distgit: cri-tools
 
 # pull ignition directly from copr for now
 # - src: github:coreos/ignition


### PR DESCRIPTION
Basically 1.11 landed in f28, which is built differently than
the `release-1.10` branch.  Big picture, the rpmdistro-gitoverlay
model overlaps badly with lsm5's "auto build in dist-git" stuff.

https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/4ZIWOOJIKBPCL57H5WBYUYH6VBL2GT73/

For now, let's just build what's exactly in dist-git.

Note this also does bump to 1.11, but I think that makes sense as
origin now rebased to 1.11.