### PR TITLE
rdgo: Move pivot to openshift namespace

### DIFF
--- a/rdgo/overlay.yml
+++ b/rdgo/overlay.yml
@@ -26,5 +26,5 @@ components:
   - src: github:openshift/redhat-release-coreos
     spec: internal
 
-  - src: github:ashcrow/pivot
+  - src: github:openshift/pivot
     spec: internal


### PR DESCRIPTION
`ashcrow/pivot` is now `openshift/pivot`