### PR TITLE
ami-copy-regions: Also include origin region (us-east-1)

### DIFF
--- a/scripts/ami-copy-regions
+++ b/scripts/ami-copy-regions
@@ -113,7 +113,8 @@ for ami in amis:
         print("Failed to await: {}".format(ami))
 
 # Write our output JSON
-ami_json = []
+ami_json = [{'name': args.source_region,
+             'hvm': args.source_image_id}]
 for ami in amis:
     ami_json.append({'name': ami.region,
                      'hvm': ami.iid})


### PR DESCRIPTION
So that we can have this list be canonical and drop the other one.