### PR TITLE
Rename maipo repos to use that name

### DIFF
--- a/host-maipo.yaml
+++ b/host-maipo.yaml
@@ -9,12 +9,12 @@ repos:
   - atomic-centos-continuous
   - rhcos-continuous
   - openshift
-  - rhel-7.5-server
-  - rhel-7.5-server-optional
-  - rhel-7.5-server-extras
-  - rhel-7.5-atomic
-  - ceph-tools-2
-  - glusterfs
+  - maipo-server
+  - maipo-server-optional
+  - maipo-server-extras
+  - maipo-atomic
+  - maipo-ceph-tools-2
+  - maipo-glusterfs
   - dustymabe-ignition
   - lucab-rhcos-coreos-metadata
 mutate-os-release: "4.0"

--- a/maipo.repo
+++ b/maipo.repo
@@ -1,39 +1,39 @@
-[rhel-7.5-server]
+[maipo-server]
 enabled=1
 baseurl=http://cdn.stage.redhat.com/content/dist/rhel/server/7/7Server/x86_64/os/
 metadata_expire=1m
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/redhat/RPM-GPG-KEY-redhat7-release
 
-[rhel-7.5-server-optional]
+[maipo-server-optional]
 enabled=1
 baseurl=http://cdn.stage.redhat.com/content/dist/rhel/server/7/7Server/x86_64/optional/os/
 metadata_expire=1m
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/redhat/RPM-GPG-KEY-redhat7-release
 
-[rhel-7.5-server-extras]
+[maipo-server-extras]
 enabled=1
 baseurl=http://cdn.stage.redhat.com/content/dist/rhel/server/7/7Server/x86_64/extras/os/
 metadata_expire=1m
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/redhat/RPM-GPG-KEY-redhat7-release
 
-[rhel-7.5-atomic]
+[maipo-atomic]
 enabled=1
 baseurl=http://cdn.stage.redhat.com/content/dist/rhel/atomic/7/7Server/x86_64/os/
 metadata_expire=1m
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/redhat/RPM-GPG-KEY-redhat7-release
 
-[ceph-tools-2]
+[maipo-ceph-tools-2]
 enabled=1
 baseurl=http://cdn.stage.redhat.com/content/dist/rhel/server/7/7Server/x86_64/ceph-tools/2/os/
 metadata_expire=1m
 gpgcheck=1
 gpgkey=file:///usr/share/distribution-gpg-keys/redhat/RPM-GPG-KEY-redhat7-release
 
-[glusterfs]
+[maipo-glusterfs]
 enabled=1
 baseurl=http://cdn.stage.redhat.com/content/dist/rhel/server/7/7Server/x86_64/rhs-client/os/
 metadata_expire=1m


### PR DESCRIPTION
For consistency with ootpa.  Also having a version number in
the repo names now was deceptive as we now track "latest".