### PR TITLE
WIP: promote 'os-maipo' image to 'alpha' after successful sanity test

### DIFF
--- a/Jenkinsfile.cloud
+++ b/Jenkinsfile.cloud
@@ -2,6 +2,8 @@ def TIMER = "H H/3 * * *"
 def NODE = "rhcos-jenkins"
 def DOCKER_IMG = "quay.io/cgwalters/coreos-assembler"
 def DOCKER_ARGS = "-v /srv:/srv --privileged --device /dev/kvm"
+def API_CI_REGISTRY = "registry.svc.ci.openshift.org"
+def OSCONTAINER_IMG = API_CI_REGISTRY + "/rhcos/os-maipo"
 
 // Are there really other regions?  We're sending explorers to find out
 def AWS_REGION = "us-east-1"
@@ -21,8 +23,23 @@ node(NODE) {
     utils = load("pipeline-utils.groovy")
     utils.define_properties(TIMER)
 
+    // Split the credentials up
+    def username, password;
+    withCredentials([
+        usernameColonPassword(credentialsId: params.REGISTRY_CREDENTIALS, variable: 'CREDS'),
+    ]) {
+        (username, password) = "${CREDS}".split(':')
+    }
+
     docker.image(DOCKER_IMG).pull()
     docker.image(DOCKER_IMG).inside(DOCKER_ARGS) {
+    stage("Login") { sh """
+        set +x
+        echo podman login -u ${username} -p '<password>' ${API_CI_REGISTRY}
+        podman login -u "${username}" -p "${password}" ${API_CI_REGISTRY}
+        echo "login done"
+    """ }
+
     stage("Clone qcow2-to-vagrant") {
         // I tried to use git() but not sure where that went, it isn't the workspace
         sh('git clone https://github.com/cgwalters/qcow2-to-vagrant')
@@ -104,6 +121,17 @@ node(NODE) {
     """ }
     } finally {
         archiveArtifacts artifacts: "rhcos-basic.tap", allowEmptyArchive: true
+    }
+
+    // We passed some sanity checks, so pull the image again, retag it, and push
+    stage("Push an 'alpha' tag") {
+        if (params.DRY_RUN) {
+            echo "DRY_RUN set, skipping alpha tag"
+        } else if (!params.DRY_RUN) { sh """
+            podman pull ${OSCONTAINER_IMG}:${latest_commit}
+            podman tag ${OSCONTAINER_IMG}:${latest_commit} ${OSCONTAINER_IMG}:alpha
+            podman push ${OSCONTAINER_IMG}:alpha
+        """ }
     }
 
     def dirname, img_prefix, commit, version, dirpath, qcow, vmdk, ec2, vagrant_libvirt

--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -2,7 +2,7 @@ def TIMER = "H/30 * * * *"
 def NODE = "atomic-jslave-autobrew"
 def DOCKER_IMG = "quay.io/cgwalters/coreos-assembler"
 def API_CI_REGISTRY = "registry.svc.ci.openshift.org"
-def OSCONTAINER_IMG = API_CI_REGISTRY + "/rhcos/os-maipo:latest"
+def OSCONTAINER_IMG = API_CI_REGISTRY + "/rhcos/os-maipo"
 def DOCKER_ARGS = "--net=host -v /srv:/srv -v /run/docker.sock:/run/docker.sock --privileged"
 
 def treecompose_workdir = "/srv/rhcos/treecompose"
@@ -48,8 +48,8 @@ node(NODE) {
             mkdir -p ${treecompose_workdir}/containers
             mount --bind ${treecompose_workdir}/containers /var/lib/containers
             skopeo inspect docker://${OSCONTAINER_IMG}
-            podman pull ${OSCONTAINER_IMG}
-            cid=\$(podman run --net=host -d --name oscontainer --entrypoint sleep ${OSCONTAINER_IMG} infinity)
+            podman pull ${OSCONTAINER_IMG}:latest
+            cid=\$(podman run --net=host -d --name oscontainer --entrypoint sleep ${OSCONTAINER_IMG}:latest infinity)
             ln -sf \$(podman mount \${cid})/srv/repo ${treecompose_workdir}/repo
         """ }
 
@@ -122,15 +122,19 @@ node(NODE) {
       stage("Build new container") { sh """
           podman build --build-arg OS_VERSION=${version} \
                        --build-arg OS_COMMIT=${commit} \
-                       -t ${OSCONTAINER_IMG} \
+                       -t ${OSCONTAINER_IMG}:latest \
                        -f ${treecompose_workdir}/Dockerfile.rollup ${treecompose_workdir}
+          podman tag ${OSCONTAINER_IMG}:latest ${OSCONTAINER_IMG}:${version}
+          podman tag ${OSCONTAINER_IMG}:latest ${OSCONTAINER_IMG}:${commit}
       """ }
-      stage("Push container") { sh """
-          podman push ${OSCONTAINER_IMG}
-          podman inspect --format='{{.Id}}' ${OSCONTAINER_IMG} > imgid.txt
+      stage("Push containers") { sh """
+          podman push ${OSCONTAINER_IMG}:latest
+          podman push ${OSCONTAINER_IMG}:${version}
+          podman push ${OSCONTIANER_IMG}:${commit}
+          podman inspect --format='{{.Id}}' ${OSCONTAINER_IMG}:latest > imgid.txt
       """
           def cid = readFile('imgid.txt').trim();
-          currentBuild.description = "🆕 ${OSCONTAINER_IMG}@sha256:${cid} (${version})";
+          currentBuild.description = "🆕 ${OSCONTAINER_IMG}:latest@sha256:${cid} (${version})";
       }
 
       stage("rsync out") {


### PR DESCRIPTION
Now that we have a basic `kola` test in the pipeline, we can promote our images to 'alpha' status after a successful test.

To do this, we create an additional tag using the commit ID for the `os-maipo` image after its created.  Then, we reference this tag when doing the promotion to 'alpha'
