### PR TITLE
host: add coreos-metadata binary and service

### DIFF
--- a/coreos-metadata.repo
+++ b/coreos-metadata.repo
@@ -1,0 +1,10 @@
+[lucab-rhcos-coreos-metadata]
+name=Copr repo for rhcos-coreos-metadata owned by lucab
+baseurl=https://copr-be.cloud.fedoraproject.org/results/lucab/rhcos-coreos-metadata/epel-7-$basearch/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=1
+gpgkey=https://copr-be.cloud.fedoraproject.org/results/lucab/rhcos-coreos-metadata/pubkey.gpg
+repo_gpgcheck=0
+enabled=1
+enabled_metadata=1

--- a/host-base.yaml
+++ b/host-base.yaml
@@ -59,8 +59,9 @@ packages:
  # Time sync
  - chrony
  # Extra runtime
- - sssd shadow-utils
+ - coreos-metadata
  - logrotate
+ - sssd shadow-utils
  # Used by admins interactively
  - sudo coreutils less tar xz gzip bzip2 rsync tmux
  - nmap-ncat net-tools bind-utils strace

--- a/host-maipo.yaml
+++ b/host-maipo.yaml
@@ -14,6 +14,7 @@ repos:
   - rhel-7.5-server-extras
   - rhel-7.5-atomic
   - dustymabe-ignition
+  - lucab-rhcos-coreos-metadata
 mutate-os-release: "4.0"
 packages:
  # auth legacy


### PR DESCRIPTION
This adds coreos-metadata RPM to RHCOS treefile. Current package is for
latest upstream version (v3.0.0) and provides the binary and a
service unit (disabled). The ssh-keys service is not relevant to RHCOS
and not installed in the rpm.

This consumes a dedicated copr repo:
https://copr.fedorainfracloud.org/coprs/lucab/rhcos-coreos-metadata/

Source specfile is at https://github.com/lucab/rhcos-coreos-metadata

Ref: COREOS-406