### PR TITLE
jenkins/treecompose: Archive composeMeta JSON

### DIFF
--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -64,6 +64,7 @@ node(NODE) {
                 currentBuild.description = "🆕 ${composeMeta.version} (commit ${composeMeta.commit})";
             }
         } finally {
+            archiveArtifacts artifacts: "compose.json"
             archiveArtifacts artifacts: "pkg-diff.txt", allowEmptyArchive: true
         }
 


### PR DESCRIPTION
We don't sync it anywhere right now, and it's convenient to
have just on general principle.  Down the line we may add more
stuff there.