### PR TITLE
treecompose: use 'skopeo copy' to push new tag to registry

### DIFF
--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -109,7 +109,7 @@ node(NODE) {
 
         stage("Push container") { sh """
             podman push ${OSCONTAINER_IMG}:buildmaster
-            podman push ${OSCONTAINER_IMG}:${composeMeta.commit}
+            skopeo copy docker://${OSCONTAINER_IMG}:buildmaster docker://${OSCONTAINER_IMG}:${composeMeta.commit}
             skopeo inspect docker://${OSCONTAINER_IMG}:buildmaster | jq '.Digest' > imgid.txt
         """
             def cid = readFile('imgid.txt').trim().replaceAll('"','');


### PR DESCRIPTION
The two `podman push` operations were taking a long time to complete
and could fail the whole pipeline if one failed.  Let's try using
`skopeo copy` to perform the additional tagging.