### PR TITLE
overlay.d: Use `systemctl {add-wants, add-requires}`

### DIFF
--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/30rhcos-afterburn-checkin/module-setup.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/30rhcos-afterburn-checkin/module-setup.sh
@@ -18,7 +18,6 @@ check() {
 
 install() {
     local unit=rhcos-afterburn-checkin.service
-    mkdir -p "$initdir/$systemdsystemunitdir/ignition-files.service.requires"
     inst_simple "$moddir/$unit" "$systemdsystemunitdir/$unit"
-    ln_r "../$unit" "$systemdsystemunitdir/ignition-files.service.requires/$unit"
+    systemctl -q --root="$initdir" add-requires ignition-files.service "$unit"
 }

--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fde/module-setup.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fde/module-setup.sh
@@ -8,9 +8,7 @@ install_unit() {
     local unit=$1; shift
     local target=${1:-ignition-complete.target}
     inst_simple "$moddir/$unit" "$systemdsystemunitdir/$unit"
-    local targetpath="$systemdsystemunitdir/${target}.requires/"
-    mkdir -p "${initdir}/${targetpath}"
-    ln_r "../$unit" "${targetpath}/${unit}"
+    systemctl -q --root="$initdir" add-requires "$target" "$unit"
 }
 
 depends() {

--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/module-setup.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/module-setup.sh
@@ -32,10 +32,7 @@ install() {
     echo "# RHCOS FIPS mode installation complete" > "$initdir/etc/system-fips"
 
     # We don't support FIPS in diskless cases currently
-    target=ignition-diskful
-    mkdir -p "$initdir/$systemdsystemunitdir/${target}.target.requires"
-    ln_r "$moddir/rhcos-fips.service" \
-        "$systemdsystemunitdir/${target}.target.requires/rhcos-fips.service"
-    ln_r "$moddir/rhcos-fips-finish.service" \
-        "$systemdsystemunitdir/${target}.target.requires/rhcos-fips-finish.service"
+    target=ignition-diskful.target
+    systemctl -q --root="$initdir" add-requires "$target" rhcos-fips.service
+    systemctl -q --root="$initdir" add-requires "$target" rhcos-fips-finish.service
 }

--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/41rhcos-check-luks-syntax/module-setup.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/41rhcos-check-luks-syntax/module-setup.sh
@@ -5,8 +5,7 @@ install_unit() {
     local target="${1:-ignition-complete.target}"; shift
     local instantiated="${1:-$unit}"; shift
     inst_simple "$moddir/$unit" "$systemdsystemunitdir/$unit"
-    mkdir -p "$initdir/$systemdsystemunitdir/$target.requires"
-    ln_r "../$unit" "$systemdsystemunitdir/$target.requires/$instantiated"
+    systemctl -q --root="$initdir" add-requires "$target" "$instantiated"
 }
 
 install() {


### PR DESCRIPTION
Use `systemctl`'s built-in way of adding `Wants=` and `Requires=`
dependencies, since this is the recommended way of adding dependencies
and we can do so with a single command.