### PR TITLE
.gitignore: Empty out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,0 @@
-src/
-snapshot/
-build*
-latest_openshift.repo


### PR DESCRIPTION
I found it very confusing when I added a `scripts/build-prepare`
and it wasn't showing up in `git status`.  Turned out to be the
`build*` rule in `.gitignore`.

A quick glance at `git log` shows those rules were intended to
ignore rpmdistro-gitoverlay artifacts.  But we don't really
encourage doing that in this directory at all, and the metadata
now lives in `rdgo` anyways.

Also hopefully soon the assembler will learn how to rdgo or
equivalent.