### PR TITLE
tests/kola/misc-ro: backport kdump.service test

### DIFF
--- a/tests/kola/luks/ignition/config.ign
+++ b/tests/kola/luks/ignition/config.ign
@@ -1,6 +1,6 @@
 {
     "ignition": {
-        "version": "3.2.0-experimental"
+        "version": "3.2.0"
     },
     "storage": {
         "luks": [

--- a/tests/kola/misc-ro/misc-ro.sh
+++ b/tests/kola/misc-ro/misc-ro.sh
@@ -50,6 +50,13 @@ if [ "$(systemctl is-enabled afterburn-sshkeys@.service)" = enabled ]; then
 fi
 echo "ok afterburn-sshkeys@ is disabled"
 
+# Make sure that kdump didn't start (it's either disabled, or enabled but
+# conditional on crashkernel= karg, which we don't bake).
+if ! systemctl show -p ActiveState kdump.service | grep -q ActiveState=inactive; then
+    fatal "Unit kdump.service shouldn't be active"
+fi
+echo "ok kdump.service not active"
+
 test -d /etc/yum.repos.d
 echo "ok have /etc/yum.repos.d"
 


### PR DESCRIPTION
From coreos/fedora-coreos-config#716.