### PR TITLE
rdgo: remove uncessary install steps

### DIFF
--- a/Jenkinsfile.rdgo
+++ b/Jenkinsfile.rdgo
@@ -18,10 +18,10 @@ node(NODE) {
     docker.image(DOCKER_IMG).inside(DOCKER_ARGS) {
         stage("Provision") {
             sh """
-                dnf install -y git rsync openssh-clients dnf-plugins-core fedpkg dnf-utils awscli
+                if [ ! -d ${rdgo} ]; then
+                    mkdir -p ${rdgo}
+                fi
                 cp RPM-GPG-* /etc/pki/rpm-gpg/
-                dnf copr -y enable walters/buildtools-fedora
-                dnf install -y rpmdistro-gitoverlay
             """
         }
 

--- a/Jenkinsfile.rdgo
+++ b/Jenkinsfile.rdgo
@@ -37,7 +37,7 @@ node(NODE) {
         stage("Setup and Initialize RDGO") {
             sh """
                 rm -f rdgo.stamp
-                ln -sf $WORKSPACE/rdgo/overlay.yml ${rdgo}/
+                ln -sf ${WORKSPACE}/rdgo/overlay.yml ${rdgo}/
                 cd ${rdgo}
                 rpmdistro-gitoverlay init
             """
@@ -48,7 +48,7 @@ node(NODE) {
         }
 
         stage("Build Overlay Packages") {
-            sh "cd ${rdgo} && rpmdistro-gitoverlay build --touch-if-changed $WORKSPACE/rdgo.stamp --logdir=${WORKSPACE}/log"
+            sh "cd ${rdgo} && rpmdistro-gitoverlay build --touch-if-changed ${WORKSPACE}/rdgo.stamp --logdir=${WORKSPACE}/log"
         }
 
         if (!fileExists("rdgo.stamp")) {


### PR DESCRIPTION
The `coreos-assembler` image now has `rpmdistro-gitoverlay` installed and its required dependencies, so we don't need to install them any more.

Additionally, I cleaned up some of the use of `$WORKSPACE` in the pipeline.