### PR TITLE
jenkins/treecompse: Skip change detection logic for DRY_RUN

### DIFF
--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -53,7 +53,7 @@ node(NODE) {
             }
         }
 
-        if (!fileExists('build.stamp') && last_build_version != force_nocache) {
+        if (!params.DRY_RUN && !fileExists('build.stamp') && last_build_version != force_nocache) {
             echo "No changes."
             currentBuild.result = 'SUCCESS'
             currentBuild.description = '(No changes)'


### PR DESCRIPTION
I use `DRY_RUN` when testing, and there I am usually not testing
the change logic.  This matches what we do for cloud.