### PR TITLE
adopt `buildmaster` and `alpha` tags for oscontainer

### DIFF
--- a/Jenkinsfile.aws-test
+++ b/Jenkinsfile.aws-test
@@ -1,5 +1,8 @@
 def NODE = "rhcos-jenkins"
 def AWS_REGION = "us-east-1"
+def API_CI_REGISTRY = "registry.svc.ci.openshift.org"
+def OS_NAME = "maipo";
+def OSCONTAINER_IMG = API_CI_REGISTRY + "/rhcos/os-${OS_NAME}"
 
 // location on the server we'll rsync to/from our $WORKSPACE
 def images = "/srv/rhcos/output/images"
@@ -23,7 +26,7 @@ node(NODE) {
 
     // We're only ever triggered by the cloud job, so we know the latest build is in latest/
     // We immediately resolve it back to the specific images/ dir
-    def version
+    def ostree_commit, version
     try {
     utils.inside_assembler_container("") {
     stage("Sync In") {
@@ -32,6 +35,7 @@ node(NODE) {
             sshUserPrivateKey(credentialsId: params.ARTIFACT_SSH_CREDS_ID, keyFileVariable: 'KEY_FILE'),
         ]) {
             utils.rsync_file_in_dest(ARTIFACT_SERVER, KEY_FILE, "${images}/cloud/latest/meta.json", "${WORKSPACE}/meta.json")
+            ostree_commit = utils.sh_capture("jq -r '.[\"ostree-commit\"]' ${WORKSPACE}/meta.json")
             version = utils.sh_capture("jq -r '.[\"ostree-version\"]' ${WORKSPACE}/meta.json")
             // resolve to original dir to avoid races in the next rsync in
             def imgv = utils.sh_capture("jq -r '.[\"image-version\"]' ${WORKSPACE}/meta.json")
@@ -48,12 +52,21 @@ node(NODE) {
                 string(credentialsId: params.S3_PRIVATE_BUCKET, variable: 'S3_PRIVATE_BUCKET'),
                 string(credentialsId: params.AWS_CI_ACCOUNT, variable: 'AWS_CI_ACCOUNT'),
                 string(credentialsId: params.S3_PUBLIC_BUCKET, variable: 'S3_PUBLIC_BUCKET'),
+                usernameColonPassword(credentialsId: params.REGISTRY_CREDENTIALS, variable: 'CREDS'),
             ]) {
                 def ami_intermediate = utils.sh_capture("jq -r .HVM ${WORKSPACE}/aws-${AWS_REGION}.json")
+
+                // login to registry and setup container storage
+                def (registryUser, registryPass) = "${CREDS}".split(':')
+                utils.registry_login(registryUser, registryPass, "${API_CI_REGISTRY}")
+                utils.prep_container_storage("${WORKSPACE}")
+
                 currentBuild.description = "version=${version} ami=${ami_intermediate}"
                 sh """
                     # Do testing with intermediate aws image passed in by cloud job
                     if ! kola -b rhcos -p aws --aws-type t2.small --tapfile rhcos-aws.tap --aws-ami ${ami_intermediate} --aws-region ${AWS_REGION} -j ${NUM_VMS} run; then
+                        # if the tests fail, GC the container image tagged with the ostree commit
+                        skopeo delete docker://${OSCONTAINER_IMG}:${ostree_commit}
                         exit 1
                     fi
 
@@ -71,6 +84,10 @@ node(NODE) {
                     aws s3 cp --acl public-read \
                         ${WORKSPACE}/aws-${AWS_REGION}.json \
                         s3://${S3_PUBLIC_BUCKET}/aws-${AWS_REGION}-tested.json
+
+                    # Copy the container image to alpha, then GC the image tagged with the ostree commit
+                    skopeo copy docker://${OSCONTAINER_IMG}:${ostree_commit} docker://${OSCONTAINER_IMG}:alpha
+                    skopeo delete docker://${OSCONTAINER_IMG}:${ostree_commit}
                 """
             }
         }

--- a/Jenkinsfile.aws-test
+++ b/Jenkinsfile.aws-test
@@ -26,7 +26,7 @@ node(NODE) {
 
     // We're only ever triggered by the cloud job, so we know the latest build is in latest/
     // We immediately resolve it back to the specific images/ dir
-    def ostree_commit, version
+    def latest_meta, ostree_commit, version
     try {
     utils.inside_assembler_container("") {
     stage("Sync In") {
@@ -35,16 +35,18 @@ node(NODE) {
             sshUserPrivateKey(credentialsId: params.ARTIFACT_SSH_CREDS_ID, keyFileVariable: 'KEY_FILE'),
         ]) {
             utils.rsync_file_in_dest(ARTIFACT_SERVER, KEY_FILE, "${images}/cloud/latest/meta.json", "${WORKSPACE}/meta.json")
-            ostree_commit = utils.sh_capture("jq -r '.[\"ostree-commit\"]' ${WORKSPACE}/meta.json")
-            version = utils.sh_capture("jq -r '.[\"ostree-version\"]' ${WORKSPACE}/meta.json")
+            latest_meta = readJSON file: "meta.json";
+            ostree_commit = latest_meta["ostree-commit"];
+            version = latest_meta["ostree-version"];
             // resolve to original dir to avoid races in the next rsync in
-            def imgv = utils.sh_capture("jq -r '.[\"image-version\"]' ${WORKSPACE}/meta.json")
+            def imgv = latest_meta["image-version"]
             utils.rsync_file_in_dest(ARTIFACT_SERVER, KEY_FILE, "${images}/cloud/${imgv}/aws-${AWS_REGION}.json", "${WORKSPACE}/aws-${AWS_REGION}.json")
         }
     }
 
     // Number of parallel kola tests
     def NUM_VMS = "10"
+    def aws_json
     try {
     stage("Run Kola tests on intermediate aws image") {
             withCredentials([
@@ -54,7 +56,8 @@ node(NODE) {
                 string(credentialsId: params.S3_PUBLIC_BUCKET, variable: 'S3_PUBLIC_BUCKET'),
                 usernameColonPassword(credentialsId: params.REGISTRY_CREDENTIALS, variable: 'CREDS'),
             ]) {
-                def ami_intermediate = utils.sh_capture("jq -r .HVM ${WORKSPACE}/aws-${AWS_REGION}.json")
+                aws_json = readJSON file: "aws-${AWS_REGION}.json";
+                def ami_intermediate = aws_json["HVM"];
 
                 // login to registry and setup container storage
                 def (registryUser, registryPass) = "${CREDS}".split(':')
@@ -95,6 +98,7 @@ node(NODE) {
         sh 'if test -e _kola_temp; then tar -cJf _kola_temp.tar.xz _kola_temp; fi'
         archiveArtifacts artifacts: "_kola_temp.tar.xz", allowEmptyArchive: true
         archiveArtifacts artifacts: "rhcos-aws.tap", allowEmptyArchive: true
+        archiveArtifacts artifacts: "*.json", allowEmptyArchive: true
     }
 
     stage("rsync out") {

--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -36,7 +36,15 @@ node(NODE) {
             withCredentials([
                 usernameColonPassword(credentialsId: params.REGISTRY_CREDENTIALS, variable: 'CREDS'),
             ]) {
-                sh """./scripts/pull-mount-oscontainer ${API_CI_REGISTRY} ${treecompose_workdir} ${OSCONTAINER_IMG}"""
+                def (registryUser, registryPass) = "${CREDS}".split(':')
+                utils.registry_login(registryUser, registryPass, "${API_CI_REGISTRY}")
+                sh """
+                    if ! skopeo inspect docker://${OSCONTAINER_IMG}:buildmaster; then
+                        ./scripts/pull-mount-oscontainer ${API_CI_REGISTRY} ${treecompose_workdir} ${OSCONTAINER_IMG}:latest
+                    else
+                        ./scripts/pull-mount-oscontainer ${API_CI_REGISTRY} ${treecompose_workdir} ${OSCONTAINER_IMG}:buildmaster
+                    fi
+                """
             }
         }
 

--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -2,13 +2,11 @@ def TIMER = "H/30 * * * *"
 def NODE = "rhcos-jenkins"
 def API_CI_REGISTRY = "registry.svc.ci.openshift.org"
 def OS_NAME = "maipo";
-def OSCONTAINER_IMG = API_CI_REGISTRY + "/rhcos/os-${OS_NAME}:latest"
+def OSCONTAINER_IMG = API_CI_REGISTRY + "/rhcos/os-${OS_NAME}"
 def COMPOSEFLAGS = "";
 
 // We write to this one for now
 def artifact_repo = "/srv/rhcos/output/repo"
-// We write pkg_diff.txt here
-def images = "/srv/rhcos/output/images"
 
 node(NODE) {
     def par_stages = [:]
@@ -90,8 +88,9 @@ node(NODE) {
         stage("Build new container") { sh """
             podman build --build-arg OS_VERSION=${composeMeta.version} \
                          --build-arg OS_COMMIT=${composeMeta.commit} \
-                         -t ${OSCONTAINER_IMG} \
+                         -t ${OSCONTAINER_IMG}:buildmaster \
                          -f ${WORKSPACE}/Dockerfile.rollup ${WORKSPACE}
+            podman tag ${OSCONTAINER_IMG}:buildmaster ${OSCONTAINER_IMG}:${composeMeta.commit}
         """ }
 
         if (params.DRY_RUN) {
@@ -102,8 +101,9 @@ node(NODE) {
         }
 
         stage("Push container") { sh """
-            podman push ${OSCONTAINER_IMG}
-            skopeo inspect docker://${OSCONTAINER_IMG} | jq '.Digest' > imgid.txt
+            podman push ${OSCONTAINER_IMG}:buildmaster
+            podman push ${OSCONTAINER_IMG}:${composeMeta.commit}
+            skopeo inspect docker://${OSCONTAINER_IMG}:buildmaster | jq '.Digest' > imgid.txt
         """
             def cid = readFile('imgid.txt').trim().replaceAll('"','');
             currentBuild.description = "🆕 ${OSCONTAINER_IMG}@${cid} (${composeMeta.version})";
@@ -119,7 +119,7 @@ node(NODE) {
                    --dest ${ARTIFACT_SERVER}:${artifact_repo} --src=${repo}/ \
                    --rsync-opt=--stats --rsync-opt=-e \
                    --rsync-opt='ssh -i ${KEY_FILE} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no'
-            """ 
+            """
         } }
 
         stage("Cleanup") { sh """


### PR DESCRIPTION
This pile of commits attempts to implement some of the versioning scheme for the `oscontainer` discussed in #201.

Firstly, during the `treecompose` pipeline, the `oscontainer` is no longer tagged with `latest`, but with `buildmaster`.  Additionally, it is tagged with the `ostree` commit that was used to generate the container image.

This `ostree` commit is passed to the `aws-test` pipeline after a successful `cloud` pipeline run.  In the `aws-test` pipeline, the `oscontainer` is pulled by the `ostree` commit and if the AWS tests are successful, the `oscontainer` is tagged with `alpha` and pushed to the registry.

This is probably not the best way to do this kind of image promotion and will likely be obsoleted by `coreos-assembler`, but I figured I would still put this out there to see how it was received.