### PR TITLE
aws-test: don't use `skopeo delete` to untag images

### DIFF
--- a/Jenkinsfile.aws-test
+++ b/Jenkinsfile.aws-test
@@ -72,8 +72,6 @@ node(NODE) {
                 sh """
                     # Do testing with intermediate aws image passed in by cloud job
                     if ! kola -b rhcos -p aws --aws-type t2.small --tapfile rhcos-aws.tap --aws-ami ${ami_intermediate} --aws-region ${AWS_REGION} -j ${NUM_VMS} run; then
-                        # if the tests fail, GC the container image tagged with the ostree commit
-                        skopeo delete docker://${OSCONTAINER_IMG}:${ostree_commit}
                         exit 1
                     fi
 
@@ -102,9 +100,8 @@ node(NODE) {
                         ${WORKSPACE}/aws.json \
                         s3://${S3_PUBLIC_BUCKET}/aws-tested.json
 
-                    # Copy the container image to alpha, then GC the image tagged with the ostree commit
+                    # Copy the container image to alpha
                     skopeo copy docker://${OSCONTAINER_IMG}:${ostree_commit} docker://${OSCONTAINER_IMG}:alpha
-                    skopeo delete docker://${OSCONTAINER_IMG}:${ostree_commit}
                 """
             }
         }


### PR DESCRIPTION
From containers/skopeo#531:

>  `skopeo delete` is not an “untag” operation: it deletes the image,
and all tags referring to it within the repository. It is not possible
to delete a single tag pointing at an image without deleting the image
and all other tags pointing at it at the same time; the registry API
does not provide such an operation.

Since the `delete` operation is going to fail, just remove it for now
to unblock the job until we get a workaround.