### PR TITLE
host: add in subman certs

### DIFF
--- a/host.yaml
+++ b/host.yaml
@@ -89,6 +89,8 @@ packages:
  - origin-node origin-hyperkube origin-clients
  # pivot/ota tools
  - pivot
+ # Red Hat CA certs
+ - subscription-manager-rhsm-certificates
 
 remove-from-packages:
   - - filesystem


### PR DESCRIPTION
This brings in the Red Hat CA certs, which allows users to pull
containers from the Red Hat registry successfully. No additional
dependecies are pulled in.

```
Added:
  subscription-manager-rhsm-certificates-1.20.11-1.el7_5.x86_64
```

Closes #179