### PR TITLE
rdgo: don't sync out broken overlay.yml symlink

### DIFF
--- a/Jenkinsfile.rdgo
+++ b/Jenkinsfile.rdgo
@@ -69,6 +69,8 @@ node(NODE) {
                 string(credentialsId: params.ARTIFACT_SERVER, variable: 'ARTIFACT_SERVER'),
                 sshUserPrivateKey(credentialsId: params.ARTIFACT_SSH_CREDS_ID, keyFileVariable: 'KEY_FILE'),
             ]) {
+                # don't sync overlay.yml symlink since it won't resolve
+                sh "rm -f ${rdgo}/overlay.yml"
                 utils.rsync_dir_out(ARTIFACT_SERVER, KEY_FILE, rdgo)
             }
             currentBuild.description = 'rdgo build+sync done'


### PR DESCRIPTION
We don't need to archive it and anyway it won't resolve. I think this
may be causing `aws s3 sync` in the backup pipeline to fail.