### PR TITLE
host-base: Drop ref

### DIFF
--- a/host-base.yaml
+++ b/host-base.yaml
@@ -1,4 +1,3 @@
-ref: "openshift/3.10/x86_64/os-base"
 install-langs:
  - en_US
 documentation: false


### PR DESCRIPTION
It's not necessary for quite a while now, and inhibits a switch
to omitting `ref` entirely.  See also
https://github.com/projectatomic/rpm-ostree/pull/1603