### PR TITLE
Jenkinsfile.cloud: +8G the qemu qcow2

### DIFF
--- a/Jenkinsfile.cloud
+++ b/Jenkinsfile.cloud
@@ -166,6 +166,8 @@ node(NODE) {
     parallel par_stages; par_stages = [:]
 
     stage("Finalizing, generate metadata") {
+        // See https://github.com/openshift/installer/blob/master/Documentation/dev/libvirt-howto.md#13a-rhcos
+        sh "qemu-img resize ${qcow} +8G"
         sh "gzip < ${qcow} > ${img_prefix}-qemu.qcow2.gz"
         sh "ln -sr ${img_prefix}-qemu.qcow2.gz ${dirpath}/rhcos-qemu.qcow2.gz"
         // Everything above in parallel worked on qcow, we're done with it now


### PR DESCRIPTION
The installer requires the image to start off with an extra
+8G developer usage. @eparis noted it would be helpful to have
this happen in the pipeline rather than each developer doing it
on their own.

In the (near) future it would be preferable for the installer
to handle this.