### PR TITLE
rhcos-check-luks: Fix trailing space and script variable

### DIFF
--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/41rhcos-check-luks-syntax/module-setup.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/41rhcos-check-luks-syntax/module-setup.sh
@@ -10,7 +10,7 @@ install_unit() {
 }
 
 install() {
-    inst_script "$moddir/rhcos-fail-boot-for-legacy-luks-config" \ 
+    inst_script "$moddir/rhcos-fail-boot-for-legacy-luks-config" \
         "/usr/libexec/rhcos-fail-boot-for-legacy-luks-config"
     
     install_unit rhcos-fail-boot-for-legacy-luks-config.service

--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/41rhcos-check-luks-syntax/rhcos-fail-boot-for-legacy-luks-config
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/41rhcos-check-luks-syntax/rhcos-fail-boot-for-legacy-luks-config
@@ -9,7 +9,7 @@ ignition_cfg="/run/ignition.json"
 wanted_path="/etc/clevis.json"
 
 # select the `/etc/clevis.json` entry from a given Ignition config
-if jq -e ".storage.files[]? | select(.path==\"${wanted_path}\")" "${ign_config}" > /dev/null; then
+if jq -e ".storage.files[]? | select(.path==\"${wanted_path}\")" "${ignition_cfg}" > /dev/null; then
     echo "Your Ignition config specifies LUKS filesystem encryption using the obsolete
 ${wanted_path} config file, which is no longer supported. Refusing to boot. 
 Please refer to https://github.com/openshift/openshift-docs/pull/27661 for more 


### PR DESCRIPTION
The trailing space causes boot failure in the initramfs because the script
is missing.  Also the variable name was incorrect.