### PR TITLE
oscontainer: remove spaces from image labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,8 @@ RUN rpm -q rpm-ostree && rpm-ostree --version && \
 FROM registry.centos.org/centos/centos:7
 ARG OS_VERSION="3.10-7.5"
 ARG OS_COMMIT="null"
-# Use separate LABEL instructions until podman/buildah is fixed
-# https://github.com/projectatomic/buildah/issues/879
-LABEL io.openshift.os-version = "$OS_VERSION"
-LABEL io.openshift.os-commit = "$OS_COMMIT"
+LABEL io.openshift.os-version="$OS_VERSION" \
+      io.openshift.os-commit="$OS_COMMIT"
 RUN yum install -y epel-release && yum -y install nginx && yum clean all
 # Keep this in sync with Dockerfile.rollup.in
 COPY --from=build /srv/build/repo /srv/repo/

--- a/Dockerfile.rollup
+++ b/Dockerfile.rollup
@@ -4,10 +4,8 @@
 FROM registry.fedoraproject.org/fedora:28
 ARG OS_VERSION="3.10-7.5"
 ARG OS_COMMIT="null"
-# Use separate LABEL instructions until podman/buildah is fixed
-# https://github.com/projectatomic/buildah/issues/879
-LABEL io.openshift.os-version = "$OS_VERSION"
-LABEL io.openshift.os-commit = "$OS_COMMIT"
+LABEL io.openshift.os-version="$OS_VERSION" \
+      io.openshift.os-commit="$OS_COMMIT"
 RUN yum -y install ostree nginx && yum clean all
 COPY repo /srv/repo
 # Keep this in sync with Dockerfile


### PR DESCRIPTION
The Dockerfile reference states that LABELs need to have explicit
'key=value' pairs.  Previously, we had 'key = value' and the extra
spaces were causing the labels to be incorrect.

With this change, we are also able to use a single LABEL instruction,
with the 'key=value' pairs split across multiple lines.

Whitespace matters, folks!