### PR TITLE
jenkins: Lower more treecompose logic to shell

### DIFF
--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -63,23 +63,12 @@ node(NODE) {
         // Note that we don't keep history in the ostree repo, so we
         // delete the ref head (so rpm-ostree won't add a parent) and
         // then we do a repo prune after.
-        def version, commit
+        def composeMeta;
         try {
-            stage("Compose Tree") { sh """
-                rm ${repo}/refs/heads/* -rf
-                env G_DEBUG=fatal-warnings rpm-ostree compose tree --repo=${repo} \
-                                                            --add-metadata-string=version=${version_prefix}.${env.BUILD_NUMBER} \
-                                                            ${manifest}
-                ostree --repo=${repo} rev-parse ${ref} > commit.txt
-            """
-                commit = readFile('commit.txt').trim();
-                version = utils.get_rev_version("${repo}", commit)
-                currentBuild.description = "🆕 ${version} (commit ${commit})";
-                if (previous_commit.length() > 0) { sh """
-                    rpm-ostree --repo=${repo} db diff ${previous_commit} ${commit} > ${WORKSPACE}/pkg-diff.txt
-                """ }
-                sh "ostree --repo=${repo} prune --refs-only --depth=0"
-                sh "ostree summary --repo=${repo} --update"
+            stage("Compose Tree") {
+                sh """./scripts/run-treecompose ${repo} ${ref} ${manifest} --add-metadata-string=version=${version_prefix}.${env.BUILD_NUMBER}"""
+                composeMeta = readJSON file: "compose.json"
+                currentBuild.description = "🆕 ${composeMeta.version} (commit ${composeMeta.commit})";
             }
         } finally {
             archiveArtifacts artifacts: "pkg-diff.txt", allowEmptyArchive: true
@@ -99,8 +88,8 @@ node(NODE) {
         """ }
 
         stage("Build new container") { sh """
-            podman build --build-arg OS_VERSION=${version} \
-                         --build-arg OS_COMMIT=${commit} \
+            podman build --build-arg OS_VERSION=${composeMeta.version} \
+                         --build-arg OS_COMMIT=${composeMeta.commit} \
                          -t ${OSCONTAINER_IMG} \
                          -f ${WORKSPACE}/Dockerfile.rollup ${WORKSPACE}
         """ }
@@ -117,7 +106,7 @@ node(NODE) {
             podman inspect --format='{{.Id}}' ${OSCONTAINER_IMG} > imgid.txt
         """
             def cid = readFile('imgid.txt').trim();
-            currentBuild.description = "🆕 ${OSCONTAINER_IMG}@sha256:${cid} (${version})";
+            currentBuild.description = "🆕 ${OSCONTAINER_IMG}@sha256:${cid} (${composeMeta.version})";
         }
 
         stage("rsync out") {

--- a/scripts/run-treecompose
+++ b/scripts/run-treecompose
@@ -1,0 +1,39 @@
+#!/usr/bin/bash
+set -xeuo pipefail
+
+repo=$1; shift
+ref=$1; shift
+
+# We don't keep history in the tree.
+previous_commit=$(ostree --repo="${repo}" rev-parse "${ref}" || true)
+rm ${repo}/refs/heads/* -rf
+# This should be the default.  It'll help us trace down a
+# coredump we're seeing periodically.
+export G_DEBUG=fatal-warnings
+rpm-ostree compose tree --repo=${repo} "$@"
+commit=$(ostree --repo=${repo} rev-parse ${ref})
+version=$(ostree --repo=${repo} show --print-metadata-key=version ${commit} | sed -e "s,',,g")
+
+# Generate a package-level diff
+if [ -n "${previous_commit}" ]; then
+    rpm-ostree --repo=${repo} db diff "${previous_commit}" "${commit}" > pkg-diff.txt
+fi
+
+# Now do a prune (again no history in the repo)
+ostree --repo=${repo} prune --refs-only --depth=0
+ostree --repo=${repo} summary -u
+
+# Generate JSON
+if [ -n "${previous_commit}" ]; then
+    previous_commit_json='"'"${previous_commit}"'"'
+else
+    previous_commit_json=null
+fi
+# This is easy to parse from Groovy
+cat > compose.json <<EOF
+{
+ "previous-commit": ${previous_commit_json},
+ "commit": "${commit}",
+ "version": "${version}"
+}
+EOF


### PR DESCRIPTION
Prep for sharing with ootpa and moving away from groovy.

I like this idea of "scripts/tools generate JSON" - then it's
easy for Jenkins to parse.