### PR TITLE
manifest: Add qemu-guest-agent

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -254,6 +254,8 @@ packages:
  - authselect
  # Dracut module dependencies
  - bsdtar
+ # https://bugzilla.redhat.com/show_bug.cgi?id=1900759
+ - qemu-guest-agent
  # BELOW HERE ARE PACKAGES NOT IN RHEL
  # OpenShift OKD
  #- origin-node origin-hyperkube origin-clients

--- a/tests/kola/misc-ro/misc-ro.sh
+++ b/tests/kola/misc-ro/misc-ro.sh
@@ -105,6 +105,12 @@ elif [[ $nm_ts -gt $switchroot_ts ]] && on_platform aws; then
 fi
 echo ok conditional initrd networking
 
+# Verify this is shipped
+if ! test -f /usr/bin/qemu-ga; then
+  fatal "missing qemu guest agent"
+fi
+echo ok qemu guest agent
+
 case "$(arch)" in
     x86_64|aarch64)
         if runuser -u core -- ls /boot/efi &>/dev/null; then


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1900759

Basically MCO is buried in PRs, shipping it via a container
is would be another special case there.

Shipping it in RHCOS by default mirrors what we do for the
vmware agent today.  This is important for RHV and will help
with a lot of bugs they have around machineAPI provisioning.

I think OKD will also do the same (package layer it in
machine-os-content built time).
Not proposing we ship it in base FCOS at this time.

Longer term I think we should investigate switching both
this and vmware to be package layered "internally" so
we're not including it obviously on e.g. AWS/Azure instances.

But the potential for conflict is basically zero; the
way the agent works is via a udev rule that keys off
the presence of the virtio socket.