### PR TITLE
jenkins/cloud: Fix image genver logic

### DIFF
--- a/Jenkinsfile.cloud
+++ b/Jenkinsfile.cloud
@@ -125,8 +125,8 @@ node(NODE) {
     // We write this to meta.json
     def meta = [:];
     Integer image_genver;
-    if (last_build_meta != null) {
-        image_genver = last_build_meta["image-genver"] + 1;
+    if (previously_built_commit) {
+        image_genver = Integer.parseInt(last_build_meta["image-genver"]) + 1;
     } else {
         image_genver = 1;
     }


### PR DESCRIPTION
We only want to go from `1` to `2` if we previously built the commit,
not if there was a previous build.

Also, we need to convert the genver into an integer before trying to
add to it.