### PR TITLE
jenkins: use `oc` for image tagging

### DIFF
--- a/Jenkinsfile.aws-test
+++ b/Jenkinsfile.aws-test
@@ -4,6 +4,8 @@ def AWS_REGION = "us-east-1"
 def API_CI_REGISTRY = "registry.svc.ci.openshift.org"
 def OS_NAME = "maipo";
 def OSCONTAINER_IMG = API_CI_REGISTRY + "/rhcos/os-${OS_NAME}"
+def OPENSHIFT_URL = "https://api.ci.openshift.org";
+
 // We copy tested AMIs to other regions; this
 // list is hardcoded right now pending discussion
 // with ops about which regions we should target
@@ -64,14 +66,17 @@ node(NODE) {
                 aws_json = readJSON file: "aws-${AWS_REGION}.json";
                 def ami_intermediate = aws_json["HVM"];
 
-                // login to registry and setup container storage
-                utils.registry_login("${OSCONTAINER_IMG}", "${CREDS}")
-                utils.prep_container_storage("${WORKSPACE}")
+                // login to OpenShift + registry and setup container storage
+                utils.openshift_login("${OPENSHIFT_URL}", "${CREDS}", "rhcos");
+                utils.registry_login("${OSCONTAINER_IMG}", "${CREDS}");
+                utils.prep_container_storage("${WORKSPACE}");
 
-                currentBuild.description = "version=${version} ami=${ami_intermediate}"
+                currentBuild.description = "version=${version} ami=${ami_intermediate}";
                 sh """
                     # Do testing with intermediate aws image passed in by cloud job
                     if ! kola -b rhcos -p aws --aws-type t2.small --tapfile rhcos-aws.tap --aws-ami ${ami_intermediate} --aws-region ${AWS_REGION} -j ${NUM_VMS} run; then
+                        # if the tests fail, GC the ostree commit tag
+                        oc tag -d os-${OS_NAME}:${ostree_commit}
                         exit 1
                     fi
 
@@ -100,8 +105,9 @@ node(NODE) {
                         ${WORKSPACE}/aws.json \
                         s3://${S3_PUBLIC_BUCKET}/aws-tested.json
 
-                    # Copy the container image to alpha
-                    skopeo copy docker://${OSCONTAINER_IMG}:${ostree_commit} docker://${OSCONTAINER_IMG}:alpha
+                    # Tag the image to alpha; GC the ostree commit tag
+                    oc tag os-${OS_NAME}:${ostree_commit} os-${OS_NAME}:alpha
+                    oc tag -d os-${OS_NAME}:${ostree_commit}
                 """
             }
         }

--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -3,6 +3,7 @@ def NODE = "rhcos-jenkins"
 def API_CI_REGISTRY = "registry.svc.ci.openshift.org"
 def OS_NAME = "maipo";
 def OSCONTAINER_IMG = API_CI_REGISTRY + "/rhcos/os-${OS_NAME}"
+def OPENSHIFT_URL = "https://api.ci.openshift.org";
 def COMPOSEFLAGS = "";
 
 // We write to this one for now
@@ -36,6 +37,7 @@ node(NODE) {
             withCredentials([
                 usernameColonPassword(credentialsId: params.REGISTRY_CREDENTIALS, variable: 'CREDS'),
             ]) {
+                utils.openshift_login("${OPENSHIFT_URL}", "${CREDS}", "rhcos")
                 utils.registry_login("${OSCONTAINER_IMG}", "${CREDS}")
                 sh """
                     if ! skopeo inspect docker://${OSCONTAINER_IMG}:buildmaster; then
@@ -109,10 +111,11 @@ node(NODE) {
 
         stage("Push container") { sh """
             podman push ${OSCONTAINER_IMG}:buildmaster
-            skopeo copy docker://${OSCONTAINER_IMG}:buildmaster docker://${OSCONTAINER_IMG}:${composeMeta.commit}
             skopeo inspect docker://${OSCONTAINER_IMG}:buildmaster | jq '.Digest' > imgid.txt
         """
             def cid = readFile('imgid.txt').trim().replaceAll('"','');
+            // tag the image by SHA256 using OpenShift means
+            sh """oc tag os-${OS_NAME}@${cid} os-${OS_NAME}:${composeMeta.commit}"""
             currentBuild.description = "🆕 ${OSCONTAINER_IMG}@${cid} (${composeMeta.version})";
         }
 

--- a/pipeline-utils.groovy
+++ b/pipeline-utils.groovy
@@ -155,7 +155,15 @@ def sh_capture(cmd) {
 def registry_login(oscontainer_name, creds) {
     def registry = oscontainer_name.split('/')[0];
     def (username, password) = creds.split(':');
+    sh "echo 'podman login -u '${username}' -p '<password>' ${registry}";
     sh "set +x; podman login -u '${username}' -p '${password}' ${registry}";
+}
+
+def openshift_login(url, creds, project) {
+    def (username, password) = creds.split(':');
+    sh "echo oc login --token '<token> ${url}";
+    sh "set +x; oc login --token '${password}' ${url}";
+    sh "oc project '${project}'";
 }
 
 // re-implementation of some functionality from scripts/pull-mount-oscontainer


### PR DESCRIPTION
To do tag manipulation on our `oscontainer` images, we need to use `oc` to operate on the ImageStream, rather than trying to use `podman` and `skopeo`.

The reasoning is that `podman` and `skopeo` can only operate according to the registry API which lacks a mechanism to "untag" an image.  (See https://github.com/containers/skopeo/issues/531#issuecomment-411227524)