### PR TITLE
ootpa: Add coreos-metadata repo

### DIFF
--- a/host-ootpa.yaml
+++ b/host-ootpa.yaml
@@ -12,6 +12,7 @@ repos:
   - ootpa-appstream
   - ootpa-buildroot
   - dustymabe-ignition
+  - lucab-rhcos-coreos-metadata
 mutate-os-release: "4.0"
 packages:
   # Dependency of iscsi


### PR DESCRIPTION
This is shipping maipo binaries on ootpa, which is the same thing
we're doing for Ignition.