### PR TITLE
jenkins: Automatically make jobs not starting with rhcos- devel

### DIFF
--- a/pipeline-utils.groovy
+++ b/pipeline-utils.groovy
@@ -7,11 +7,13 @@
 
 def define_properties(timer) {
 
-    // Set this to TRUE to disable the timer, and set DRY_RUN=true by default
-    def developmentPipeline = false;
+    // Name your test jobs something not starting with rhcos-
+    def developmentPipeline = !env.JOB_NAME.startsWith("rhcos-");
 
     if (developmentPipeline)
       timer = null;
+
+    echo("Development pipeline: ${developmentPipeline}");
 
     /* There's a subtle gotcha here. Don't use `env.$PARAM`, but `params.$PARAM`
      * instead. The former will *not* be set on the first run, since the


### PR DESCRIPTION
I keep having the timer set on my test job, which ends up overriding
DRY_RUN and pushing to prod, which I obviously don't want.