### PR TITLE
Add RHCOS kola testing on aws

### DIFF
--- a/Jenkinsfile.aws-test
+++ b/Jenkinsfile.aws-test
@@ -1,0 +1,78 @@
+def NODE = "rhcos-jenkins"
+def AWS_REGION = "us-east-1"
+
+// this var conveniently refers to a location on the server as well as the
+// local dir we sync to/from
+def images = "/srv/rhcos/output/images"
+
+node(NODE) {
+    stage("Clean workspace") {
+       step([$class: 'WsCleanup'])
+    }
+    checkout scm
+    utils = load("pipeline-utils.groovy")
+
+    // This job should only be triggered by Jenkinsfile.cloud
+    utils.define_properties(null)
+
+    if (params.DRY_RUN) {
+        echo "DRY_RUN set, skipping aws tests and launch permissions"
+        currentBuild.result = 'NOT_BUILT'
+        currentBuild.description = '(dry run)'
+        return
+    }
+
+    utils.inside_assembler_container("-v /srv:/srv") {
+    stage("Sync In") {
+        withCredentials([
+            string(credentialsId: params.ARTIFACT_SERVER, variable: 'ARTIFACT_SERVER'),
+            sshUserPrivateKey(credentialsId: params.ARTIFACT_SSH_CREDS_ID, keyFileVariable: 'KEY_FILE'),
+        ]) {
+            sh "mkdir -p ${dirpath}"
+            utils.rsync_file_in(ARTIFACT_SERVER, KEY_FILE, "${dirpath}/aws-${AWS_REGION}-smoketested.json")
+        }
+    }
+
+    try {
+    stage("Run Kola tests on intermediate aws image") {
+            withCredentials([
+                [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: params.AWS_CREDENTIALS],
+                string(credentialsId: params.S3_PRIVATE_BUCKET, variable: 'S3_PRIVATE_BUCKET'),
+                string(credentialsId: params.AWS_CI_ACCOUNT, variable: 'AWS_CI_ACCOUNT'),
+            ]) {
+                currentBuild.description = "ami: ${ami_intermediate}"
+                sh """
+                    # Do testing with intermediate aws image passed in by cloud job
+                    if ! kola -b rhcos -p aws --aws-type ${aws_type} --tapfile rhcos-aws.tap --aws-ami ${ami_intermediate} --aws-region ${AWS_REGION} run; then
+                        exit 1
+                    fi
+
+                    # Tests pass, tag the json in the artifact server to a persistent location
+                    # and give launch permissions to OpenShift CI
+                    if [ ! -e ${dirpath}/aws-${AWS_REGION}-smoketested.json ]; then
+                        echo "Cannot find smoketested json artifact."
+                        exit 1
+                    fi
+                    cp ${dirpath}/aws-${AWS_REGION}-smoketested.json ${images}/aws-${AWS_REGION}-tested.json
+                    aws ec2 modify-image-attribute \
+                        --image-id ${ami_intermediate} \
+                        --launch-permission '{"Add":[{"UserId":"${AWS_CI_ACCOUNT}"}]}'
+                """
+            }
+        }
+    } finally {
+        sh 'if test -e _kola_temp; then tar -cJf _kola_temp.tar.xz _kola_temp; fi'
+        archiveArtifacts artifacts: "_kola_temp.tar.xz", allowEmptyArchive: true
+        archiveArtifacts artifacts: "rhcos-aws.tap", allowEmptyArchive: true
+    }
+
+    stage("rsync out") {
+        withCredentials([
+            string(credentialsId: params.ARTIFACT_SERVER, variable: 'ARTIFACT_SERVER'),
+            sshUserPrivateKey(credentialsId: params.ARTIFACT_SSH_CREDS_ID, keyFileVariable: 'KEY_FILE'),
+        ]) {
+            utils.rsync_file_out(ARTIFACT_SERVER, KEY_FILE, "${images}/aws-${AWS_REGION}-tested.json")
+        }
+    }
+    }
+}

--- a/Jenkinsfile.cloud
+++ b/Jenkinsfile.cloud
@@ -192,15 +192,14 @@ node(NODE) {
        return
    }
 
-    stage("Create AMI") {
+    stage("Create Intermediate AMI") {
             withCredentials([
                 [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: params.AWS_CREDENTIALS],
                 string(credentialsId: params.S3_PRIVATE_BUCKET, variable: 'S3_PRIVATE_BUCKET'),
                 string(credentialsId: params.AWS_CI_ACCOUNT, variable: 'AWS_CI_ACCOUNT'),
             ]) {
                 sh """
-                    # use a symlink so that our uploaded filename is unique
-                    amijson=${dirpath}/aws-${AWS_REGION}.json
+                    amijson=${dirpath}/aws-${AWS_REGION}-smoketested.json
                     ore aws upload --region ${AWS_REGION} \
                         --ami-name 'rhcos_dev_${commit[0..6]}' \
                         --ami-description 'Red Hat CoreOS ${version} (${commit})' \
@@ -220,11 +219,6 @@ node(NODE) {
                         --resources \${ami} \${snapshot} \
                         --tags Key=ostree_commit,Value=${commit} \
                                Key=ostree_version,Value=${version}
-
-                    # give launch permissions to OpenShift CI
-                    aws ec2 modify-image-attribute \
-                        --image-id \${ami} \
-                        --launch-permission '{"Add":[{"UserId":"${AWS_CI_ACCOUNT}"}]}'
                 """
             }
     }
@@ -238,5 +232,13 @@ node(NODE) {
         }
     } }
     parallel par_stages; par_stages = [:]
+
+    // Build the job responsible for testing and publishing the ami
+    def ami_intermediate = utils.sh_capture("jq -r .HVM ${dirpath}/aws-${AWS_REGION}.json")
+    build job: 'coreos-rhcos-aws-test', wait: false, parameters: [
+        string(name: 'ami_intermediate', value: "${ami_intermediate}"),
+        string(name: 'dirpath', value: "${dirpath}"),
+        string(name: 'aws_type', value: "t2.small")
+    ]
     }
 }

--- a/pipeline-utils.groovy
+++ b/pipeline-utils.groovy
@@ -96,6 +96,24 @@ def rsync_dir(key, from_dir, to_dir) {
     """
 }
 
+def rsync_file_in(server, key, file) {
+    rsync_file(key, "${server}:${file}", file)
+}
+
+def rsync_file_out(server, key, file) {
+    rsync_file(key, file, "${server}:${file}")
+}
+
+def rsync_file(key, from_file, to_file) {
+    sh """
+        rsync -Hlpt --stats --delete --delete-after \
+            -e 'ssh -i ${key} \
+                    -o UserKnownHostsFile=/dev/null \
+                    -o StrictHostKeyChecking=no' \
+		    ${from_file} ${to_file}
+    """
+}
+
 def get_rev_version(repo, rev) {
     version = sh_capture("ostree show --repo=${repo} --print-metadata-key=version ${rev}")
     assert (version.startsWith("'") && version.endsWith("'"))


### PR DESCRIPTION
Add a new job coreos-rhcos-aws-test to take an ami and run kola tests
on it. If tests pass, the job gives launch permission to Openshift CI
for that ami. Modify cloud job to no longer give permission, but
instead to trigger the new aws-test job. Split the generated aws json
into smoketested and awstested, which signifies successful basic tests
and successful aws kola tests, respectively.

Signed off by: Yu Qi Zhang <jerzhang@redhat.com>