### PR TITLE
treecompose: don't copy a dir into itself

### DIFF
--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -111,7 +111,6 @@ node(NODE) {
       // with Docker/OCI images.  Ideally there'd be a way to "bind mount" content
       // into the build environment rather than copying.
       stage("Prepare repo copy") { sh """
-          cp -a --reflink=auto * ${treecompose_workdir}/
           original_repo=\$(readlink ${treecompose_workdir}/repo)
           rm ${repo}
           cp -a --reflink=auto \${original_repo} ${repo}


### PR DESCRIPTION
Before we used `$WORKSPACE` as the base for `$treecompose_workdir`,
we were copying all the contents of `$WORKSPACE` into what was
`/srv/rhcos/treecompose`.  Trying to do that same copy operation now
gives us:

`cp: cannot copy a directory, 'treecompose', into itself, '/home/jenkins/workspace/coreos-rhcos-treecompose/treecompose/treecompose'`

So let's stop doing that.