### PR TITLE
WIP: Readd ootpa pipeline using coreos-assembler

### DIFF
--- a/Dockerfile.assembler-override
+++ b/Dockerfile.assembler-override
@@ -1,0 +1,3 @@
+FROM quay.io/cgwalters/coreos-assembler:alpha
+# https://issues.jenkins-ci.org/browse/JENKINS-33149
+ENTRYPOINT []

--- a/Jenkinsfile.ootpa
+++ b/Jenkinsfile.ootpa
@@ -1,0 +1,101 @@
+def NODE = "rhcos-jenkins"
+def OS_NAME = "ootpa";
+def BUCKET = "rhcos-ci-${OS_NAME}";
+// Since we're using unreleased content
+def BUCKET_ACL = "private";
+def OSCONTAINER_IMG = "registry.svc.ci.openshift.org/rhcos/os-${OS_NAME}"
+
+node(NODE) {
+    def par_stages = [:]
+    stage("Clean workspace") {
+       step([$class: 'WsCleanup'])
+    }
+    checkout scm
+    utils = load("pipeline-utils.groovy")
+    utils.define_properties(null)
+
+    dir("openshift-os-ootpa") {
+        checkout([$class: 'GitSCM', branches: [[name: '*/master']],
+                  extensions: [[$class: 'SubmoduleOption', parentCredentials: true, recursiveSubmodules: true]],
+                  userRemoteConfigs: [[url: 'https://gitlab.cee.redhat.com/walters/openshift-os-ootpa.git']]
+                 ]);
+    }
+
+    dir("cgwalters-assembler") {
+        git(url: "https://github.com/cgwalters/coreos-assembler", branch: "walters-master")
+    }
+
+    try {
+    utils.inside_coreos_assembler("latest", "") {
+        withCredentials([
+            [$class: 'AmazonWebServicesCredentialsBinding', credentialsId: params.AWS_CREDENTIALS],
+             string(credentialsId: params.S3_PRIVATE_BUCKET, variable: 'S3_PRIVATE_BUCKET'),
+             string(credentialsId: params.AWS_CI_ACCOUNT, variable: 'AWS_CI_ACCOUNT'),
+            usernameColonPassword(credentialsId: params.REGISTRY_CREDENTIALS, variable: 'CREDS'),
+        ]) {
+
+        stage("Initialize") {
+            sh("cd cgwalters-assembler && git submodule update --init && make && make install")
+            echo("Init login")
+            utils.registry_login_builder("${OSCONTAINER_IMG}", "${CREDS}")
+            echo("Init build")
+            // Use local mirror for ISO
+            utils.sh_builder """
+            mkdir -p installer
+            (cd installer && curl -L -O http://download.devel.redhat.com/released/F-28/GOLD/Everything/x86_64/iso/Fedora-Everything-netinst-x86_64-28-1.1.iso)
+            (cd openshift-os-ootpa && make prep)
+            coreos-assembler init --force \$(pwd)/openshift-os-ootpa
+            """
+        }
+
+        def previousBuild = null;
+        if (!params.INIT) {
+            stage("Pull previous build") {
+                utils.sh_builder "./scripts/prepare-build --bucket=${BUCKET}"
+                previousBuild = [utils.sh_capture("readlink builds/latest"),
+                                 readJSON(file: "builds/latest/meta.json")];
+            }
+        }
+
+        if (!params.DRY_RUN) {
+            /// Verify our output is writable now
+            utils.sh_builder """aws s3api head-bucket --bucket=${BUCKET}"""
+        }
+
+        def changed;
+        stage("Build") {
+            def force = (params.FORCE ? "--force" : "");
+            utils.sh_builder "coreos-assembler build ${force}"
+            changed = fileExists("tmp/treecompose.stamp");
+        }
+
+        if (!changed) {
+            echo "No changes."
+            currentBuild.result = 'SUCCESS'
+            currentBuild.description = '(No changes)'
+            return
+        }
+
+        def build = [utils.sh_capture("readlink builds/latest"),
+                     readJSON(file: "builds/latest/meta.json")];
+
+        currentBuild.description = "🆕 ${build}";
+
+        if (params.DRY_RUN) {
+            echo "DRY_RUN set, skipping push"
+            currentBuild.result = 'SUCCESS'
+            currentBuild.description = '(dry run)'
+            return
+        }
+
+        stage("Upload build") {
+            utils.sh_builder """./scripts/upload-build --bucket=${BUCKET} --osc-name=${OSCONTAINER_IMG}"""
+        }
+    } }
+    } catch (Throwable e) {
+        currentBuild.result = 'FAILURE'
+        throw e
+    } finally {
+        utils.notify_status_change currentBuild
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ syntax-check:
 		python3 -c "import yaml; yaml.safe_load(open('$${yamlfile}'))"; \
 		echo "OK"; \
 	done
+	@set -e; for py in scripts/{prepare,upload}-build; do python3 -m py_compile $${py}; done
 
 .PHONY: repo-refresh
 repo-refresh:

--- a/scripts/prepare-build
+++ b/scripts/prepare-build
@@ -1,0 +1,62 @@
+#!/usr/bin/python3
+
+# coreos-assembler today maintains a builds/ directory
+# which we sync to/from s3, and the OSTree repo/ is an oscontainer.
+# This script pulls down the metadata from the previous build
+# and extracts the ostree repo from the oscontainer, setting
+# enough up for coreos-assembler to run.
+
+import os,sys,argparse,subprocess,io,time,re,multiprocessing
+import tempfile,json,yaml
+
+def fatal(msg):
+    print('error: {}'.format(msg), file=sys.stderr)
+    raise SystemExit(1)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--bucket", help="Bucket",
+                    action='store', required=True)
+
+args = parser.parse_args()
+
+# FIXME: Load (then later write) ref too since coreos-assembler requires it
+# right now
+with open('src/config/manifest.yaml') as f:
+    manifest = yaml.load(f)
+ref = manifest['ref']
+
+subprocess.check_call(['aws', 's3', 'cp',
+                       's3://{}/builds.json'.format(args.bucket),
+                       'builds/builds.json'])
+with open('builds/builds.json') as f:
+    builds = json.load(f)['builds']
+if len(builds) == 0:
+    fatal("No builds found")
+latest_build = builds[-1]
+print("Latest build: {} (of {})".format(latest_build, len(builds)))
+# Sanity checks to ensure it isn't a full filename
+assert not '..' in latest_build
+assert not '/' in latest_build
+latest_build_path = 'builds/' + latest_build
+os.mkdir(latest_build_path)
+# assembler uses this to find the previous build
+os.symlink(latest_build, 'builds/latest')
+
+subprocess.check_call(['aws', 's3', 'cp',
+                       's3://{}/{}/meta.json'.format(args.bucket, latest_build),
+                       './{}/meta.json'.format(latest_build_path)])
+with open(latest_build_path + '/meta.json') as f:
+    meta = json.load(f)
+
+oscontainer = meta['oscontainer']
+oscontainer_name_and_version = '{}:{}'.format(oscontainer['image'], latest_build)
+print(f"Downloading previous oscontainer: {oscontainer_name_and_version}")
+
+# TODO: Use labels for the build hash and avoid pulling the oscontainer
+# every time we want to poll.
+osc_workdir = "{}/tmp/oscontainer-work".format(os.getcwd())
+subprocess.check_call(['coreos-assembler', 'oscontainer',
+                       '--workdir='+osc_workdir, 'extract', '--ref='+ref,
+                       oscontainer_name_and_version, './repo'])
+subprocess.check_call(['ostree', '--repo=repo-build', 'pull-local', 'repo', ref])
+

--- a/scripts/upload-build
+++ b/scripts/upload-build
@@ -1,0 +1,75 @@
+#!/usr/bin/python3 -u
+
+# The inverse of prepare-build.
+
+import os,sys,argparse,subprocess,io,time,re,multiprocessing
+import tempfile,json
+
+def fatal(msg):
+    print('error: {}'.format(msg), file=sys.stderr)
+    raise SystemExit(1)
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--bucket", help="Bucket",
+                    action='store', required=True)
+parser.add_argument("--acl", help="ACL for objects",
+                    action='store', default='public-read')
+parser.add_argument("--osc-name", help="oscontainer name",
+                    action='store', required=True)
+
+args = parser.parse_args()
+
+with open('builds/builds.json') as f:
+    builds = json.load(f)['builds']
+if len(builds) == 0:
+    fatal("No builds found")
+latest_build = builds[-1]
+latest_build_path = 'builds/' + latest_build
+
+with open(latest_build_path + '/meta.json') as f:
+    meta = json.load(f)
+
+print("Preparing to upload build: {}".format(latest_build))
+print("  OSTree commit: {}".format(meta['ostree-commit']))
+
+osc_workdir = "{}/tmp/oscontainer-work".format(os.getcwd())
+
+# The build ID is the container tag
+osc_name_and_tag = "{}:{}".format(args.osc_name, latest_build)
+
+# TODO: Use labels for the build hash and avoid pulling the oscontainer
+# every time we want to poll.
+# TODO: Remove --from
+# TODO: Drop use of sudo, but today the Jenkinsfile setup does the
+# auth as root.
+inspect_out = os.getcwd()+'/oscontainer.json'
+subprocess.check_call(['coreos-assembler', 'oscontainer',
+                       '--workdir='+osc_workdir,
+                       'build', '--from=scratch',
+                       '--inspect-out='+inspect_out,
+                       '--push', './repo', meta['ostree-commit'],
+                       osc_name_and_tag])
+
+with open(inspect_out) as f:
+    osc_inspect = json.load(f)
+osc_digest = osc_inspect['Digest']
+
+# Inject the oscontainer with SHA256 into the build metadata
+meta['oscontainer'] = {'image': args.osc_name,
+                       'digest': osc_digest}
+with open(latest_build_path + '/meta.json', 'w') as f:
+    json.dump(meta, f, sort_keys=True)
+
+print("Uploading build")
+acl = '--acl={}'.format(args.acl)
+subprocess.check_call(['aws', 's3', 'sync', acl, '--no-follow-symlinks',
+                       './{}'.format(latest_build_path),
+                       's3://{}/{}'.format(args.bucket, latest_build)],
+                      stdout=subprocess.DEVNULL)
+
+print("Replacing build list")
+subprocess.check_call(['aws', 's3', 'cp', acl,
+                       'builds/builds.json',
+                       's3://{}/builds.json'.format(args.bucket)],
+                      stdout=subprocess.DEVNULL)
+


### PR DESCRIPTION
This took a lot of iteration.  The high level strategy is to
sync the previous build metadata from s3 (very cheap), which is
a major improvement over the previous image job.  We then sync out
the new build.

Per the coreos-assembler design, this job ties together the
treecompose + cloud images + oscontainer.  When we push an oscontainer,
it gets tagged with the build version - simple!

TODO:
 - GC for builds
 - Probably factor out a separate `build --dry-run` trigger job
 - Tweak the cloud image to be pre-pivoted
 - Add basic kola sanity test
 - Add an aws-tested equivalent job

And of course the big task is to switch maipo over to this too.
