### PR TITLE
ostree: explicitly set a version metadata string on the commit

### DIFF
--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -12,6 +12,7 @@ def artifact_repo = "/srv/rhcos/output/repo"
 
 def manifest = "host.yaml"
 def ref = "openshift/3.10/x86_64/os";
+def version_prefix = "3.10-7.5"
 
 node(NODE) {
     checkout scm
@@ -77,8 +78,11 @@ node(NODE) {
         // then we do a repo prune after.
         def version, commit
         stage("Compose Tree") { sh """
+            ostree_version = "${version_prefix}.${env.BUILD_NUMBER}"
             rm ${repo}/refs/heads/* -rf
-            env G_DEBUG=fatal-warnings coreos-assembler --repo=${repo} ${manifest}
+            env G_DEBUG=fatal-warnings coreos-assembler --repo=${repo} \
+                                                        --add-metadata-string=version=${ostree_version} \
+                                                        ${manifest}
             ostree --repo=${repo} rev-parse ${ref} > commit.txt
         """
             commit = readFile('commit.txt').trim();

--- a/host.yaml
+++ b/host.yaml
@@ -18,7 +18,6 @@ initramfs-args:
   - "--no-hostonly"
   - "--add"
   - "iscsi"
-automatic_version_prefix: "3.10-7.5"
 mutate-os-release: "7"
 # https://github.com/projectatomic/rpm-ostree/pull/1425
 machineid-compat: false


### PR DESCRIPTION
We weren't incrementing the version number each time we made a commit, which could be confusing to a user who wasn't tracking commit IDs.

Additionally, I believe not changing the version was causing us to fail [this version string check](https://github.com/openshift/os/blob/master/Jenkinsfile.cloud#L76) in the cloud pipeline.  (So at the time of the writing, our latest AMI (`ami-02323e873420d8eab`) is from July 13)

I chose to set the version to the previous version prefix plus the build number from Jenkins.