### PR TITLE
manifest: add kexec-tools for kdump

### DIFF
--- a/overlay.d/05rhcos/usr/lib/systemd/system-preset/10-rhcos-disabled.preset
+++ b/overlay.d/05rhcos/usr/lib/systemd/system-preset/10-rhcos-disabled.preset
@@ -3,3 +3,7 @@
 # https://github.com/coreos/afterburn/issues/405
 # When we changed to inherit from FCOS we started enabling this service
 disable afterburn-sshkeys@.service
+
+# Explicitly disable: it's enabled by default otherwise but will fail because
+# we don't ship with the kargs needed for enablement.
+disable kdump.service

--- a/rhcos-packages.yaml
+++ b/rhcos-packages.yaml
@@ -18,3 +18,6 @@ packages:
   - rpm-ostree
   # part of container-tools module
   - toolbox
+  # for kdump:
+  # https://github.com/coreos/fedora-coreos-tracker/issues/622
+  - kexec-tools


### PR DESCRIPTION
This was discussed in:
https://github.com/coreos/fedora-coreos-tracker/issues/622