### PR TITLE
Bump fedora-coreos-config

### DIFF
--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fde/coreos-luks-open.service
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fde/coreos-luks-open.service
@@ -13,6 +13,9 @@ After=coreos-encrypt.service
 # table, udev, etc..
 After=ignition-disks.service
 
+# Need to open device before we can restamp it
+Before=ignition-ostree-uuid-root.service
+
 # This is our luks root label
 Requires=dev-disk-by\x2dlabel-crypt_rootfs.device
 After=dev-disk-by\x2dlabel-crypt_rootfs.device

--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fde/module-setup.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fde/module-setup.sh
@@ -91,4 +91,15 @@ install() {
     # The generator enables the opening service.
     inst_simple "$moddir/coreos-luks-generator" \
         "$systemdutildir/system-generators/coreos-luks-generator"
+
+    # Gate all the rootfs replacement stuff for now behind a development flag
+    # since it conflicts with this module. Soon, we'll nuke this module entirely
+    # anyway in its place.
+    for x in ignition-ostree-rootfs-{detect,save,restore} coreos-inject-rootmap; do
+        mkdir -p $initdir/$systemdsystemunitdir/${x}.service.d/
+        cat > $initdir/$systemdsystemunitdir/${x}.service.d/neuter.conf <<EOF
+[Unit]
+ConditionKernelCommandLine=coreos.rootfs-replace.exp
+EOF
+    done
 }


### PR DESCRIPTION
Just on general principle, but specifically in prep for
adding bootupd to RHCOS.

```
Benjamin Gilbert (4):
      overrides: fast-track coreos-installer 0.6.0
      overrides: fast-track coreos-installer 0.7.0-2
      20live/coreos-livepxe-rootfs: drop support for legacy PXE images
      overrides: fast-track rust-afterburn-4.5.1-3.fc32

Clement Verna (2):
      [testing-devel] overrides: drop graduated overrides
      overrides: drop graduated overrides

Colin Walters (17):
      40ignition-ostree: Initial support for rootfs replacement
      40ignition-ostree: Regenerate UUIDs for /boot and /
      Revert "Add root reprovisioning tests"
      overlay: Install /usr/share/licenses/fedora-coreos-config/LICENSE
      live-generator: A few systemd ordering tweaks
      manifest: Add bootupd for x86_64|aarch64 (socket disabled)
      coreos-boot-mount-generator: Use Options=umask=077 for /boot/efi
      overlay/coreos-boot-mount-generator: Small code simplification
      tests/manual: Clarify expected state
      40ignition-ostree: Fix Before= for fsck for root
      growpart: Add btrfs support
      Move documentation removal to toplevel manifest
      manifests/bootloader: Drop armhfp
      Drop bits in overlay to chmod (use cosa fix), add test
      overlay: Enable bootupd.socket by default
      manifests/bootupd: `mkdir /run` for now
      lockfile: Bump bootupd

CoreOS Bot (68):
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest
      lockfiles: bump to latest

Dusty Mabe (30):
      overrides: drop graduated overrides
      overrides: fast-track podman-2.0.6-1.fc32
      overrides: fast-track ostree-2020.6-2.fc32
      tests/kola: add rootless-systemd podman test
      overrides: drop graduated overrides
      overrides: fast-track catatonit 0.1.5-3
      overrides: fast-track kernel-5.8.10-200.fc32
      tests/manual: nettest: stop using ign-converter for RHCOS
      tests/manual: nettest: use virsh shutdown instead of reboot
      tests/manual: nettest: workaround NM 1.26 bug
      tests/manual: nettest: add nameserver testing
      overlay: initramfs teardown: read hostname from file
      overrides: drop graduated overrides
      overrides: Fast-track zincati-0.0.13-1.fc32
      tests: misc-ro: make systemd-resolved service check conditional
      manifest.yaml: host systemd-networkd removal bits in manifest.yaml
      overrides: bump to coreos-installer-0.7.0-3.fc32
      tests: add chrony.dhcp-propagation to denylist for f33
      tests: add ext.config.root-reprovision to denylist for f33
      manifests: move the permissions on chrony files to fedora-coreos-base.yaml
      image.yaml: set osmet-pack-with-cosa-coreinst to true
      manifests: fedora-coreos-base: temporary support for RSA-SHA1 keys on f33
      tests: switch Fedora 32 containers to Fedora 33
      manifests: fedora-coreos: add archive repo to FCOS
      README: update notes for moving to new Fedora Major
      manifests: fedora-coreos-base: add zram-generator
      manifests: fedora-coreos-base: add back in podman-plugins, dnsmasq
      tests/kola/chrony: make dhcp-propagation test faster
      manifests: fedora-coreos-base: remove temporary support for RSA-SHA1 keys on F33
      overlay: 15fcos: add systemd unit to migrate to systemd-resolved

Joe Doss (1):
      manifest: Include systemd-resolved for F33 change

Jonathan Lebon (32):
      tests/kola: restrict DHCP propagation test to qemu
      40ignition-ostree: add coreos-inject-rootmap.service
      15coreos-network: add missing word in comment
      15coreos-network: drop dep on obsoleted service name
      40ignition-ostree: skip growpart if moving rootfs
      40ignition-ostree: put growpart stamp file in /run
      Add root reprovisioning tests
      40ignition-ostree: drop unnecessary inst_simple
      40ignition-ostree: split out `coreos-rootflags` script
      99emergency-timeout/virtio-dump: sync before dumping
      tests/kola: add test for separate /var mount
      ci: Also test live images
      20live: explicitly mount squashfs with `loop` option
      Revert "Revert "Add root reprovisioning tests""
      Add support for root-on-LUKS
      tests/kola: use wipeVolume for root-on-LUKS test
      tests/kola/misc-ro: check that rpmdb is using bdb
      tests/kola/root-reprovision/luks: limit to x86_64
      manifests/base: add ncurses
      ci: checkout repo to the config/ directory
      Revert "image.yaml: set osmet-pack-with-cosa-coreinst to true"
      ignition-ostree-rootfs: drop unnecessary EnvironmentFile=
      ignition-ostree-rootfs: avoid unnecessary `cd`
      ignition-ostree-rootfs: use our own tmpfs with size=80%
      lockfiles: drop graduated overrides
      lockfiles: fast-track ostree-2020.7-2.fc32
      Revert "kola-denylist: disable root-reprovision.luks while releasing"
      coreos-enable-network: reword Description field
      coreos-update-ca-trust: order before first-boot-complete.target
      manifest: add kexec-tools for kdump
      tests/kola/misc-ro: verify that kdump isn't active
      tests/kola/misc-ro: fix variable reference

Kelvin Fan (5):
      overrides: fast-track console-login-helper-messages-0.19-1.fc32
      overlay.d/05core: update CLHM presets
      overrides: fast-track console-login-helper-messages-0.19-2.fc32
      overlay.d/05core: Update CLHM presets
      overrides: fast-track console-login-helper-messages-0.20.1-1.fc32

Sohan Kunkerkar (9):
      overrides: drop graduated overrides
      overlay/15fcos: remove CLHM dependency
      overrides: fast-track systemd 245.8-2
      kola-denylist: remove chrony.dhcp-propagation reference
      overrides: fast-track afterburn
      overrides: drop Ignition pin
      overrides: fast-track coreos-installer 0.7.2
      40ignition-conf: add new base config
      15fcos: place afterburn-sshkeys.ign in 50ignition-conf-fcos

Stephen Lowrie (3):
      kola-denylist: disable root-reprovision.luks while releasing
      overrides: fast-track Ignition 2.7.0
      tests/kola: update root-reprovision luks test to use 3.2.0 spec

Timothée Ravier (1):
      overrides: drop graduated overrides

bh7cw (3):
      overrides: fast-track rust-afterburn-4.5.1-1.fc32
      overlay/15fcos: update `afterburn-sshkeys@core.service`
      `core` user: specifically enable `afterburn-sshkeys@core.service`

```