### PR TITLE
treecompose: Drop some dead code

### DIFF
--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -35,15 +35,9 @@ node(NODE) {
             }
         }
 
-        def previous_commit, last_build_version, force_nocache
+        def last_build_version, force_nocache
         stage("Check for Changes") { sh """
             make repo-refresh
-            rm -f $WORKSPACE/build.stamp
-            ls -al ${repo}
-            ostree --repo=${repo} rev-parse ${ref} > commit.txt || true
-        """
-            previous_commit = readFile('commit.txt').trim();
-        sh """
             rpm-ostree compose tree --dry-run --repo=${repo} --touch-if-changed=$WORKSPACE/build.stamp ${manifest}
         """
             last_build_version = utils.get_rev_version(repo, ref)


### PR DESCRIPTION
 - We clean the workspace now
 - The `ls` is clearly just a debug leftover
 - The previous commit is set consistently in the composeMeta json
   generated by the later code (nothing was reading `previous_commit`)