### PR TITLE
Document and standardize on rpm-repo names used by api.ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,41 @@ is entangled with various private things and is omitted.
 
 Going forward, this repository will be canonical; more
 to come.
+
+# Building
+
+You need to create a `rhcos.repo` file that looks like this:
+
+```
+# RHEL repos
+[rhel8-baseos]
+baseurl=<url>
+
+[rhel8-appstream]
+baseurl=<url>
+
+[rhel8-nfv]
+baseurl=<url>
+
+[rhel8-fast-datapath]
+baseurl=<url>
+
+# These are the OpenShift RPMs, see https://mirror.openshift.com/pub/openshift-v4/dependencies/rpms/
+# except there's things like afterburn that are only internal right now unfortunately.
+[rhel-8-server-ose]
+baseurl=<url>
+```
+
+The names of the repos must match those in `manifest.yaml`.
+
+## Accessing repos in api.ci
+
+The "api.ci" (CI cluster used by OpenShift builds itself) has a service that pulls
+internal RHEL repos:
+See https://github.com/openshift/release/blob/master/core-services/release-controller/README.md#rpm-mirrors
+
+Use this:
+```
+$ cosa init https://github.com/openshift/os
+$ curl -L http://base-4-7-rhel8.ocp.svc.cluster.local > src/config/ocp.repo
+```

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -15,16 +15,13 @@ arch-include:
   ppc64le: fedora-coreos-config/manifests/grub2-removals.yaml
   aarch64: fedora-coreos-config/manifests/grub2-removals.yaml
 
+# See README.md
+# and https://github.com/openshift/release/blob/master/core-services/release-controller/README.md#rpm-mirrors
 repos:
-  # Base RHEL
-  - rhel8-baseos
-  - rhel8-appstream
-  - rhel8-fast-datapath
-  # ART RHAOS repos
-  - art-rhaos-4.4
-  - art-rhaos-4.5
-  - art-rhaos-4.6
-  - art-rhaos-4.7
+  - rhel-8-baseos
+  - rhel-8-appstream
+  - rhel-8-fast-datapath
+  - rhel-8-server-ose
 
 # We include hours/minutes to avoid version number reuse
 automatic-version-prefix: "47.82.<date:%Y%m%d%H%M>"

--- a/scripts/download-extensions
+++ b/scripts/download-extensions
@@ -19,7 +19,7 @@ mkdir dependencies
 
 yumdownload() {
     # FIXME eventually use rpm-ostree for this
-    yum --setopt=reposdir=${reposdir} --disablerepo='*' --arch=$(cosa basearch) --enablerepo=rhel8-baseos --enablerepo=rhel8-appstream --enablerepo=art-rhaos-4.6 --enablerepo=rhel8-nfv download "$@"
+    yum --setopt=reposdir=${reposdir} --disablerepo='*' --arch=$(cosa basearch) --enablerepo=rhel-8-baseos --enablerepo=rhel-8-appstream --enablerepo=rhel-8-server-ose --enablerepo=rhel-8-nfv download "$@"
 }
 
 if [ "$(arch)" = x86_64 ]; then


### PR DESCRIPTION
Better document the fact that we don't include any `.repo`
files that you need to build this.

Update the manifest to use the repo names used by api.ci;
this *will break* current downstream RHCOS until we adjust
it to match these repo names.

I'll look at a patch for that.