### PR TITLE
ci: Adapt for coreos-assembler

### DIFF
--- a/.prow.sh
+++ b/.prow.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -xeuo pipefail
 
-yum -y install jq PyYAML
+# This script is run by prow using the coreos-assembler container.
+
 make syntax-check
 # And disable the container again until we figure out about Prow -> internal
 # make container

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ syntax-check:
 	done
 	@set -e; for yamlfile in $$(find ${ROOT_DIR} -name '*.yaml' -o -name '*.yml'); do \
 		echo -n "Checking YAML syntax for $${yamlfile}... "; \
-		python -c "import yaml; yaml.safe_load(open('$${yamlfile}'))"; \
+		python3 -c "import yaml; yaml.safe_load(open('$${yamlfile}'))"; \
 		echo "OK"; \
 	done
 


### PR DESCRIPTION
Both `jq` and `python3-PyYAML` are already installed in the container.
Also since coreo-assembler is Fedora based, adjust `syntax-check`.