### PR TITLE
compose-post.sh: Enable crio by default

### DIFF
--- a/compose-post.sh
+++ b/compose-post.sh
@@ -47,6 +47,9 @@ rm /etc/rc.d/rc*.d/*network
 # It's long dead upstream, we definitely don't want it.
 rm -f /usr/lib/systemd/systemd-readahead /usr/lib/systemd/system/systemd-readahead-*
 
+# Enable crio by default
+systemctl enable crio
+
 # Let's have a non-boring motd, just like CL (although theirs is more subdued
 # nowadays compared to early versions with ASCII art).  One thing we do here
 # is add --- as a "separator"; the idea is that any "dynamic" information should


### PR DESCRIPTION
See https://github.com/coreos/mantle/pull/885#issuecomment-404637101

This seemed like a safer place to do an `enable` compared to `cloud.ks` but let me know if it should move.