### PR TITLE
overlay.d: Add 20rhcos-kdump

### DIFF
--- a/overlay.d/20rhcos-kdump/usr/lib/dracut/modules.d/50rhcos-kdump/module-setup.sh
+++ b/overlay.d/20rhcos-kdump/usr/lib/dracut/modules.d/50rhcos-kdump/module-setup.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# The latest Dracut release that landed in RHEL 8.3 stopped creating
+# `$systemdsystemunitdir/initrd.target.wants` dir, causing
+# `kdump-capture.service` to not be installed correctly and thus making
+# kdump unable to capture the vmcore during a kernel panic.
+# There is a patch in kexec-tools to address this issue
+# https://bugzilla.redhat.com/show_bug.cgi?id=1907253.
+# For now, we will create this directory ourselves, but we should drop
+# this once the proper kexec-tools patches land.
+
+check() {
+    return 0
+}
+
+depends() {
+    return 0
+}
+
+install() {
+    mkdir -p "$initdir/$systemdsystemunitdir/initrd.target.wants"
+}

--- a/tests/kola/misc-ro/misc-ro.sh
+++ b/tests/kola/misc-ro/misc-ro.sh
@@ -132,3 +132,10 @@ if ! test -f /etc/iscsi/initiatorname.iscsi; then
     fatal "Missing /etc/iscsi/initiatorname.iscsi"
 fi
 echo "ok iSCSI initiator name"
+
+# Check whether the fixed version of kexec-tools has landed.
+# xref: https://bugzilla.redhat.com/show_bug.cgi?id=1907253
+if grep "add-wants" /usr/lib/dracut/modules.d/99kdumpbase/module-setup.sh; then
+  echo "kexec-tools has been updated; remove workaround from https://github.com/openshift/os/pull/469"
+  sleep 2
+fi


### PR DESCRIPTION
The latest Dracut release that landed in RHEL 8.3 stopped creating
`$systemdsystemunitdir/initrd.target.wants` dir, causing
`kdump-capture.service` to not be installed correctly and thus making
kdump unable to capture the vmcore during a kernel panic.
There is a patch in kexec-tools to address this issue
https://bugzilla.redhat.com/show_bug.cgi?id=1907253.
For now, we will create this directory ourselves, but we should drop
this once the proper kexec-tools patches land.