### PR TITLE
jenkins: revert to `skopeo copy` for tagging

### DIFF
--- a/Jenkinsfile.aws-test
+++ b/Jenkinsfile.aws-test
@@ -75,8 +75,6 @@ node(NODE) {
                 sh """
                     # Do testing with intermediate aws image passed in by cloud job
                     if ! kola -b rhcos -p aws --aws-type t2.small --tapfile rhcos-aws.tap --aws-ami ${ami_intermediate} --aws-region ${AWS_REGION} -j ${NUM_VMS} run; then
-                        # if the tests fail, GC the ostree commit tag
-                        oc tag -d os-${OS_NAME}:${ostree_commit}
                         exit 1
                     fi
 
@@ -105,9 +103,8 @@ node(NODE) {
                         ${WORKSPACE}/aws.json \
                         s3://${S3_PUBLIC_BUCKET}/aws-tested.json
 
-                    # Tag the image to alpha; GC the ostree commit tag
-                    oc tag os-${OS_NAME}:${ostree_commit} os-${OS_NAME}:alpha
-                    oc tag -d os-${OS_NAME}:${ostree_commit}
+                    # fallback to skopeo copy to tag to alpha; see openshift/os#347
+                    skopeo copy docker://${OSCONTAINER_IMG}:${ostree_commit} docker://${OSCONTAINER_IMG}:alpha
                 """
             }
         }

--- a/Jenkinsfile.treecompose
+++ b/Jenkinsfile.treecompose
@@ -114,8 +114,9 @@ node(NODE) {
             skopeo inspect docker://${OSCONTAINER_IMG}:buildmaster | jq '.Digest' > imgid.txt
         """
             def cid = readFile('imgid.txt').trim().replaceAll('"','');
-            // tag the image by SHA256 using OpenShift means
-            sh """oc tag os-${OS_NAME}@${cid} os-${OS_NAME}:${composeMeta.commit}"""
+            // fallback to skopeo copy to tag images; see openshift/os#347
+            // we'll end up with some extra images, but should keep the train running
+            sh """skopeo copy docker://${OSCONTAINER_IMG}@${cid} docker://${OSCONTAINER_IMG}:${composeMeta.version}""";
             currentBuild.description = "🆕 ${OSCONTAINER_IMG}@${cid} (${composeMeta.version})";
         }
 


### PR DESCRIPTION
Until our account gets the right authz (#347), let's use `skopeo copy`
to do some primitive tagging.  We incur the cost of extra images on
the registry, but I don't believe it should be too great.