### PR TITLE
Add toolbox package to rdgo

### DIFF
--- a/host-base.yaml
+++ b/host-base.yaml
@@ -145,6 +145,8 @@ packages:
  # Containers
  - podman skopeo runc containernetworking-plugins
  - cri-o cri-tools
+ # Toolbox
+ - toolbox
  # Networking
  - nfs-utils
  - NetworkManager dnsmasq

--- a/rdgo/overlay.yml
+++ b/rdgo/overlay.yml
@@ -28,3 +28,6 @@ components:
 
   - src: github:openshift/pivot
     spec: internal
+
+  - src: github:coreos/toolbox
+    spec: internal


### PR DESCRIPTION
Add toolbox script into host-base from github via rdgo,
to be used for admin/debug container running.

Signed-off-by: Yu Qi Zhang <jerzhang@redhat.com>