### PR TITLE
cloud: read host.yaml after SCM checkout

### DIFF
--- a/Jenkinsfile.cloud
+++ b/Jenkinsfile.cloud
@@ -9,10 +9,6 @@ def AWS_REGION = "us-east-1"
 def images = "/srv/rhcos/output/images"
 
 node(NODE) {
-    def manifest = "host.yaml"
-    def manifest_data = readYaml file: "${manifest}";
-    def ref = manifest_data.ref;
-
     def par_stages = [:]
     stage("Clean workspace") {
        step([$class: 'WsCleanup'])
@@ -20,6 +16,10 @@ node(NODE) {
     checkout scm
     utils = load("pipeline-utils.groovy")
     utils.define_properties(TIMER)
+
+    def manifest = "host.yaml"
+    def manifest_data = readYaml file: "${manifest}";
+    def ref = manifest_data.ref;
 
     utils.inside_assembler_container("-v /srv:/srv") {
     stage("Clone qcow2-to-vagrant") {


### PR DESCRIPTION
When using a freshly configured pipeline (i.e. new devel pipeline),
reading the `host.yaml` will fail.  But moving it after the SCM
checkout is successful.