### PR TITLE
extensions.yaml: New declarative file for extensions

### DIFF
--- a/extensions.yaml
+++ b/extensions.yaml
@@ -1,0 +1,35 @@
+# RPMs as operating system extensions, distinct from the base ostree commit/image
+# https://github.com/openshift/enhancements/blob/master/enhancements/rhcos/extensions.md
+# and https://github.com/coreos/fedora-coreos-tracker/issues/401
+# We currently explicitly list dependencies for each extension; see
+# https://github.com/coreos/rpm-ostree/issues/2055
+
+extensions:
+  # https://github.com/coreos/fedora-coreos-tracker/issues/326
+  usbguard:
+    packages:
+      - usbguard
+      - libqb
+      - protobuf
+  # kernel-devel
+  # https://github.com/kmods-via-containers/kmods-via-containers/issues/3
+  # https://gitlab.cee.redhat.com/coreos/redhat-coreos/merge_requests/866
+  kernel-devel:
+    packages:
+      - kernel-devel
+      - kernel-core
+      - kernel-headers
+      - kernel-modules
+      - kernel-modules-extra
+  # GRPA-2822
+  # https://github.com/openshift/machine-config-operator/pull/1330
+  # https://github.com/openshift/enhancements/blob/master/enhancements/support-for-realtime-kernel.md
+  kernel-rt:
+    architectures:
+      - x86_64
+    packages:
+      - kernel-rt-core
+      - kernel-rt-kvm
+      - kernel-rt-modules
+      - kernel-rt-modules-extra
+      - kernel-rt-devel


### PR DESCRIPTION
I was trying to upload a custom oscontainer with a patched
rpm-ostree to help someone test it:
https://bugzilla.redhat.com/show_bug.cgi?id=1865839

And apparently made it incorrectly; doing the build involves
copy-pasting stuff from the internal Jenkins glue.

Let's accomplish two things:

- Make the list of extensions properly declarative, distinct
  from the code implementing it
- Move the logic for sticking it into the oscontainer as
  part of coreos-assembler (making this whole repo more declarative)
  And also therefore making oscontainer generation more ergonomic
  to run locally.