### PR TITLE
kola-denylist: re-enable Tang tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -17,6 +17,3 @@
    - s390x
 - pattern: coreos.ignition.journald-log
   tracker: https://github.com/coreos/coreos-assembler/issues/1173
-# Disable Tang tests for now; we're investigating CI flakes
-- pattern: luks.*
-  tracker: https://bugzilla.redhat.com/show_bug.cgi?id=1906511


### PR DESCRIPTION
This should be resolved now with
https://gitlab.cee.redhat.com/openshift-art/rhcos-upshift/-/merge_requests/213