### PR TITLE
40rhcos-fde: gate rootfs reprovisioning behind coreos.rootfs-replace.exp

### DIFF
--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fde/coreos-luks-open.service
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fde/coreos-luks-open.service
@@ -13,6 +13,9 @@ After=coreos-encrypt.service
 # table, udev, etc..
 After=ignition-disks.service
 
+# Need to open device before we can restamp it
+Before=ignition-ostree-uuid-root.service
+
 # This is our luks root label
 Requires=dev-disk-by\x2dlabel-crypt_rootfs.device
 After=dev-disk-by\x2dlabel-crypt_rootfs.device

--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fde/module-setup.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fde/module-setup.sh
@@ -91,4 +91,15 @@ install() {
     # The generator enables the opening service.
     inst_simple "$moddir/coreos-luks-generator" \
         "$systemdutildir/system-generators/coreos-luks-generator"
+
+    # Gate all the rootfs replacement stuff for now behind a development flag
+    # since it conflicts with this module. Soon, we'll nuke this module entirely
+    # anyway in its place.
+    for x in ignition-ostree-rootfs-{detect,save,restore} coreos-inject-rootmap; do
+        mkdir -p $initdir/$systemdsystemunitdir/${x}.service.d/
+        cat > $initdir/$systemdsystemunitdir/${x}.service.d/neuter.conf <<EOF
+[Unit]
+ConditionKernelCommandLine=coreos.rootfs-replace.exp
+EOF
+    done
 }


### PR DESCRIPTION
Right now, with the latest FCOS, we get failures because e.g. the
rootmap code trips up on the dm-linear target trick we use.

This is a transitional state towards using the new rootfs reprovisioning
and LUKS-via-Ignition work. So for now so that we can keep bumping the
FCOS submodule, let's just gate all the reprovisioning services behind a
karg. That way, devs can still re-enable them if they'd like.