### PR TITLE
pipelines: skip the repo checkout

### DIFF
--- a/Jenkinsfile.cloud
+++ b/Jenkinsfile.cloud
@@ -18,7 +18,6 @@ node(NODE) {
        step([$class: 'WsCleanup'])
     }
 
-    checkout scm
     utils = load("pipeline-utils.groovy")
     utils.define_properties(TIMER)
 

--- a/Jenkinsfile.rdgo
+++ b/Jenkinsfile.rdgo
@@ -10,7 +10,6 @@ def rdgo = "/srv/rhcos/output/rdgo"
 node(NODE) {
     docker.image(DOCKER_IMG).pull()
 
-    checkout scm
     utils = load("pipeline-utils.groovy")
     utils.define_properties(TIMER)
 

--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -16,7 +16,6 @@ def ref = "openshift/3.10/x86_64/os";
 def version_prefix = "4.0"
 
 node(NODE) {
-    checkout scm
     utils = load("pipeline-utils.groovy")
     utils.define_properties(TIMER)
 


### PR DESCRIPTION
Jenkins will checkout the `openshift/os` repo into its workspace
before any of the stages are started.  The workspace is then mounted
into the container to be used by the stages.  We can skip checking out
the repo a second time, as it is automatically made available inside
the container.