### PR TITLE
kola-denylist: filter Tang only, and update tracker issue

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -17,9 +17,6 @@
    - s390x
 - pattern: coreos.ignition.journald-log
   tracker: https://github.com/coreos/coreos-assembler/issues/1173
-# Disable all LUKS related tests for RHEL 8.3 cryptsetup until they are updated
-# for the new Ignition based support
-- pattern: rhcos.luks.*
-  tracker: https://issues.redhat.com/browse/GRPA-2887
-- pattern: ext.config.luks.*
-  tracker: https://issues.redhat.com/browse/GRPA-2887
+# Disable Tang tests until we have the necessary dracut patches in RHCOS
+- pattern: luks.*
+  tracker: https://bugzilla.redhat.com/show_bug.cgi?id=1897384


### PR DESCRIPTION
The Tang-pinning LUKS tests were updated for the new path in
https://github.com/coreos/coreos-assembler/pull/1870
but they won't pass until we have the necessary dracut patches. Update
the tracker issue to the relevant RHBZ.

The TPM2-pinning LUKS tests should be fine now though, so stop filtering
that one.