### PR TITLE
Switch to faster moving cri-o rpms

### DIFF
--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -37,6 +37,14 @@ node(NODE) {
             }
         }
 
+        stage("Pull in creds for cri-o-tested repo") {
+            withCredentials([
+                file(credentialsId: params.OPENSHIFT_MIRROR_CREDENTIALS_FILE, variable: 'OPENSHIFT_MIRROR_CREDENTIALS_FILE'),
+            ]) {
+                sh """cp ${OPENSHIFT_MIRROR_CREDENTIALS_FILE} ${WORKSPACE}/ops-mirror.pem && sed -i -e "s~WORKSPACE~$WORKSPACE~g" ${WORKSPACE}/cri-o-tested.repo"""
+            }
+        }
+
         def last_build_version, force_nocache
         stage("Check for Changes") { sh """
             make repo-refresh

--- a/cri-o-tested.repo
+++ b/cri-o-tested.repo
@@ -1,0 +1,10 @@
+[cri-o-tested]
+name=RHEL tested cri-o repo with dependencies
+baseurl=https://mirror.ops.rhcloud.com/enterprise/rhel/cri-o-tested/3.11/x86_64/os/
+type=rpm-md
+skip_if_unavailable=True
+gpgcheck=0
+enabled=1
+sslverify=0
+sslclientkey=WORKSPACE/ops-mirror.pem
+sslclientcert=WORKSPACE/ops-mirror.pem

--- a/host-base.yaml
+++ b/host-base.yaml
@@ -47,7 +47,7 @@ packages:
  # SSH
  - openssh-server openssh-clients
  # Containers
- - podman skopeo runc
+ - podman skopeo runc containernetworking-plugins
  - cri-o cri-tools
  # Networking
  - nfs-utils

--- a/host-maipo.yaml
+++ b/host-maipo.yaml
@@ -17,6 +17,7 @@ repos:
   - maipo-glusterfs
   - dustymabe-ignition
   - lucab-rhcos-coreos-metadata
+  - cri-o-tested
 mutate-os-release: "4.0"
 packages:
  # auth legacy

--- a/pipeline-utils.groovy
+++ b/pipeline-utils.groovy
@@ -43,6 +43,11 @@ def define_properties(timer) {
                     description: "Credentials for Docker registry.",
                     defaultValue: 'e3fd566b-46c1-44e4-aec9-bb59214c1926',
                     required: true),
+        credentials(name: 'OPENSHIFT_MIRROR_CREDENTIALS_FILE',
+                    credentialType: 'org.jenkinsci.plugins.plaincredentials.impl.FileCredentialsImpl',
+                    description: "OpenShift shared-secrets mirror cred as file.",
+                    defaultValue: '299ad25c-f8d1-4f56-9f00-06a85490321a',
+                    required: true),
         // Past here, we're just using parameters as a way to avoid hardcoding internal values; they
         // are not actually secret.
         booleanParam(name: 'DRY_RUN', defaultValue: developmentPipeline, description: 'If true, do not push changes'),

--- a/rdgo/overlay.yml
+++ b/rdgo/overlay.yml
@@ -19,9 +19,6 @@ components:
     override-version: "1.13.1"
     branch: docker-1.13.1-rhel
 
-  - distgit: cri-o
-  - distgit: cri-tools
-
 # pull ignition directly from copr for now
 # - src: github:coreos/ignition
 #   distgit:
@@ -29,12 +26,6 @@ components:
 #       name: ignition
 #       patches: drop
 #       branch: master
-
-  # Required as a cri-o dependency
-  - src: https://github.com/containernetworking/plugins.git
-    distgit:
-        name: containernetworking-cni
-        patches: drop
 
   - src: github:openshift/redhat-release-coreos
     spec: internal


### PR DESCRIPTION
Change the following packages to use the cri-o-tested rhel repo:

 - cri-o
 - cri-tools
 - podman
 - skopeo
 - runc
 - containernetworking-plugins

Move the package reference to host-maipo and add cri-o-tested repo.
Add corresponding OpenShift cred file to pipeline.

Signed-off-by: Yu Qi Zhang <jerzhang@redhat.com>