### PR TITLE
Bump fedora-coreos-config submodule

### DIFF
--- a/tests/kola/networking/no-default-initramfs-net-propagation/test.sh
+++ b/tests/kola/networking/no-default-initramfs-net-propagation/test.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -xeuo pipefail
+
+# With pure network defaults no networking should have been propagated
+# from the initramfs. This test tries to verify that is the case.
+# https://github.com/coreos/fedora-coreos-tracker/issues/696
+
+ok() {
+    echo "ok" "$@"
+}
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+if ! journalctl -t coreos-teardown-initramfs | \
+       grep 'info: skipping propagation of default networking configs'; then
+    echo "no log message claiming to skip initramfs network propagation" >&2
+    fail=1
+fi
+
+if [ -n "$(ls -A /etc/NetworkManager/system-connections/)" ]; then
+    echo "configs exist in /etc/NetworkManager/system-connections/, but shouldn't" >&2
+    fail=1
+fi
+
+if [ -z "${fail:-}" ]; then
+    ok "success: no initramfs network propagation for default configuration"
+else
+    fatal "fail: no initramfs network propagation for default configuration"
+fi


### PR DESCRIPTION
This will bring in a change to help a UX problem mentioned in
https://bugzilla.redhat.com/show_bug.cgi?id=1901517 and also
update the rpm deps to account for zipl being provided by
different packages in Fedora and RHEL.

Shortlog with bot lockfile bumps omitted:

    Dusty Mabe <dusty@dustymabe.com> (1):
	  ff09e91 coreos-teardown-initramfs: don't propagate purely default network configs

    Jonathan Lebon <jonathan@jlebon.com> (1):
	  80356e0 manifests: use /usr/sbin/zipl instead of s390utils-core