### PR TITLE
overlay.d: Add GODEBUG=x509ignoreCN=0 to systemd DefaultEnvironment

### DIFF
--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/10ignition-godebug/10-default-env-godebug.conf
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/10ignition-godebug/10-default-env-godebug.conf
@@ -1,0 +1,5 @@
+# https://bugzilla.redhat.com/show_bug.cgi?id=1886134
+# Because Ignition which runs in the initrd may interface with external endpoints,
+# we should set the environment variable in the initrd
+[Manager]
+DefaultEnvironment=GODEBUG=x509ignoreCN=0

--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/10ignition-godebug/module-setup.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/10ignition-godebug/module-setup.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+depends() {
+    echo systemd
+}
+
+install() {
+    inst_simple "$moddir/10-default-env-godebug.conf" \
+        "/etc/systemd/system.conf.d/10-default-env-godebug.conf"
+}


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1886134

Performing a OCP 4.6 Installation in a restricted network on zVM
fails:

```
Sep 23 23:02:41 bootstrap-0.ospamgr2-sep22.zvmocp.notld bootkube.sh[19435]: E0923 23:02:41.319432       1 reflector.go:251] github.com/openshift/cluster-bootstrap/pkg/start/status.go:66: Failed to watch *v1.Pod: Get "https://localhost:6443/api/v1/pods?watch=true": dial tcp [::1]:6443: connect: connection refused
Sep 23 23:02:42 bootstrap-0.ospamgr2-sep22.zvmocp.notld bootkube.sh[19435]: E0923 23:02:42.325119       1 reflector.go:134] github.com/openshift/cluster-bootstrap/pkg/start/status.go:66: Failed to list *v1.Pod: Get "https://localhost:6443/api/v1/pods": dial tcp [::1]:6443: connect: connection refused
Sep 23 23:02:43 bootstrap-0.ospamgr2-sep22.zvmocp.notld bootkube.sh[19435]: E0923 23:02:43.327963       1 reflector.go:134] github.com/openshift/cluster-bootstrap/pkg/start/status.go:66: Failed to list *v1.Pod: Get "https://localhost:6443/api/v1/pods": dial tcp [::1]:6443: connect: connection refused
Sep 23 23:02:44 bootstrap-0.ospamgr2-sep22.zvmocp.notld bootkube.sh[19435]: E0923 23:02:44.332599       1 reflector.go:134] github.com/openshift/cluster-bootstrap/pkg/start/status.go:66: Failed to list *v1.Pod: Get "https://localhost:6443/api/v1/pods": dial tcp [::1]:6443: connect: connection refused
```

Because Ignition which runs in the initrd may interface with external endpoints,
we should set the environment variable in the initrd.

inspired by - https://github.com/openshift/machine-config-operator/pull/2141/