### PR TITLE
manifest: make sure clevis is >= 15-1.el8

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -118,11 +118,6 @@ postprocess:
     semanage boolean --modify --on container_use_cephfs      # RHBZ#1694045
     semanage boolean --modify --on virt_use_samba            # RHBZ#1754825
 
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1762509
-  - |
-    #!/usr/bin/env bash
-    sed -i -e 's,echo "rd.neednet=1",true,' /usr/lib/dracut/modules.d/60clevis/module-setup.sh
-
   # https://gitlab.cee.redhat.com/coreos/redhat-coreos/merge_requests/812
   # https://bugzilla.redhat.com/show_bug.cgi?id=1796537
   - |

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -249,8 +249,11 @@ packages:
  - systemd-journal-gateway
  # RHEL7 compatibility
  - compat-openssl10
- # LUKS/Encryption support
- - clevis clevis-luks clevis-dracut cryptsetup-reencrypt tpm2-tools
+ # Make sure we pull in at least clevis 15; it drops the rd.neednet=1 hardcode
+ # and has a few other patches we need.
+ # https://bugzilla.redhat.com/show_bug.cgi?id=1853651
+ - "'clevis >= 15-1.el8' 'clevis-luks >= 15-1.el8' 'clevis-dracut >= 15-1.el8'"
+ - cryptsetup-reencrypt tpm2-tools
  # Used to update PAM configuration to work with SSSD
  # https://bugzilla.redhat.com/show_bug.cgi?id=1774154
  - authselect


### PR DESCRIPTION
For RHCOS 4.7, we need to make sure that we use a clevis newer than
what's in 8.3. We're currently cherry-picking from 8.4. Encode that
into the manifest to be more explicit and add a link to the RHBZ.