### PR TITLE
jenkins/cloud: Do checkout scm

### DIFF
--- a/Jenkinsfile.cloud
+++ b/Jenkinsfile.cloud
@@ -18,6 +18,8 @@ node(NODE) {
        step([$class: 'WsCleanup'])
     }
 
+    checkout scm
+
     utils = load("pipeline-utils.groovy")
     utils.define_properties(TIMER)
 


### PR DESCRIPTION
In this one we're using workspace cleanup (which we should probably
do everywhere) - but for now let's just readd `checkout scm` here.
https://github.com/openshift/os/pull/197#issuecomment-410780804