### PR TITLE
jenkins/treecompose: Only trigger cloud on changes

### DIFF
--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -143,8 +143,8 @@ node(NODE) {
       stage("Cleanup") { sh """
           rm ${treecompose_workdir} -rf
       """ }
-  }
 
-  // Trigger downstream jobs
-  build job: 'coreos-rhcos-cloud', wait: false
+      // Trigger downstream jobs
+      build job: 'coreos-rhcos-cloud', wait: false
+  }
 }


### PR DESCRIPTION
This matches what we were doing with rdgo → treecompose; the problem
was that our `return` only exited the docker scope.