### PR TITLE
jenkins: Add Slack notifications for job status changes

### DIFF
--- a/Jenkinsfile.aws-test
+++ b/Jenkinsfile.aws-test
@@ -22,6 +22,7 @@ node(NODE) {
         return
     }
 
+    try {
     utils.inside_assembler_container("-v /srv:/srv") {
     stage("Sync In") {
         withCredentials([
@@ -78,5 +79,11 @@ node(NODE) {
             utils.rsync_file_out(ARTIFACT_SERVER, KEY_FILE, "${images}/aws-${AWS_REGION}-tested.json")
         }
     }
+    }
+    } catch (Throwable e) {
+        currentBuild.result = 'FAILURE'
+        throw e
+    } finally {
+        utils.notify_status_change currentBuild
     }
 }

--- a/Jenkinsfile.cloud
+++ b/Jenkinsfile.cloud
@@ -17,6 +17,7 @@ node(NODE) {
     utils = load("pipeline-utils.groovy")
     utils.define_properties(TIMER)
 
+    try {
     def manifest = "host-maipo.yaml"
     def manifest_data = readYaml file: "${manifest}";
     def ref = manifest_data.ref;
@@ -256,5 +257,11 @@ node(NODE) {
         string(name: 'dirpath', value: "${dirpath}"),
         string(name: 'aws_type', value: "t2.small")
     ]
+    }
+    } catch (Throwable e) {
+        currentBuild.result = 'FAILURE'
+        throw e
+    } finally {
+        utils.notify_status_change currentBuild
     }
 }

--- a/Jenkinsfile.rdgo
+++ b/Jenkinsfile.rdgo
@@ -78,8 +78,11 @@ node(NODE) {
         build job: 'coreos-rhcos-treecompose', wait: false
     }
 
+    } catch (Throwable e) {
+        currentBuild.result = 'FAILURE'
+        throw e
     } finally {
         archiveArtifacts artifacts: "log/**", allowEmptyArchive: true
+        utils.notify_status_change currentBuild
     }
 }
-

--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -19,6 +19,7 @@ node(NODE) {
     utils = load("pipeline-utils.groovy")
     utils.define_properties(TIMER)
 
+    try {
     def manifest = "host-${OS_NAME}.yaml"
     def manifest_data = readYaml file: "${manifest}";
     // TODO - stop using the ref in favor of oscontainer:// pivot
@@ -127,5 +128,11 @@ node(NODE) {
 
         // Trigger downstream jobs
         build job: 'coreos-rhcos-cloud', wait: false
-  }
+    }
+    } catch (Throwable e) {
+        currentBuild.result = 'FAILURE'
+        throw e
+    } finally {
+        utils.notify_status_change currentBuild
+    }
 }

--- a/Jenkinsfile.treecompose-ootpa
+++ b/Jenkinsfile.treecompose-ootpa
@@ -14,6 +14,7 @@ node(NODE) {
     utils = load("pipeline-utils.groovy")
     utils.define_properties(TIMER)
 
+    try {
     def manifest = "host-${OS_NAME}.yaml"
     def manifest_data = readYaml file: "${manifest}";
     // TODO - stop using the ref in favor of oscontainer:// pivot
@@ -105,5 +106,11 @@ node(NODE) {
        stage("Cleanup") { sh """
             rm ${treecompose_workdir} -rf
         """ }
-  }
+    }
+    } catch (Throwable e) {
+        currentBuild.result = 'FAILURE'
+        throw e
+    } finally {
+        utils.notify_status_change currentBuild
+    }
 }


### PR DESCRIPTION
This wraps the body of most jobs in a try/catch block which sets the run's status to failure if an exception or error is thrown.  At the end, that status is compared to the previous run, and a notification is sent if they differ (treating anything other than success as a failure).

The logic for sending notifications is stored in the utils file to reduce code duplication, which means notifications will not be sent for failures caused by changes to the utils file.

This expects that the Slack plugin is configured to be able to send to the CoreOS Slack instance.  It only overrides the default Slack channel, in case something else makes more sense for the global configuration.