### PR TITLE
oscontainer: workaround podman label bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,10 @@ RUN rpm -q rpm-ostree && rpm-ostree --version && \
 FROM registry.centos.org/centos/centos:7
 ARG OS_VERSION="3.10-7.5"
 ARG OS_COMMIT="null"
-LABEL io.openshift.os-version = "$OS_VERSION" \
-      io.openshift.os-commit = "$OS_COMMIT"
+# Use separate LABEL instructions until podman/buildah is fixed
+# https://github.com/projectatomic/buildah/issues/879
+LABEL io.openshift.os-version = "$OS_VERSION"
+LABEL io.openshift.os-commit = "$OS_COMMIT"
 RUN yum install -y epel-release && yum -y install nginx && yum clean all
 # Keep this in sync with Dockerfile.rollup.in
 COPY --from=build /srv/build/repo /srv/repo/

--- a/Dockerfile.rollup
+++ b/Dockerfile.rollup
@@ -4,8 +4,10 @@
 FROM registry.fedoraproject.org/fedora:28
 ARG OS_VERSION="3.10-7.5"
 ARG OS_COMMIT="null"
-LABEL io.openshift.os-version = "$OS_VERSION" \
-      io.openshift.os-commit = "$OS_COMMIT"
+# Use separate LABEL instructions until podman/buildah is fixed
+# https://github.com/projectatomic/buildah/issues/879
+LABEL io.openshift.os-version = "$OS_VERSION"
+LABEL io.openshift.os-commit = "$OS_COMMIT"
 RUN yum -y install ostree nginx && yum clean all
 COPY repo /srv/repo
 # Keep this in sync with Dockerfile


### PR DESCRIPTION
When building a container image via `podman` (which actually uses
`buildah`), key=value pairs split across multiple lines under a
single LABEL instruction are getting mangled.  This misbehavior
is captured in projectatomic/buildah#879.

Until that is fixed, use a single LABEL per key=value pair.