### PR TITLE
manifest: add jlebon-dracut-tmp repo

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -26,6 +26,7 @@ repos:
   - rhel-8-appstream
   - rhel-8-fast-datapath
   - rhel-8-server-ose
+  - jlebon-dracut-tmp
 
 # We include hours/minutes to avoid version number reuse
 automatic-version-prefix: "47.83.<date:%Y%m%d%H%M>"

--- a/tests/kola/misc-ro/misc-ro.sh
+++ b/tests/kola/misc-ro/misc-ro.sh
@@ -118,3 +118,8 @@ case "$(arch)" in
         ok bootupctl
         ;;
 esac
+
+# This is a time bomb to make sure we delete temporary repos once the official
+# builds are in. See https://github.com/openshift/os/pull/444.
+rpm -q dracut-049-95.jl.git20200804.el8_3
+echo ok dracut temporary override


### PR DESCRIPTION
This is a temporary repo containing a dracut build with the patches we
need for working LUKS.

Will be dropped once we have official builds.