### PR TITLE
manifest: Drop duplicates from host-base now that rpm-ostree updated

### DIFF
--- a/host-maipo.yaml
+++ b/host-maipo.yaml
@@ -1,10 +1,5 @@
 ref: "openshift/3.10/x86_64/os"
 include: host-base.yaml
-# https://github.com/projectatomic/rpm-ostree/issues/1524
-boot_location: new
-machineid-compat: false
-tmp-is-dir: true
-# end duplicates from host-base.yaml
 repos:
   # Base maipo repos
   - maipo-server

--- a/host-ootpa.yaml
+++ b/host-ootpa.yaml
@@ -1,10 +1,5 @@
 ref: "openshift/4/x86_64/os-ootpa"
 include: host-base.yaml
-# https://github.com/projectatomic/rpm-ostree/issues/1524
-boot_location: new
-machineid-compat: false
-tmp-is-dir: true
-# end duplicates from host-base.yaml
 repos:
   - rhcos-continuous
   - openshift


### PR DESCRIPTION
Since we've updated to `rpm-ostree-2018.8` in the `coreos-assembler:alpha`
container, we can drop duplicates from host-base.yaml.