### PR TITLE
oscontainer: store commit + version in labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,10 @@ RUN rpm -q rpm-ostree && rpm-ostree --version && \
 
 # Now inject this content into a new container
 FROM registry.centos.org/centos/centos:7
+ARG OS_VERSION="3.10-7.5"
+ARG OS_COMMIT="null"
+LABEL org.openshift.os.version = "$OS_VERSION" \
+      org.openshift.os.commit = "$OS_COMMIT"
 RUN yum install -y epel-release && yum -y install nginx && yum clean all
 # Keep this in sync with Dockerfile.rollup.in
 COPY --from=build /srv/build/repo /srv/repo/

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,8 @@ RUN rpm -q rpm-ostree && rpm-ostree --version && \
 FROM registry.centos.org/centos/centos:7
 ARG OS_VERSION="3.10-7.5"
 ARG OS_COMMIT="null"
-LABEL org.openshift.os.version = "$OS_VERSION" \
-      org.openshift.os.commit = "$OS_COMMIT"
+LABEL io.openshift.os-version = "$OS_VERSION" \
+      io.openshift.os-commit = "$OS_COMMIT"
 RUN yum install -y epel-release && yum -y install nginx && yum clean all
 # Keep this in sync with Dockerfile.rollup.in
 COPY --from=build /srv/build/repo /srv/repo/

--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -75,12 +75,13 @@ node(NODE) {
         // Note that we don't keep history in the ostree repo, so we
         // delete the ref head (so rpm-ostree won't add a parent) and
         // then we do a repo prune after.
+        def version, commit
         stage("Compose Tree") { sh """
             rm ${repo}/refs/heads/* -rf
             env G_DEBUG=fatal-warnings coreos-assembler --repo=${repo} ${manifest}
             ostree --repo=${repo} rev-parse ${ref} > commit.txt
         """
-            def commit = readFile('commit.txt').trim();
+            commit = readFile('commit.txt').trim();
             version = utils.get_rev_version("${repo}", commit)
             currentBuild.description = "🆕 ${version} (commit ${commit})";
             if (previous_commit.length() > 0) {
@@ -111,7 +112,10 @@ node(NODE) {
           podman rm oscontainer
       """ }
       stage("Build new container") { sh """
-          podman build -t ${OSCONTAINER_IMG} -f ${treecompose_workdir}/Dockerfile.rollup ${treecompose_workdir}
+          podman build --build-arg OS_VERSION=${version} \
+                       --build-arg OS_COMMIT=${commit} \
+                       -t ${OSCONTAINER_IMG} \
+                       -f ${treecompose_workdir}/Dockerfile.rollup ${treecompose_workdir}
       """ }
       stage("Push container") { sh """
           podman push ${OSCONTAINER_IMG}


### PR DESCRIPTION
This changes the Dockerfile for the `oscontainer` to support storing the commit ID and version in the image labels.  Additionally, the treecompose pipeline was updated to build the container with those changes.

I chose the `org.openshift.os` namespace as a reasonable place to store the values.

I tested using `podman` to build a container with these kind of changes to a Dockerfile, but did not test the whole pipeline.