### PR TITLE
coreos-generate-iscsi-initiatorname.service: drop ConditionFirstBoot=true

### DIFF
--- a/overlay.d/05rhcos/usr/lib/systemd/system/coreos-generate-iscsi-initiatorname.service
+++ b/overlay.d/05rhcos/usr/lib/systemd/system/coreos-generate-iscsi-initiatorname.service
@@ -5,7 +5,6 @@
 Description=CoreOS Generate iSCSI Initiator Name
 Documentation=https://bugzilla.redhat.com/show_bug.cgi?id=1493296
 Documentation=https://bugzilla.redhat.com/show_bug.cgi?id=1687722
-ConditionFirstBoot=true
 # But only if not already written by Ignition
 # https://bugzilla.redhat.com/show_bug.cgi?id=1868174
 ConditionPathExists=!/etc/iscsi/initiatorname.iscsi


### PR DESCRIPTION
So that even nodes upgrading that hit the previous bug where we wouldn't
generate the iSCSI initiator name get it fixed.

It also matches what the upstream one which will obsolete this does:

https://github.com/open-iscsi/open-iscsi/blob/b680f6e81f2f05f7e721f0aa97ce8aa885b3f0ba/etc/systemd/iscsi-init.service

See: https://bugzilla.redhat.com/show_bug.cgi?id=1901021#c20