### PR TITLE
jenkins: Create a prepare_configuration() helper

### DIFF
--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -29,6 +29,10 @@ node(NODE) {
         def treecompose_workdir = "${WORKSPACE}/treecompose";
         def repo = "${treecompose_workdir}/repo";
 
+        stage("Prepare configuration") {
+            utils.prepare_configuration();
+        }
+
         stage("Pull and run oscontainer") {
             withCredentials([
                 usernameColonPassword(credentialsId: params.REGISTRY_CREDENTIALS, variable: 'CREDS'),
@@ -37,17 +41,8 @@ node(NODE) {
             }
         }
 
-        stage("Pull in creds for cri-o-tested repo") {
-            withCredentials([
-                file(credentialsId: params.OPENSHIFT_MIRROR_CREDENTIALS_FILE, variable: 'OPENSHIFT_MIRROR_CREDENTIALS_FILE'),
-            ]) {
-                sh """cp ${OPENSHIFT_MIRROR_CREDENTIALS_FILE} ${WORKSPACE}/ops-mirror.pem && sed -i -e "s~WORKSPACE~$WORKSPACE~g" ${WORKSPACE}/cri-o-tested.repo"""
-            }
-        }
-
         def last_build_version, force_nocache
         stage("Check for Changes") { sh """
-            make repo-refresh
             rpm-ostree compose tree --dry-run --repo=${repo} --touch-if-changed=$WORKSPACE/build.stamp ${manifest}
         """
             last_build_version = utils.get_rev_version(repo, ref)

--- a/Jenkinsfile.treecompose-ootpa
+++ b/Jenkinsfile.treecompose-ootpa
@@ -24,6 +24,10 @@ node(NODE) {
         def treecompose_workdir = "${WORKSPACE}/treecompose";
         def repo = "${treecompose_workdir}/repo";
 
+        stage("Prepare configuration") {
+            utils.prepare_configuration();
+        }
+
         stage("Pull and run oscontainer") {
             withCredentials([
                 usernameColonPassword(credentialsId: params.REGISTRY_CREDENTIALS, variable: 'CREDS'),
@@ -32,19 +36,8 @@ node(NODE) {
             }
         }
 
-        // NOTE - this differs from the base treecompose job
-        withCredentials([
-            string(credentialsId: params.OOTPA_COMPOSE, variable: 'OOTPA_COMPOSE'),
-            string(credentialsId: params.OOTPA_BUILDROOT_COMPOSE, variable: 'OOTPA_BUILDROOT_COMPOSE'),
-        ]) {
-        sh """
-            sed -e 's,@OOTPA_COMPOSE@,${OOTPA_COMPOSE},' -e 's,@OOTPA_BUILDROOT_COMPOSE@,${OOTPA_BUILDROOT_COMPOSE},' < ootpa.repo.in > ootpa.repo
-        """
-        }
-
         def last_build_version, force_nocache
         stage("Check for Changes") { sh """
-            make repo-refresh
             rpm-ostree compose tree --dry-run --repo=${repo} --touch-if-changed=$WORKSPACE/build.stamp ${manifest}
         """
             last_build_version = utils.get_rev_version(repo, ref)


### PR DESCRIPTION
More followup for cri-o+ootpa.  We need to inject the cert in
the ootpa job too.  Let's define a common helper for this and
also run it early, since it doesn't depend on anything else.

(Ideally this would somehow be possible to run locally from
 the `Makefile` but that really requires splitting out the
 "not-actually-credentials" into an internal git repo or something)