### PR TITLE
jenkins: Drop separate API_CI_REGISTRY constant

### DIFF
--- a/Jenkinsfile.aws-test
+++ b/Jenkinsfile.aws-test
@@ -1,8 +1,7 @@
 def NODE = "rhcos-jenkins"
 def AWS_REGION = "us-east-1"
-def API_CI_REGISTRY = "registry.svc.ci.openshift.org"
 def OS_NAME = "maipo";
-def OSCONTAINER_IMG = API_CI_REGISTRY + "/rhcos/os-${OS_NAME}"
+def OSCONTAINER_IMG = "registry.svc.ci.openshift.org/rhcos/os-${OS_NAME}";
 
 // location on the server we'll rsync to/from our $WORKSPACE
 def images = "/srv/rhcos/output/images"

--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -1,8 +1,7 @@
 def TIMER = "H/30 * * * *"
 def NODE = "rhcos-jenkins"
-def API_CI_REGISTRY = "registry.svc.ci.openshift.org"
 def OS_NAME = "maipo";
-def OSCONTAINER_IMG = API_CI_REGISTRY + "/rhcos/os-${OS_NAME}"
+def OSCONTAINER_IMG = "registry.svc.ci.openshift.org/rhcos/os-${OS_NAME}";
 def COMPOSEFLAGS = "";
 
 // We write to this one for now


### PR DESCRIPTION
Now that our login API parses the ref, there's no reason to have
it split out.

This clarifies that what we care about primarily is the oscontainer
reference, we're not currently interacting with that registry
in any other way.