### PR TITLE
jenkins/treecompose: Use `rpm-ostree compose tree` directly

### DIFF
--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -59,7 +59,7 @@ node(NODE) {
         """
             previous_commit = readFile('commit.txt').trim();
         sh """
-            coreos-assembler --dry-run --repo=${repo} --touch-if-changed=$WORKSPACE/build.stamp ${manifest}
+            rpm-ostree compose tree --dry-run --repo=${repo} --touch-if-changed=$WORKSPACE/build.stamp ${manifest}
         """
             last_build_version = utils.get_rev_version(repo, ref)
             if (fileExists('force-nocache-build')) {
@@ -80,7 +80,7 @@ node(NODE) {
         def version, commit
         stage("Compose Tree") { sh """
             rm ${repo}/refs/heads/* -rf
-            env G_DEBUG=fatal-warnings coreos-assembler --repo=${repo} \
+            env G_DEBUG=fatal-warnings rpm-ostree compose tree --repo=${repo} \
                                                         --add-metadata-string=version=${version_prefix}.${env.BUILD_NUMBER} \
                                                         ${manifest}
             ostree --repo=${repo} rev-parse ${ref} > commit.txt


### PR DESCRIPTION
I don't think wrapping/renaming it was a good idea.  There's lots
of other tasks here (e.g. making disk images).  What we should really
do is move some of these things into Makefile targets or something
that live in the assembler container.