### PR TITLE
cloud: Specify eth0 for now for ip= line to ensure networking

### DIFF
--- a/cloud.ks
+++ b/cloud.ks
@@ -25,7 +25,7 @@ clearpart --initlabel --all
 #  - ip=dhcp           # how to get network
 #  - rd.neednet=1      # tell dracut we need network
 #  - $coreos_firstboot # This is actually a GRUB variable
-bootloader --timeout=1 --append="no_timer_check console=ttyS0,115200n8 console=tty0 net.ifnames=0 biosdevname=0 ip=dhcp rd.neednet=1 rw $coreos_firstboot"
+bootloader --timeout=1 --append="no_timer_check console=ttyS0,115200n8 console=tty0 net.ifnames=0 biosdevname=0 ip=eth0:dhcp rd.neednet=1 rw $coreos_firstboot"
 
 part /boot --size=300 --fstype="xfs" --label=boot
 part / --size=3000 --fstype="xfs" --label=root --grow


### PR DESCRIPTION
Dracut has a weird behavior where when we remove LVM from the equation
we don't end up running files in /lib/dracut/hooks/initqueue/*.sh
(which includes ifup-eth0.sh) because the root device already exists
(i.e. we don't have to run udevadm settle (line 28 in [1]) to wait for
it to show up).

We need to specify ip=eth0:dhcp so that [2] will hit this code [3] and
dev=eth0 will be set, so IFACES gets set [4] so that /tmp/net.ifaces
will get set [5] and then  /lib/dracut/hooks/initqueue/finished/wait-eth0.sh
will get created [6] so check_finished from [1] won't return true until
eth0 is up.

fixes #298

[1] https://github.com/dracutdevs/dracut/blob/fb008ce6656f0efb10b3aba4d3740db302b4e683/modules.d/98systemd/dracut-initqueue.sh#L26-L40
[2] https://github.com/dracutdevs/dracut/blob/fb008ce6656f0efb10b3aba4d3740db302b4e683/modules.d/40network/parse-ip-opts.sh#L52
[3] https://github.com/dracutdevs/dracut/blob/fb008ce6656f0efb10b3aba4d3740db302b4e683/modules.d/40network/net-lib.sh#L475-L486
[4] https://github.com/dracutdevs/dracut/blob/fb008ce6656f0efb10b3aba4d3740db302b4e683/modules.d/40network/parse-ip-opts.sh#L91-L100
[5] https://github.com/dracutdevs/dracut/blob/fb008ce6656f0efb10b3aba4d3740db302b4e683/modules.d/40network/parse-ip-opts.sh#L141
[6] https://github.com/dracutdevs/dracut/blob/fb008ce6656f0efb10b3aba4d3740db302b4e683/modules.d/40network/net-genrules.sh#L97-L101