### PR TITLE
tests/kola: disable tpm test for aarch64

### DIFF
--- a/tests/kola/luks/tpm/kola.json
+++ b/tests/kola/luks/tpm/kola.json
@@ -1,4 +1,4 @@
 {
-    "architectures": "!s390x ppc64le",
+    "architectures": "!s390x ppc64le aarch64",
     "platforms": "qemu-unpriv"
 }


### PR DESCRIPTION
tpm is not yet supported for aarch64 in f32.