### PR TITLE
05rhcos/*: Fail boot if Ignition uses an older syntax for LUKS in 4.7

### DIFF
--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/41rhcos-check-luks-syntax/module-setup.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/41rhcos-check-luks-syntax/module-setup.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+install_unit() {
+    local unit="$1"; shift
+    local target="${1:-ignition-complete.target}"; shift
+    local instantiated="${1:-$unit}"; shift
+    inst_simple "$moddir/$unit" "$systemdsystemunitdir/$unit"
+    mkdir -p "$initdir/$systemdsystemunitdir/$target.requires"
+    ln_r "../$unit" "$systemdsystemunitdir/$target.requires/$instantiated"
+}
+
+install() {
+    inst_script "$moddir/rhcos-fail-boot-for-legacy-luks-config" \ 
+        "/usr/libexec/rhcos-fail-boot-for-legacy-luks-config"
+    
+    install_unit rhcos-fail-boot-for-legacy-luks-config.service
+}

--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/41rhcos-check-luks-syntax/rhcos-fail-boot-for-legacy-luks-config
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/41rhcos-check-luks-syntax/rhcos-fail-boot-for-legacy-luks-config
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+# This script tries to look for a `files` entry with the `/etc/clevis.json` 
+# path (used to enable LUKS in RHCOS 4.6 or earlier versions) in an 
+# Ignition config. If it exists, then the script ends with exit 1.
+
+ignition_cfg="/run/ignition.json"
+wanted_path="/etc/clevis.json"
+
+# select the `/etc/clevis.json` entry from a given Ignition config
+if jq -e ".storage.files[]? | select(.path==\"${wanted_path}\")" "${ign_config}" > /dev/null; then
+    echo "Your Ignition config specifies LUKS filesystem encryption using the obsolete
+${wanted_path} config file, which is no longer supported. Refusing to boot. 
+Please refer to https://github.com/openshift/openshift-docs/pull/27661 for more 
+information."
+    exit 1
+fi

--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/41rhcos-check-luks-syntax/rhcos-fail-boot-for-legacy-luks-config.service
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/41rhcos-check-luks-syntax/rhcos-fail-boot-for-legacy-luks-config.service
@@ -1,0 +1,16 @@
+# Fail the boot if the user tries to use the legacy 
+# LUKS configuration in an Ignition config to enable 
+# LUKS in RHCOS, so they don't accidentally end up 
+# with an unencrypted system.
+[Unit]
+Description=RHCOS Check For Legacy LUKS Configuration
+Documentation=https://github.com/openshift/openshift-docs/pull/27661
+After=ignition-fetch.service
+Before=ignition-disks.service
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/rhcos-fail-boot-for-legacy-luks-config
+RemainAfterExit=yes


### PR DESCRIPTION
This change ensures that the user provides the correct LUKS syntax in an Ignition config while trying to enable LUKS in 4.7.