### PR TITLE
Revert to base 8.3 rpm-ostree

### DIFF
--- a/rhcos-packages.yaml
+++ b/rhcos-packages.yaml
@@ -15,7 +15,7 @@ packages:
   # needed by rpm-ostree for managing users
   - nss-altfiles
   - ostree
-  - "'rpm-ostree >= 2020.7'"
+  - rpm-ostree-2020.4-1.el8  # Pinned for a bit due to incorrect tagging in ART's 4.7 repo
   # part of container-tools module
   - toolbox
   # for kdump:


### PR DESCRIPTION
We need to tag more packages to make this work.