### PR TITLE
rhcos-upgrade-root-filesystem-container: Run Before=kubelet.service

### DIFF
--- a/overlay.d/05rhcos/usr/lib/systemd/system/rhcos-upgrade-root-filesystem-container.service
+++ b/overlay.d/05rhcos/usr/lib/systemd/system/rhcos-upgrade-root-filesystem-container.service
@@ -3,6 +3,8 @@
 [Unit]
 Description=CoreOS Upgrade Root Filesystem Encryption Container
 ConditionKernelCommandLine=rhcos.root=crypt_rootfs
+# Ensure we run before the MCD
+Before=kubelet.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
I was looking at logs from an upgrade job for a different
bug and I noticed that this service ran about 20 seconds before
the MCD.  But since it's starting a rpm-ostree transaction it *could* have
conflicted.