### PR TITLE
cloud.ks: Add tty0 console output for ignition logging

### DIFF
--- a/cloud.ks
+++ b/cloud.ks
@@ -24,7 +24,7 @@ clearpart --initlabel --all
 #  - rd.neednet=1      # tell dracut we need network
 #  - enforcing=0       # ignition + selinux doesn't work
 #  - $coreos_firstboot # This is actually a GRUB variable
-bootloader --timeout=1 --append="no_timer_check console=tty1 console=ttyS0,115200n8 net.ifnames=0 biosdevname=0 ip=dhcp rd.neednet=1 enforcing=0 $coreos_firstboot"
+bootloader --timeout=1 --append="no_timer_check console=ttyS0,115200n8 console=tty0 net.ifnames=0 biosdevname=0 ip=dhcp rd.neednet=1 enforcing=0 $coreos_firstboot"
 
 part /boot --size=300 --fstype="xfs"
 part pv.01 --grow


### PR DESCRIPTION
Many platforms, like QEMU, use tty0 for console output. This PR adds tty0 console output to allow ignition logging/debugging.

Jira card: https://projects.engineering.redhat.com/browse/COREOS-202