### PR TITLE
Set version to 4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN rpm -q rpm-ostree && rpm-ostree --version && \
 
 # Now inject this content into a new container
 FROM registry.centos.org/centos/centos:7
-ARG OS_VERSION="3.10-7.5"
-ARG OS_COMMIT="null"
+ARG OS_VERSION=""
+ARG OS_COMMIT=""
 LABEL io.openshift.os-version="$OS_VERSION" \
       io.openshift.os-commit="$OS_COMMIT"
 RUN yum install -y epel-release && yum -y install nginx && yum clean all

--- a/Dockerfile.rollup
+++ b/Dockerfile.rollup
@@ -2,8 +2,8 @@
 # the "oscontainer" image which has an embedded ostree repo inside.
 # It expects "repo" to exist in the current directory.
 FROM registry.fedoraproject.org/fedora:28
-ARG OS_VERSION="3.10-7.5"
-ARG OS_COMMIT="null"
+ARG OS_VERSION=""
+ARG OS_COMMIT=""
 LABEL io.openshift.os-version="$OS_VERSION" \
       io.openshift.os-commit="$OS_COMMIT"
 RUN yum -y install ostree nginx && yum clean all

--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -11,8 +11,9 @@ def repo = "${treecompose_workdir}/repo"
 def artifact_repo = "/srv/rhcos/output/repo"
 
 def manifest = "host.yaml"
+// TODO - stop using the ref in favor of oscontainer:// pivot
 def ref = "openshift/3.10/x86_64/os";
-def version_prefix = "3.10-7.5"
+def version_prefix = "4.0"
 
 node(NODE) {
     checkout scm


### PR DESCRIPTION
The 7.5 is not very useful today.  I'm tentatively thinking that
we represent a new base with a different image stream entirely; probably
rename our current image too.  Something like:

`openshift/os-maipo:4.1249`
and
`openshift/os-2018:4.1249`
or so.