### PR TITLE
Make /tmp be tmpfs by default

### DIFF
--- a/cloud.ks
+++ b/cloud.ks
@@ -62,11 +62,6 @@ PERSISTENT_DHCLIENT="yes"
 NM_CONTROLLED="yes"
 EOF
 
-# Because memory is scarce resource in most cloud/virt environments,
-# and because this impedes forensics, we are differing from the Fedora
-# default of having /tmp on tmpfs.
-systemctl mask tmp.mount
-
 # Anaconda is writing a /etc/resolv.conf from the generating environment.
 # The system should start out with an empty file.
 truncate -s 0 /etc/resolv.conf

--- a/compose-post.sh
+++ b/compose-post.sh
@@ -6,6 +6,9 @@ set -xe
 # Since that makes presets run on boot, we need to have our defaults in /usr
 ln -sfr /usr/lib/systemd/system/{multi-user,default}.target
 
+# This is fixed in post-RHEL7 systemd
+ln -sf ../tmp.mount /usr/lib/systemd/system/local-fs.target.wants
+
 # The loops below are too spammy otherwise...
 set +x
 

--- a/host.yaml
+++ b/host.yaml
@@ -11,9 +11,8 @@ repos:
 install-langs:
  - en_US
 documentation: false
-# Doesn't quite work out of the box yet in RHEL7,
-# but see https://pagure.io/fedora-atomic/pull-request/62/edit
-tmp-is-dir: false
+# See https://pagure.io/fedora-atomic/pull-request/62
+tmp-is-dir: true
 initramfs-args:
   - "--no-hostonly"
   - "--add"


### PR DESCRIPTION
Drops cruft from the cloud kickstart, hence unifying across
metal and cloud.  Also, this is a key prerequisite for having
`/sysroot` be read-only by default.

I finally figured out the problem I had with this before; systemd
in RHEL7 is missing the `tmp.mount` unit being enabled by default.