### PR TITLE
Drop tuned

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,6 @@ rdgo:
 # Composes an ostree
 .PHONY: rpmostree-compose
 rpmostree-compose: ${ROOT_DIR}/openshift.repo init-ostree-repo
-	cp -n ${ROOT_DIR}/RPM-GPG-* /etc/pki/rpm-gpg/
 	mkdir -p ${REPO}
 	ostree init --repo=${REPO} --mode=archive
 	if test -d cache; then cachedir='--cachedir $(shell pwd)/cache'; fi && \

--- a/host-maipo.yaml
+++ b/host-maipo.yaml
@@ -22,8 +22,6 @@ packages:
  # Docker legacy
  - docker docker-lvm-plugin docker-novolume-plugin
  - oci-umount
- # tuned (legacy IMO)
- - tuned tuned-profiles-atomic
  # SELinux
  - policycoreutils-python
  # Networking legacy


### PR DESCRIPTION
Helps move us towards not shipping python.  We also generally
want our configuration to be static - we don't want admins interactively
running tuned in general.