### PR TITLE
Fix podman login in various ways

### DIFF
--- a/Jenkinsfile.aws-test
+++ b/Jenkinsfile.aws-test
@@ -60,8 +60,7 @@ node(NODE) {
                 def ami_intermediate = aws_json["HVM"];
 
                 // login to registry and setup container storage
-                def (registryUser, registryPass) = "${CREDS}".split(':')
-                utils.registry_login(registryUser, registryPass, "${API_CI_REGISTRY}")
+                utils.registry_login("${OSCONTAINER_IMG}", "${CREDS}")
                 utils.prep_container_storage("${WORKSPACE}")
 
                 currentBuild.description = "version=${version} ami=${ami_intermediate}"

--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -36,8 +36,7 @@ node(NODE) {
             withCredentials([
                 usernameColonPassword(credentialsId: params.REGISTRY_CREDENTIALS, variable: 'CREDS'),
             ]) {
-                def (registryUser, registryPass) = "${CREDS}".split(':')
-                utils.registry_login(registryUser, registryPass, "${API_CI_REGISTRY}")
+                utils.registry_login("${OSCONTAINER_IMG}", "${CREDS}")
                 sh """
                     if ! skopeo inspect docker://${OSCONTAINER_IMG}:buildmaster; then
                         ./scripts/pull-mount-oscontainer ${API_CI_REGISTRY} ${treecompose_workdir} ${OSCONTAINER_IMG}:latest

--- a/pipeline-utils.groovy
+++ b/pipeline-utils.groovy
@@ -152,8 +152,10 @@ def sh_capture(cmd) {
     return sh(returnStdout: true, script: cmd).trim()
 }
 
-def registry_login(username, password, registry) {
-    sh "podman login -u '${username}' -p '${password}' ${registry}"
+def registry_login(oscontainer_name, creds) {
+    def registry = oscontainer_name.split('/')[0];
+    def (username, password) = creds.split(':');
+    sh "set +x; podman login -u '${username}' -p '${password}' ${registry}";
 }
 
 // re-implementation of some functionality from scripts/pull-mount-oscontainer

--- a/scripts/pull-mount-oscontainer
+++ b/scripts/pull-mount-oscontainer
@@ -1,17 +1,7 @@
 #!/usr/bin/bash
 set -xeuo pipefail
 
-# First, login.  We expect a CREDS environment variable.
-registry=$1; shift
-set +x
-username=${CREDS%:*}
-password=${CREDS##*:}
-echo podman login -u "${username}" -p '<password>' ${registry}
-podman login -u "${username}" -p "${password}" ${registry}
-# Re-enable verbose mode
-set -x
-
-# Now parse arguments and mount the image.
+# Parse arguments and mount the image.
 dest=$1; shift
 img=$1; shift
 rm ${dest} -rf


### PR DESCRIPTION
 - Use `set +x` again so we stop echoing to the log
 - Drop the pull-mount-oscontainer copy of this code
 - Change the API to accept CREDS directly and parse it inside
   the API to avoid duplicating that
 - Also change the API to accept a container name, and parse
   the registry bit out of that so we only need to juggle a
   container image name