### PR TITLE
treecompose: correct location of repo in Dockerfile

### DIFF
--- a/Dockerfile.rollup
+++ b/Dockerfile.rollup
@@ -7,7 +7,7 @@ ARG OS_COMMIT=""
 LABEL io.openshift.os-version="$OS_VERSION" \
       io.openshift.os-commit="$OS_COMMIT"
 RUN yum -y install ostree nginx && yum clean all
-COPY repo /srv/repo
+COPY treecompose/repo /srv/repo
 # Keep this in sync with Dockerfile
 COPY nginx.conf /etc/nginx/nginx.conf
 COPY index.html subdomain.css /srv/repo/


### PR DESCRIPTION
The container build process expects to be able to copy the ostree repo
into the container.  Since the restructuring of the workspace and use
of `$treecompose_workdir`, this means the location of the repo needs
to be updated in the `Dockerfile`.