### PR TITLE
aws-test: Fix JSON filename passed to aws

### DIFF
--- a/Jenkinsfile.aws-test
+++ b/Jenkinsfile.aws-test
@@ -69,7 +69,7 @@ node(NODE) {
 
                     # Upload the json file to a public location
                     aws s3 cp --acl public-read \
-                        ${WORKSPACE}/aws-${AWS_REGION}-tested.json \
+                        ${WORKSPACE}/aws-${AWS_REGION}.json \
                         s3://${S3_PUBLIC_BUCKET}/aws-${AWS_REGION}-tested.json
                 """
             }


### PR DESCRIPTION
Minor regression from #312. We no longer copy this file in `/srv` now,
we upload it directly from our workspace.