### PR TITLE
manifest: add ppc64le packages to detect dynamically attached devices

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -279,6 +279,9 @@ packages-x86_64:
 
 packages-ppc64le:
   - irqbalance
+  - librtas
+  - powerpc-utils-core
+  - ppc64-diag-rtas
 
 remove-from-packages:
   - - filesystem


### PR DESCRIPTION
same as https://github.com/coreos/fedora-coreos-config/pull/296