### PR TITLE
manifest: Use boot_location: new

### DIFF
--- a/host.yaml
+++ b/host.yaml
@@ -11,6 +11,8 @@ repos:
 install-langs:
  - en_US
 documentation: false
+# This should really be the default...
+boot_location: new
 # See https://pagure.io/fedora-atomic/pull-request/62
 tmp-is-dir: true
 initramfs-args:


### PR DESCRIPTION
At some point I want to do a `version: 2` treefile where we
flip a bunch of defaults...