### PR TITLE
rhcos-packages: unpin rpm-ostree

### DIFF
--- a/rhcos-packages.yaml
+++ b/rhcos-packages.yaml
@@ -15,7 +15,7 @@ packages:
   # needed by rpm-ostree for managing users
   - nss-altfiles
   - ostree
-  - rpm-ostree-2020.4-1.el8  # Pinned for a bit due to incorrect tagging in ART's 4.7 repo
+  - rpm-ostree
   # part of container-tools module
   - toolbox
   # for kdump:


### PR DESCRIPTION
The latest build in there is now compatible with 8.3. The offending
build was untagged.