### PR TITLE
manifest: Explicitly set machineid-compat: false at toplevel

### DIFF
--- a/host-maipo.yaml
+++ b/host-maipo.yaml
@@ -1,5 +1,10 @@
 ref: "openshift/3.10/x86_64/os"
 include: host-base.yaml
+# https://github.com/projectatomic/rpm-ostree/issues/1524
+boot_location: new
+machineid-compat: false
+tmp-is-dir: true
+# end duplicates from host-base.yaml
 repos:
   - atomic-centos-continuous
   - rhcos-continuous


### PR DESCRIPTION
It looks like the include logic in rpm-ostree isn't handling
this correctly.

Closes: https://github.com/openshift/os/issues/243