### PR TITLE
manifest.yaml: include bootupd only for x86 and aarch64

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -7,14 +7,17 @@ rojig:
 include:
   - fedora-coreos-config/manifests/ignition-and-ostree.yaml
   - fedora-coreos-config/manifests/file-transfer.yaml
-  - fedora-coreos-config/manifests/bootupd.yaml
   # RHCOS owned packages
   - rhcos-packages.yaml
 
 arch-include:
-  x86_64: fedora-coreos-config/manifests/grub2-removals.yaml
+  x86_64:
+    - fedora-coreos-config/manifests/grub2-removals.yaml
+    - fedora-coreos-config/manifests/bootupd.yaml
   ppc64le: fedora-coreos-config/manifests/grub2-removals.yaml
-  aarch64: fedora-coreos-config/manifests/grub2-removals.yaml
+  aarch64:
+    - fedora-coreos-config/manifests/grub2-removals.yaml
+    - fedora-coreos-config/manifests/bootupd.yaml
 
 # See README.md
 # and https://github.com/openshift/release/blob/master/core-services/release-controller/README.md#rpm-mirrors


### PR DESCRIPTION
bootupd doesn't apply to other arches causing build failures