### PR TITLE
.gitmodules: add branch for fedora-coreos-config submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "fedora-coreos-config"]
 	path = fedora-coreos-config
 	url = https://github.com/coreos/fedora-coreos-config
+	branch = testing-devel


### PR DESCRIPTION
Modern git allows specifying a branch in `.gitmodules` so that bumping
it can be done with `git submodule update --remote fedora-coreos-config`
which is nicer than manually fetching and checking out in the submodule
directory.