### PR TITLE
jenkins/treecompose: Rename current oscontainer to `os-maipo`

### DIFF
--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -2,7 +2,7 @@ def TIMER = "H/30 * * * *"
 def NODE = "atomic-jslave-autobrew"
 def DOCKER_IMG = "quay.io/cgwalters/coreos-assembler"
 def API_CI_REGISTRY = "registry.svc.ci.openshift.org"
-def OSCONTAINER_IMG = API_CI_REGISTRY + "/rhcos/os:latest"
+def OSCONTAINER_IMG = API_CI_REGISTRY + "/rhcos/os-maipo:latest"
 def DOCKER_ARGS = "--net=host -v /srv:/srv -v /run/docker.sock:/run/docker.sock --privileged"
 
 def treecompose_workdir = "/srv/rhcos/treecompose"


### PR DESCRIPTION
We know in the future we're going to introduce a fundamentally
much newer version of the OS.  Let's prepare for that by renaming
our existing container to have an "OS identifier".

The goal in avoiding an explicit OS version number here is to make clear
that we may have different content than an existing OS; but
at the same time we want to retain *some* linkage to that OS.
Hence, I chose to use the "codename".