### PR TITLE
overlay/05rhcos: fix iSCSI service preset name

### DIFF
--- a/overlay.d/05rhcos/usr/lib/systemd/system-preset/43-manifest-rhcos.preset
+++ b/overlay.d/05rhcos/usr/lib/systemd/system-preset/43-manifest-rhcos.preset
@@ -4,7 +4,7 @@
 # package.
 
 # Enable the iscsi workaround
-enable coreos-regenerate-iscsi-initiatorname.service
+enable coreos-generate-iscsi-initiatorname.service
 # Enable GCP routes
 enable gcp-routes.service
 # Enable auditd. See https://jira.coreos.com/browse/RHCOS-536

--- a/tests/kola/misc-ro/misc-ro.sh
+++ b/tests/kola/misc-ro/misc-ro.sh
@@ -118,3 +118,11 @@ case "$(arch)" in
         ok bootupctl
         ;;
 esac
+
+if ! systemctl show -p ActiveState coreos-generate-iscsi-initiatorname.service | grep -q ActiveState=active; then
+    fatal "coreos-generate-iscsi-initiatorname.service not active"
+fi
+if ! test -f /etc/iscsi/initiatorname.iscsi; then
+    fatal "Missing /etc/iscsi/initiatorname.iscsi"
+fi
+echo "ok iSCSI initiator name"


### PR DESCRIPTION
As noticed by Luca in rhbz#1901021, the systemd service was renamed in
d7507287 but the corresponding systemd preset wasn't adapted.

Fix this and also add a test to make sure that the service is active and
that the initiator name is set.

Resolves: rhbz#1901021