### PR TITLE
kola-denylist: temporarily deny Tang tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -17,3 +17,6 @@
    - s390x
 - pattern: coreos.ignition.journald-log
   tracker: https://github.com/coreos/coreos-assembler/issues/1173
+# Disable Tang tests for now; we're investigating CI flakes
+- pattern: luks.*
+  tracker: https://bugzilla.redhat.com/show_bug.cgi?id=1906511


### PR DESCRIPTION
We're seeing flakes that happen only in CI. Let's investigate this, but
meanwhile unblock the pipeline.