### PR TITLE
Revert "manifest: add jlebon-dracut-tmp repo"

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -26,7 +26,6 @@ repos:
   - rhel-8-appstream
   - rhel-8-fast-datapath
   - rhel-8-server-ose
-  - jlebon-dracut-tmp
 
 # We include hours/minutes to avoid version number reuse
 automatic-version-prefix: "47.83.<date:%Y%m%d%H%M>"

--- a/tests/kola/misc-ro/misc-ro.sh
+++ b/tests/kola/misc-ro/misc-ro.sh
@@ -118,8 +118,3 @@ case "$(arch)" in
         ok bootupctl
         ;;
 esac
-
-# This is a time bomb to make sure we delete temporary repos once the official
-# builds are in. See https://github.com/openshift/os/pull/444.
-rpm -q dracut-049-95.jl.git20200804.el8_3
-echo ok dracut temporary override


### PR DESCRIPTION
This reverts commit 5845493ff003dff9c2c0ce432fc75ec1a0e79f7f.

There were concerns about carrying this, even if it's temporary. Let's
revert.