### PR TITLE
kola-denylist: re-enable Tang tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -17,6 +17,3 @@
    - s390x
 - pattern: coreos.ignition.journald-log
   tracker: https://github.com/coreos/coreos-assembler/issues/1173
-# Disable Tang tests until we have the necessary dracut patches in RHCOS
-- pattern: luks.*
-  tracker: https://bugzilla.redhat.com/show_bug.cgi?id=1897384


### PR DESCRIPTION
Dracut patches needed for these landed in 4.7, so these tests pass now.