### PR TITLE
oscontainer: actually store commit + version in labels

### DIFF
--- a/Dockerfile.rollup
+++ b/Dockerfile.rollup
@@ -2,6 +2,10 @@
 # the "oscontainer" image which has an embedded ostree repo inside.
 # It expects "repo" to exist in the current directory.
 FROM registry.fedoraproject.org/fedora:28
+ARG OS_VERSION="3.10-7.5"
+ARG OS_COMMIT="null"
+LABEL io.openshift.os-version = "$OS_VERSION" \
+      io.openshift.os-commit = "$OS_COMMIT"
 RUN yum -y install ostree nginx && yum clean all
 COPY repo /srv/repo
 # Keep this in sync with Dockerfile


### PR DESCRIPTION
In #181, I changed a `Dockerfile` to include the commit ID and version
string in the label of the container image that would be generated.
What I failed to notice was that I made changes to a `Dockerfile` that
does not appear to be used in the pipeline at all.

This makes the same changes from that PR to `Dockerfile.rollup`, which
is actually used in the `treecompose` phase of the pipeline.