### PR TITLE
Revert "Revert to base 8.3 rpm-ostree"

### DIFF
--- a/rhcos-packages.yaml
+++ b/rhcos-packages.yaml
@@ -15,7 +15,7 @@ packages:
   # needed by rpm-ostree for managing users
   - nss-altfiles
   - ostree
-  - rpm-ostree-2020.4-1.el8  # Pinned for a bit due to incorrect tagging in ART's 4.7 repo
+  - rpm-ostree
   # part of container-tools module
   - toolbox
   # for kdump:


### PR DESCRIPTION
We now have `rpm-ostree-2020.7-1.el8_3` available in the 4.7 plashet,
so we can stop using the older version.

Slightly modified the revert to drop any version comparison.

This reverts commit 7d997ddf614ddb06982598ea8e9868757117764c.