### PR TITLE
Switch back to LVM+container-storage-setup

### DIFF
--- a/cloud.ks
+++ b/cloud.ks
@@ -28,7 +28,9 @@ clearpart --initlabel --all
 bootloader --timeout=1 --append="no_timer_check console=ttyS0,115200n8 console=tty0 net.ifnames=0 biosdevname=0 ip=dhcp rd.neednet=1 rw $coreos_firstboot"
 
 part /boot --size=300 --fstype="xfs" --label=boot
-part / --size=3000 --fstype="xfs" --label=root --grow
+part pv.01 --grow
+volgroup coreos pv.01
+logvol / --size=3000 --fstype="xfs" --name=root --label=root --vgname=coreos --grow
 
 ostreesetup --nogpg --osname=rhcos --remote=rhcos --url=@@OSTREE_INSTALL_URL@@ --ref=@@OSTREE_INSTALL_REF@@
 


### PR DESCRIPTION
Dropping LVM caused race conditions in dracut startup - I *think*
it's the fact that the LVM bits basically process the whole udev
queue to assemble devices, there's a `udevadm settle` in that code.

Our dracut probably needs to learn to settle/wait for network
devices with `ip=dhcp`.

Closes: https://github.com/openshift/os/issues/298