### PR TITLE
treecompose: use 'ceph-tools-2' + 'glusterfs' repo

### DIFF
--- a/host-maipo.yaml
+++ b/host-maipo.yaml
@@ -14,6 +14,7 @@ repos:
   - rhel-7.5-server-extras
   - rhel-7.5-atomic
   - ceph-tools-2
+  - glusterfs
   - dustymabe-ignition
   - lucab-rhcos-coreos-metadata
 mutate-os-release: "4.0"

--- a/host-maipo.yaml
+++ b/host-maipo.yaml
@@ -13,6 +13,7 @@ repos:
   - rhel-7.5-server-optional
   - rhel-7.5-server-extras
   - rhel-7.5-atomic
+  - ceph-tools-2
   - dustymabe-ignition
   - lucab-rhcos-coreos-metadata
 mutate-os-release: "4.0"

--- a/rhel.repo
+++ b/rhel.repo
@@ -33,3 +33,9 @@ metadata_expire=1m
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/redhat/RPM-GPG-KEY-redhat7-release
 
+[glusterfs]
+enabled=1
+baseurl=http://cdn.stage.redhat.com/content/dist/rhel/server/7/7Server/x86_64/rhs-client/os/
+metadata_expire=1m
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/redhat/RPM-GPG-KEY-redhat7-release

--- a/rhel.repo
+++ b/rhel.repo
@@ -25,3 +25,11 @@ baseurl=http://cdn.stage.redhat.com/content/dist/rhel/atomic/7/7.5/x86_64/os/
 metadata_expire=1m
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/redhat/RPM-GPG-KEY-redhat7-release
+
+[ceph-tools-2]
+enabled=1
+baseurl=http://cdn.stage.redhat.com/content/dist/rhel/server/7/7Server/x86_64/ceph-tools/2/os/
+metadata_expire=1m
+gpgcheck=1
+gpgkey=file:///usr/share/distribution-gpg-keys/redhat/RPM-GPG-KEY-redhat7-release
+


### PR DESCRIPTION
This switches the `treecompose` job to pull content from the `ceph-tools-2` repo, which should give us a more current version of `ceph-common`

Closes: #271 