### PR TITLE
packages: Require rpm-ostree 2020.7

### DIFF
--- a/rhcos-packages.yaml
+++ b/rhcos-packages.yaml
@@ -15,7 +15,7 @@ packages:
   # needed by rpm-ostree for managing users
   - nss-altfiles
   - ostree
-  - rpm-ostree
+  - "'rpm-ostree >= 2020.7'"
   # part of container-tools module
   - toolbox
   # for kdump:


### PR DESCRIPTION
For https://bugzilla.redhat.com/show_bug.cgi?id=1865839