### PR TITLE
Add basic CI script

### DIFF
--- a/ci/build-test.sh
+++ b/ci/build-test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -xeuo pipefail
+# First ensure submodules are initialized
+git submodule update --init --recursive
+# Basic syntax check
+./fedora-coreos-config/ci/validate
+# To be expanded with a cosa build


### PR DESCRIPTION
This just reuses https://github.com/coreos/fedora-coreos-config/blob/testing-devel/ci/validate
to start until we solve access to the RHEL RPMs and nested virt CI.