### PR TITLE
host-base: Run xfs_growfs after growpart

### DIFF
--- a/host-base.yaml
+++ b/host-base.yaml
@@ -16,10 +16,12 @@ machineid-compat: false
 postprocess:
   - |
      #!/usr/bin/env bash
-     set -xe
+     set -xeo pipefail
+
      # See machineid-compat in host-base.yaml.
      # Since that makes presets run on boot, we need to have our defaults in /usr
      ln -sfr /usr/lib/systemd/system/{multi-user,default}.target
+
      # The canonical copy of this is in fedora-coreos-config.  If
      # making changes, please do them there first!
      cat > /usr/libexec/coreos-growpart << 'EOF'
@@ -38,6 +40,7 @@ postprocess:
      touch /var/lib/coreos-growpart.stamp
      EOF
      chmod a+x /usr/libexec/coreos-growpart
+
      cat > /usr/lib/systemd/system/coreos-growpart.service <<'EOF'
      [Unit]
      ConditionPathExists=!/var/lib/coreos-growpart.stamp
@@ -51,8 +54,10 @@ postprocess:
      cat >/usr/lib/systemd/system-preset/42-coreos-growpart.preset << EOF
      enable coreos-growpart.service
      EOF
+
      # Persistent journal by default, because Atomic doesn't have syslog
      echo 'Storage=persistent' >> /etc/systemd/journald.conf
+
      # See: https://bugzilla.redhat.com/show_bug.cgi?id=1051816
      # and: https://bugzilla.redhat.com/show_bug.cgi?id=1186757
      # Keep this in sync with the `install-langs` in the treefile JSON
@@ -70,21 +75,28 @@ postprocess:
             localedef --delete-from-archive "$locale"
         fi
      done
+
      set -x
+
      # Rebuild locales
      cp -f /usr/lib/locale/locale-archive /usr/lib/locale/locale-archive.tmpl
      build-locale-archive
+
      # https://github.com/openshift/os/issues/96
      # sudo group https://github.com/openshift/os/issues/96
      echo '%sudo        ALL=(ALL)       NOPASSWD: ALL' > /etc/sudoers.d/coreos-sudo-group
+
      # Nuke network.service from orbit
      # https://github.com/openshift/os/issues/117
      rm -rf /etc/rc.d/init.d/network /etc/rc.d/rc*.d/*network
+
      # And readahead https://bugzilla.redhat.com/show_bug.cgi?id=1594984
      # It's long dead upstream, we definitely don't want it.
      rm -f /usr/lib/systemd/systemd-readahead /usr/lib/systemd/system/systemd-readahead-*
+
      # We're not using resolved yet
      rm -f /usr/lib/systemd/system/systemd-resolved.service
+
      # Let's have a non-boring motd, just like CL (although theirs is more subdued
      # nowadays compared to early versions with ASCII art).  One thing we do here
      # is add --- as a "separator"; the idea is that any "dynamic" information should
@@ -93,10 +105,10 @@ postprocess:
      Red Hat CoreOS
       Information: https://url.corp.redhat.com/redhat-coreos
       Bugs: https://github.com/openshift/os
-     
+
      ---
      EOF
-   
+
 etc-group-members:
   - wheel
   - sudo

--- a/host-base.yaml
+++ b/host-base.yaml
@@ -37,6 +37,7 @@ postprocess:
      # TODO: make this idempotent, and don't error out if
      # we can't resize.
      growpart ${parent_device} ${partition} || true
+     xfs_growfs /sysroot # this is already idempotent
      touch /var/lib/coreos-growpart.stamp
      EOF
      chmod a+x /usr/libexec/coreos-growpart


### PR DESCRIPTION
Backport of coreos/fedora-coreos-config#19.

Closes: #319

(Untested, though I did test the upstream version, because it's insanely easy to test changes there.)