### PR TITLE
jenkins: List OS version in AMI test job

### DIFF
--- a/Jenkinsfile.aws-test
+++ b/Jenkinsfile.aws-test
@@ -42,7 +42,7 @@ node(NODE) {
                 string(credentialsId: params.S3_PRIVATE_BUCKET, variable: 'S3_PRIVATE_BUCKET'),
                 string(credentialsId: params.AWS_CI_ACCOUNT, variable: 'AWS_CI_ACCOUNT'),
             ]) {
-                currentBuild.description = "ami: ${ami_intermediate}"
+                currentBuild.description = "version=${version} ami=${ami_intermediate}"
                 sh """
                     # Do testing with intermediate aws image passed in by cloud job
                     if ! kola -b rhcos -p aws --aws-type ${aws_type} --tapfile rhcos-aws.tap --aws-ami ${ami_intermediate} --aws-region ${AWS_REGION} -j ${NUM_VMS} run; then

--- a/Jenkinsfile.cloud
+++ b/Jenkinsfile.cloud
@@ -253,6 +253,7 @@ node(NODE) {
     def ami_intermediate = utils.sh_capture("jq -r .HVM ${dirpath}/aws-${AWS_REGION}-smoketested.json")
     build job: 'coreos-rhcos-aws-test', wait: false, parameters: [
         string(name: 'ami_intermediate', value: "${ami_intermediate}"),
+        string(name: 'version', value: "${version}"),
         string(name: 'dirpath', value: "${dirpath}"),
         string(name: 'aws_type', value: "t2.small")
     ]


### PR DESCRIPTION
Otherwise one has to back up to the cloud job to extract it when
browsing, or drop to the AWS API to list the tags.