### PR TITLE
Jenkinsfile.cloud: fix image archive

### DIFF
--- a/Jenkinsfile.cloud
+++ b/Jenkinsfile.cloud
@@ -108,7 +108,7 @@ node(NODE) {
         sh 'tar -cJf _kola_temp.tar.xz _kola_temp'
         archiveArtifacts artifacts: "_kola_temp.tar.xz", allowEmptyArchive: true
         archiveArtifacts artifacts: "rhcos-basic.tap", allowEmptyArchive: true
-        archiveArtifacts artifacts: "rhcos.qcow2", allowEmptyArchive: true
+        archiveArtifacts artifacts: "$[image}", allowEmptyArchive: true
     }
 
     def dirname, img_prefix, commit, version, dirpath, qcow, vmdk, ec2, vagrant_libvirt


### PR DESCRIPTION
The image being archived doesn't exist. Switches to the variable rather
than a direct name.

Not tested.