### PR TITLE
jenkins: Define a common prelude

### DIFF
--- a/Jenkinsfile.cloud
+++ b/Jenkinsfile.cloud
@@ -17,9 +17,7 @@ node(NODE) {
     stage("Clean workspace") {
        step([$class: 'WsCleanup'])
     }
-
     checkout scm
-
     utils = load("pipeline-utils.groovy")
     utils.define_properties(TIMER)
 

--- a/Jenkinsfile.rdgo
+++ b/Jenkinsfile.rdgo
@@ -8,11 +8,15 @@ def DOCKER_ARGS = "--net=host -v /srv:/srv --privileged"
 def rdgo = "/srv/rhcos/output/rdgo"
 
 node(NODE) {
-    docker.image(DOCKER_IMG).pull()
-
+    def par_stages = [:]
+    stage("Clean workspace") {
+       step([$class: 'WsCleanup'])
+    }
+    checkout scm
     utils = load("pipeline-utils.groovy")
     utils.define_properties(TIMER)
 
+    docker.image(DOCKER_IMG).pull()
     try {
     docker.image(DOCKER_IMG).inside(DOCKER_ARGS) {
         stage("Provision") {

--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -16,6 +16,11 @@ def ref = "openshift/3.10/x86_64/os";
 def version_prefix = "4.0"
 
 node(NODE) {
+    def par_stages = [:]
+    stage("Clean workspace") {
+       step([$class: 'WsCleanup'])
+    }
+    checkout scm
     utils = load("pipeline-utils.groovy")
     utils.define_properties(TIMER)
 


### PR DESCRIPTION
This effectively reverts https://github.com/openshift/os/pull/197
and goes with a common prelude where we clean the workspace and
use the SCM defined by the pipeline.