### PR TITLE
overlay.d: Add 21dhcp-chrony to set default DHCP NTP settings 

### DIFF
--- a/overlay.d/21dhcp-chrony
+++ b/overlay.d/21dhcp-chrony
@@ -1,1 +1,0 @@
-../fedora-coreos-config/overlay.d/21dhcp-chrony

--- a/overlay.d/21dhcp-chrony/etc/NetworkManager/dispatcher.d/20-coreos-chrony-dhcp
+++ b/overlay.d/21dhcp-chrony/etc/NetworkManager/dispatcher.d/20-coreos-chrony-dhcp
@@ -1,0 +1,69 @@
+#!/bin/sh
+# This is a NetworkManager dispatcher script for chronyd to update
+# its NTP sources passed from DHCP options. Note that this script is
+# specific to NetworkManager-dispatcher due to use of the
+# DHCP4_NTP_SERVERS environment variable. For networkd-dispatcher,
+# an alternative approach is external means such as a dhclient hook.
+#
+# Carried in Fedora CoreOS and RHEL CoreOS temporarily.
+# See: https://bugzilla.redhat.com/show_bug.cgi?id=1800901
+
+export LC_ALL=C
+
+# Exit if support for dhcp4-change landed in the chrony package.
+# See upstream thread: https://listengine.tuxfamily.org/chrony.tuxfamily.org/chrony-dev/2020/05/msg00022.html
+[ -f /usr/lib/NetworkManager/dispatcher.d/20-chrony-dhcp ] && \
+    grep -q "dhcp4-change" /usr/lib/NetworkManager/dispatcher.d/20-chrony-dhcp && \
+    exit 0
+[ -f /etc/NetworkManager/dispatcher.d/20-chrony-dhcp ] && \
+    grep -q "dhcp4-change" /etc/NetworkManager/dispatcher.d/20-chrony-dhcp && \
+    exit 0
+
+# If a dhclient installation is present, avoid a redundant operation
+# with dhclient which handles NTP server config through its own
+# NetworkManager dispatcher script 11-dhclient.
+[ -e /usr/sbin/dhclient ] && exit 0
+
+interface=$1
+action=$2
+
+chrony_helper=/usr/libexec/coreos-chrony-helper
+default_server_options=iburst
+server_dir=/var/run/coreos-chrony-dhcp
+
+dhcp_server_file=$server_dir/chrony.servers.$interface
+# DHCP4_NTP_SERVERS is passed from DHCP options by NetworkManager.
+nm_dhcp_servers=$DHCP4_NTP_SERVERS
+
+[ -f /etc/sysconfig/network ] && . /etc/sysconfig/network
+[ -f /etc/sysconfig/network-scripts/ifcfg-"${interface}" ] && \
+    . /etc/sysconfig/network-scripts/ifcfg-"${interface}"
+
+add_servers_from_dhcp() {
+    rm -f "$dhcp_server_file"
+
+    # Don't add NTP servers if PEERNTP=no specified; return early.
+    [ "$PEERNTP" = "no" ] && return
+
+    for server in $nm_dhcp_servers; do
+        echo "$server ${NTPSERVERARGS:-$default_server_options}" >> "$dhcp_server_file"
+    done
+    $chrony_helper update-daemon || :
+}
+
+clear_servers_from_dhcp() {
+    if [ -f "$dhcp_server_file" ]; then
+        rm -f "$dhcp_server_file"
+        $chrony_helper update-daemon || :
+    fi
+}
+
+mkdir -p $server_dir
+
+if [ "$action" = "up" ] || [ "$action" = "dhcp4-change" ]; then
+    add_servers_from_dhcp
+elif [ "$action" = "down" ]; then
+    clear_servers_from_dhcp
+fi
+
+exit 0

--- a/overlay.d/21dhcp-chrony/usr/libexec/coreos-chrony-helper
+++ b/overlay.d/21dhcp-chrony/usr/libexec/coreos-chrony-helper
@@ -1,0 +1,102 @@
+#!/bin/bash
+#
+# This is a copy of /usr/libexec/chrony-helper carried in FCOS/RHCOS
+# temporarily while upstream changes and the package update to
+# chrony-helper percolate (see
+# https://src.fedoraproject.org/rpms/chrony/pull-request/3). It should
+# not by used by any script other than the 20-coreos-chrony-dhcp NM
+# dispatcher script.
+#
+# This script configures running chronyd to use NTP servers obtained from
+# DHCP and _ntp._udp DNS SRV records. Files with servers from DHCP are managed
+# externally (e.g. by a dhclient script). Files with servers from DNS SRV
+# records are updated here using the dig utility. The script can also list
+# and set static sources in the chronyd configuration file.
+
+chronyc=/usr/bin/chronyc
+helper_dir=/var/run/coreos-chrony-helper
+server_dir=/var/run/coreos-chrony-dhcp
+
+network_sysconfig_file=/etc/sysconfig/network
+dhcp_servers_files="${server_dir}/chrony.servers.*"
+added_servers_file=$helper_dir/added_servers
+
+. $network_sysconfig_file &> /dev/null
+
+chrony_command() {
+    $chronyc -a -n -m "$1"
+}
+
+is_running() {
+    chrony_command "tracking" &> /dev/null
+}
+
+get_servers_files() {
+    [ "$PEERNTP" != "no" ] && echo "$dhcp_servers_files"
+}
+
+is_update_needed() {
+    for file in $(get_servers_files) $added_servers_file; do
+        [ -e "$file" ] && return 0
+    done
+    return 1
+}
+
+update_daemon() {
+    local all_servers_with_args all_servers added_servers
+
+    if ! is_running; then
+        rm -f $added_servers_file
+        return 0
+    fi
+
+    all_servers_with_args=$(cat $(get_servers_files) 2> /dev/null)
+
+    all_servers=$(
+        echo "$all_servers_with_args" |
+            while read -r server serverargs; do
+                echo "$server"
+            done | sort -u)
+    added_servers=$( (
+        cat $added_servers_file 2> /dev/null
+        echo "$all_servers_with_args" |
+            while read -r server serverargs; do
+                [ -z "$server" ] && continue
+                chrony_command "add server $server $serverargs" &> /dev/null &&
+                    echo "$server"
+            done) | sort -u)
+
+    comm -23 <(echo -n "$added_servers") <(echo -n "$all_servers") |
+        while read -r server; do
+            chrony_command "delete $server" &> /dev/null
+        done
+
+    added_servers=$(comm -12 <(echo -n "$added_servers") <(echo -n "$all_servers"))
+
+    if [ -n "$added_servers" ]; then
+        echo "$added_servers" > $added_servers_file
+    else
+        rm -f $added_servers_file
+    fi
+}
+
+prepare_helper_dir() {
+    mkdir -p $helper_dir
+    exec 100> $helper_dir/lock
+    if ! flock -w 20 100; then
+        echo "Failed to lock $helper_dir" >&2
+        return 1
+    fi
+}
+
+case "$1" in
+    update-daemon)
+        is_update_needed || exit 0
+        prepare_helper_dir && update_daemon
+        ;;
+    *)
+        echo "unhandled command in coreos-chrony-helper"
+        exit 2
+esac
+
+exit $?

--- a/overlay.d/README.md
+++ b/overlay.d/README.md
@@ -21,3 +21,14 @@ General RHCOS specific overlay.
 ------------------
 
 Real Time kernel support extracted from `tuned`.
+
+21dhcp-chrony
+-------------
+
+Handle DHCP-provided NTP servers and configure chrony to use them,
+without overwriting platform-specific configuration. Can be removed
+once changes in upstream chrony with support for per-platform
+defaults (https://bugzilla.redhat.com/show_bug.cgi?id=1828434),
+and handling in 20-chrony and chrony-helper using the defaults
+lands in downstream packages. See upstream thread:
+https://listengine.tuxfamily.org/chrony.tuxfamily.org/chrony-dev/2020/05/msg00022.html

--- a/tests/kola/chrony/dhcp-propagation
+++ b/tests/kola/chrony/dhcp-propagation
@@ -8,7 +8,9 @@
 
 set -xeuo pipefail
 
-# kola: { "tags": "needs-internet" }
+# Just run on QEMU; it should work theoretically on cloud platforms, but many
+# of those have platform-specific sources which take precedence.
+# kola: { "tags": "needs-internet", "platforms": "qemu-unpriv" }
 
 test_setup() {
 
@@ -26,15 +28,11 @@ test_setup() {
     ip netns exec container ip address add 172.16.0.1/24 dev veth-container
     ip netns exec container ip link set veth-container up
 
-    # create a static ethernet connection for the `veth-host`
-    nmcli dev set veth-host managed yes
-    ip link set veth-host up
-
     # run podman commands to set up dnsmasq server
     pushd $(mktemp -d)
     NTPHOSTIP=$(getent hosts time-c-g.nist.gov | cut -d ' ' -f 1)
     cat <<EOF >Dockerfile
-FROM registry.fedoraproject.org/fedora:32
+FROM registry.fedoraproject.org/fedora:33
 RUN dnf -y install systemd dnsmasq iproute iputils \
 && dnf clean all \
 && systemctl enable dnsmasq
@@ -45,6 +43,10 @@ EOF
     popd
     podman run -d --rm --name dnsmasq --privileged --network ns:/var/run/netns/container dnsmasq
 
+    # Tell NM to manage the `veth-host` interface and bring it up (will attempt DHCP).
+    # Do this after we start dnsmasq so we don't have to deal with DHCP timeouts.
+    nmcli dev set veth-host managed yes
+    ip link set veth-host up
 }
 
 main() {


### PR DESCRIPTION
Preparation for https://github.com/coreos/fedora-coreos-config/pull/703
So the upstream patch for chrony change (https://src.fedoraproject.org/rpms/chrony/pull-request/3) is still not available in RHCOS, so we'd need to fork-lift [this change](https://github.com/coreos/fedora-coreos-config/pull/412) here to enable chrony-dhcp settings for propagating NTP servers information.