### PR TITLE
host: Remove subman

### DIFF
--- a/host.yaml
+++ b/host.yaml
@@ -46,15 +46,13 @@ packages:
  - redhat-release-coreos
  # rpm-ostree
  - rpm-ostree nss-altfiles
- # Subscriptions
- - subscription-manager subscription-manager-plugin-ostree
- - subscription-manager-plugin-container
  # SELinux
  - selinux-policy-targeted policycoreutils-python
  - setools-console
  # System setup
  - ignition ignition-dracut
  - dracut-network
+ - passwd
  # Bootloader
  - grub2 grub2-efi ostree-grub2 efibootmgr shim
  # SSH
@@ -93,7 +91,5 @@ packages:
  - pivot
 
 remove-from-packages:
-  - - yum
-    - "/usr/bin/.*"
   - - filesystem
     - "/usr/share/backgrounds"


### PR DESCRIPTION
As far as I know the plan has the cluster owning a mirror of
the content; we won't entitle/subscribe each host.

Something in the yum depchain was pulling in `passwd`,
which we do want; add that explicitly.

```
Removed:
  libnl-1.1.4-3.el7.x86_64
  libxml2-python-2.9.1-6.el7_2.3.x86_64
  pygpgme-0.3-9.el7.x86_64
  pyliblzma-0.5.3-11.el7.x86_64
  python-dateutil-1.5-7.el7.noarch
  python-dmidecode-3.12.2-2.el7.x86_64
  python-ethtool-0.8-7.el7.x86_64
  python-iniparse-0.4-9.el7.noarch
  python-inotify-0.9.4-4.el7.noarch
  python-kitchen-1.1.1-5.el7.noarch
  python-pycurl-7.19.0-19.el7.x86_64
  python-urlgrabber-3.10-9.el7.noarch
  pyxattr-0.5.1-5.el7.x86_64
  rpm-build-libs-4.11.3-35.el7.x86_64
  rpm-python-4.11.3-35.el7.x86_64
  subscription-manager-1.21.5-5.el7.x86_64
  subscription-manager-plugin-container-1.21.5-5.el7.x86_64
  subscription-manager-plugin-ostree-1.21.5-5.el7.x86_64
  subscription-manager-rhsm-1.21.5-5.el7.x86_64
  subscription-manager-rhsm-certificates-1.21.5-5.el7.x86_64
  usermode-1.111-5.el7.x86_64
  yum-3.4.3-159.el7.noarch
  yum-metadata-parser-1.1.4-10.el7.x86_64
```