### PR TITLE
OWNERS: sync with current team members

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,10 +1,10 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
-# Let's maintain this list *canonically* in the rhcos-apici repo.
 approvers:
   - ashcrow
-  - dm0-
-  - sdemos
   - cgwalters
-  - yuqi-zhang
+  - dustymabe
+  - jlebon
   - miabbott
+  - mike-nguyen
+  - zonggen


### PR DESCRIPTION
This is just the current folks on the CoreOS Team within Red Hat.

I'm not sure if this was ever canonical with the `rhcos-apici` repo...