### PR TITLE
 manifest: Include bootupd

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -7,6 +7,7 @@ rojig:
 include:
   - fedora-coreos-config/manifests/ignition-and-ostree.yaml
   - fedora-coreos-config/manifests/file-transfer.yaml
+  - fedora-coreos-config/manifests/bootupd.yaml
   # RHCOS owned packages
   - rhcos-packages.yaml
 

--- a/tests/kola/misc-ro/misc-ro.sh
+++ b/tests/kola/misc-ro/misc-ro.sh
@@ -4,6 +4,10 @@ set -xeuo pipefail
 
 cd $(mktemp -d)
 
+ok() {
+    echo "ok" "$@"
+}
+
 fatal() {
   echo "$@"
   exit 1
@@ -100,3 +104,17 @@ elif [[ $nm_ts -gt $switchroot_ts ]] && on_platform aws; then
     fatal "NetworkManager not started in initramfs!"
 fi
 echo ok conditional initrd networking
+
+case "$(arch)" in
+    x86_64|aarch64)
+        if runuser -u core -- ls /boot/efi &>/dev/null; then
+            fatal "Was able to access /boot/efi as non-root"
+        fi
+        # This is just a basic sanity check; at some point we
+        # will implement "project-owned tests run in the pipeline"
+        # and be able to run the existing bootupd tests:
+        # https://github.com/coreos/fedora-coreos-config/pull/677
+        bootupctl status
+        ok bootupctl
+        ;;
+esac


### PR DESCRIPTION
Basically pulling in coreos/fedora-coreos-config#595
for RHCOS.  The immediate goal is allowing updating existing
systems in place for Boot Hole.