### PR TITLE
Add a job to generate ootpa oscontainer

### DIFF
--- a/Jenkinsfile.treecompose-ootpa
+++ b/Jenkinsfile.treecompose-ootpa
@@ -1,14 +1,9 @@
 def TIMER = "H/30 * * * *"
 def NODE = "rhcos-jenkins"
 def API_CI_REGISTRY = "registry.svc.ci.openshift.org"
-def OS_NAME = "maipo";
+def OS_NAME = "ootpa";
 def OSCONTAINER_IMG = API_CI_REGISTRY + "/rhcos/os-${OS_NAME}:latest"
-def COMPOSEFLAGS = "";
-
-// We write to this one for now
-def artifact_repo = "/srv/rhcos/output/repo"
-// We write pkg_diff.txt here
-def images = "/srv/rhcos/output/images"
+def COMPOSEFLAGS = "--unified-core";
 
 node(NODE) {
     def par_stages = [:]
@@ -37,6 +32,16 @@ node(NODE) {
             }
         }
 
+        // NOTE - this differs from the base treecompose job
+        withCredentials([
+            string(credentialsId: params.OOTPA_COMPOSE, variable: 'OOTPA_COMPOSE'),
+            string(credentialsId: params.OOTPA_BUILDROOT_COMPOSE, variable: 'OOTPA_BUILDROOT_COMPOSE'),
+        ]) {
+        sh """
+            sed -e 's,@OOTPA_COMPOSE@,${OOTPA_COMPOSE},' -e 's,@OOTPA_BUILDROOT_COMPOSE@,${OOTPA_BUILDROOT_COMPOSE},' < ootpa.repo.in > ootpa.repo
+        """
+        }
+
         def previous_commit, last_build_version, force_nocache
         stage("Check for Changes") { sh """
             cp RPM-GPG-* /etc/pki/rpm-gpg/
@@ -55,7 +60,7 @@ node(NODE) {
             }
         }
 
-        if (!fileExists('build.stamp') && last_build_version != force_nocache) {
+        if (!params.DRY_RUN && !fileExists('build.stamp') && last_build_version != force_nocache) {
             echo "No changes."
             currentBuild.result = 'SUCCESS'
             currentBuild.description = '(No changes)'
@@ -111,24 +116,8 @@ node(NODE) {
             currentBuild.description = "🆕 ${OSCONTAINER_IMG}@sha256:${cid} (${composeMeta.version})";
         }
 
-        stage("rsync out") {
-            withCredentials([
-               string(credentialsId: params.ARTIFACT_SERVER, variable: 'ARTIFACT_SERVER'),
-               sshUserPrivateKey(credentialsId: params.ARTIFACT_SSH_CREDS_ID, keyFileVariable: 'KEY_FILE'),
-            ]) {
-            sh """
-               /usr/app/ostree-releng-scripts/rsync-repos \
-                   --dest ${ARTIFACT_SERVER}:${artifact_repo} --src=${repo}/ \
-                   --rsync-opt=--stats --rsync-opt=-e \
-                   --rsync-opt='ssh -i ${KEY_FILE} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
-            """ 
-        } }
-
-        stage("Cleanup") { sh """
+       stage("Cleanup") { sh """
             rm ${treecompose_workdir} -rf
         """ }
-
-        // Trigger downstream jobs
-        build job: 'coreos-rhcos-cloud', wait: false
   }
 }

--- a/compose-post.sh
+++ b/compose-post.sh
@@ -43,12 +43,14 @@ echo '%sudo        ALL=(ALL)       NOPASSWD: ALL' > /etc/sudoers.d/coreos-sudo-g
 
 # Nuke network.service from orbit
 # https://github.com/openshift/os/issues/117
-rm /etc/rc.d/init.d/network
-rm /etc/rc.d/rc*.d/*network
+rm -rf /etc/rc.d/init.d/network /etc/rc.d/rc*.d/*network
 
 # And readahead https://bugzilla.redhat.com/show_bug.cgi?id=1594984
 # It's long dead upstream, we definitely don't want it.
 rm -f /usr/lib/systemd/systemd-readahead /usr/lib/systemd/system/systemd-readahead-*
+
+# We're not using resolved yet
+rm -f /usr/lib/systemd/system/systemd-resolved.service
 
 # Let's have a non-boring motd, just like CL (although theirs is more subdued
 # nowadays compared to early versions with ASCII art).  One thing we do here

--- a/host-ootpa.yaml
+++ b/host-ootpa.yaml
@@ -1,0 +1,18 @@
+ref: "openshift/4/x86_64/os-ootpa"
+include: host-base.yaml
+# https://github.com/projectatomic/rpm-ostree/issues/1524
+boot_location: new
+machineid-compat: false
+tmp-is-dir: true
+# end duplicates from host-base.yaml
+repos:
+  - rhcos-continuous
+  - openshift
+  - ootpa-baseos
+  - ootpa-appstream
+  - ootpa-buildroot
+  - dustymabe-ignition
+mutate-os-release: "4.0"
+packages:
+  # Dependency of iscsi
+  - hostname

--- a/ootpa.repo.in
+++ b/ootpa.repo.in
@@ -1,0 +1,17 @@
+[ootpa-baseos]
+id=ootpa-baseos
+baseurl=@OOTPA_COMPOSE@/BaseOS/$basearch/os
+enabled=1
+gpgcheck=0
+
+[ootpa-appstream]
+id=ootpa-appstream
+baseurl=@OOTPA_COMPOSE@/AppStream/$basearch/os
+enabled=1
+gpgcheck=0
+
+[ootpa-buildroot]
+id=ootpa-buildroot
+baseurl=@OOTPA_BUILDROOT_COMPOSE@/Buildroot/$basearch/os
+enabled=1
+gpgcheck=0

--- a/pipeline-utils.groovy
+++ b/pipeline-utils.groovy
@@ -66,6 +66,16 @@ def define_properties(timer) {
                     description: "(not secret) Local installer tree mirror to use when running imagefactory.",
                     defaultValue: '50db8fac-f9d8-44e1-af0f-be29325a2896',
                     required: true),
+        credentials(name: 'OOTPA_COMPOSE',
+                    credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl',
+                    description: "(not secret) URL for compose of ootpa base/appstream content",
+                    defaultValue: 'fc28db5f-62cc-4386-866d-ea69d2088410',
+                    required: true),
+        credentials(name: 'OOTPA_BUILDROOT_COMPOSE',
+                    credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.StringCredentialsImpl',
+                    description: "(not secret) URL for compose of ootpa buildroot content",
+                    defaultValue: 'aa396a81-6adc-44e8-8fbc-7ecc54bf883f',
+                    required: true),
       ])
     ])
 }

--- a/scripts/run-treecompose
+++ b/scripts/run-treecompose
@@ -7,11 +7,19 @@ ref=$1; shift
 # We don't keep history in the tree.
 previous_commit=$(ostree --repo="${repo}" rev-parse "${ref}" || true)
 rm ${repo}/refs/heads/* -rf
+
+# Generate cache directory
+cachedir=${WORKSPACE}/rpmostree-cache
+mkdir -p ${cachedir}
+build_repo=${cachedir}/build-repo
+ostree --repo=${build_repo} init --mode=bare-user
+
 # This should be the default.  It'll help us trace down a
 # coredump we're seeing periodically.
 export G_DEBUG=fatal-warnings
-rpm-ostree compose tree --repo=${repo} "$@"
-commit=$(ostree --repo=${repo} rev-parse ${ref})
+rpm-ostree compose tree --repo=${build_repo} --cachedir=$WORKSPACE/rpmostree-cache "$@"
+commit=$(ostree --repo=${build_repo} rev-parse ${ref})
+ostree --repo=${repo} pull-local ${build_repo}
 version=$(ostree --repo=${repo} show --print-metadata-key=version ${commit} | sed -e "s,',,g")
 
 # Generate a package-level diff


### PR DESCRIPTION
The treecompose job works, and one can pivot to it.  I have
more work to do to share code between the now 2 treecompose jobs.
And we're obviously missing cloud images (further patches to come
for that).

There are some SELinux denials and failing services (it looks
like preset is enabling sssd socket units somehow?)

But this is useful for us to add to the matrix and make available.