### PR TITLE
README: Fix the README-development link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This project does an [rpm-ostree](https://github.com/projectatomic/rpm-ostree)
 build inside a container; that container can then be pulled and run in a cluster,
 providing a HTTP server for clients to upgrade.
 
-Locally (but see [README-development.md] for more information on builds)
+Locally (but see [here](README-development.md) for more information on builds)
 
 ```
 $ docker build .


### PR DESCRIPTION
The link from b38dd0df [wasn't rendering][1].

[1]: https://github.com/openshift/os/blob/7e7c748ba0bee13c3987d76f847697c93c45c9d1/README.md#demonstration-of-delivering-ostree-host-updates-as-a-container-image