### PR TITLE
Bump fedora-coreos-config for various fixes

### DIFF
--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/30rhcos-afterburn-checkin/module-setup.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/30rhcos-afterburn-checkin/module-setup.sh
@@ -19,5 +19,7 @@ check() {
 install() {
     local unit=rhcos-afterburn-checkin.service
     inst_simple "$moddir/$unit" "$systemdsystemunitdir/$unit"
-    systemctl -q --root="$initdir" add-requires ignition-files.service "$unit"
+    # note we `|| exit 1` here so we error out if e.g. the units are missing
+    # see https://github.com/coreos/fedora-coreos-config/issues/799
+    systemctl -q --root="$initdir" add-requires ignition-files.service "$unit" || exit 1
 }

--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fde/module-setup.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fde/module-setup.sh
@@ -8,7 +8,9 @@ install_unit() {
     local unit=$1; shift
     local target=${1:-ignition-complete.target}
     inst_simple "$moddir/$unit" "$systemdsystemunitdir/$unit"
-    systemctl -q --root="$initdir" add-requires "$target" "$unit"
+    # note we `|| exit 1` here so we error out if e.g. the units are missing
+    # see https://github.com/coreos/fedora-coreos-config/issues/799
+    systemctl -q --root="$initdir" add-requires "$target" "$unit" || exit 1
 }
 
 depends() {

--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/module-setup.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/module-setup.sh
@@ -33,6 +33,8 @@ install() {
 
     # We don't support FIPS in diskless cases currently
     target=ignition-diskful.target
-    systemctl -q --root="$initdir" add-requires "$target" rhcos-fips.service
-    systemctl -q --root="$initdir" add-requires "$target" rhcos-fips-finish.service
+    # note we `|| exit 1` here so we error out if e.g. the units are missing
+    # see https://github.com/coreos/fedora-coreos-config/issues/799
+    systemctl -q --root="$initdir" add-requires "$target" rhcos-fips.service || exit 1
+    systemctl -q --root="$initdir" add-requires "$target" rhcos-fips-finish.service || exit 1
 }

--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/41rhcos-check-luks-syntax/module-setup.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/41rhcos-check-luks-syntax/module-setup.sh
@@ -5,7 +5,9 @@ install_unit() {
     local target="${1:-ignition-complete.target}"; shift
     local instantiated="${1:-$unit}"; shift
     inst_simple "$moddir/$unit" "$systemdsystemunitdir/$unit"
-    systemctl -q --root="$initdir" add-requires "$target" "$instantiated"
+    # note we `|| exit 1` here so we error out if e.g. the units are missing
+    # see https://github.com/coreos/fedora-coreos-config/issues/799
+    systemctl -q --root="$initdir" add-requires "$target" "$instantiated" || exit 1
 }
 
 install() {

--- a/overlay.d/25rhcos-azure-udev-rules/usr/lib/udev/rules.d/66-azure-storage.rules
+++ b/overlay.d/25rhcos-azure-udev-rules/usr/lib/udev/rules.d/66-azure-storage.rules
@@ -1,0 +1,28 @@
+ACTION=="add|change", SUBSYSTEM=="block", ENV{ID_VENDOR}=="Msft", ENV{ID_MODEL}=="Virtual_Disk", GOTO="azure_disk"
+GOTO="azure_end"
+
+LABEL="azure_disk"
+# Root has a GUID of 0000 as the second value
+# The resource/resource has GUID of 0001 as the second value
+ATTRS{device_id}=="?00000000-0000-*", ENV{fabric_name}="root", GOTO="azure_names"
+ATTRS{device_id}=="?00000000-0001-*", ENV{fabric_name}="resource", GOTO="azure_names"
+ATTRS{device_id}=="?00000001-0001-*", ENV{fabric_name}="BEK", GOTO="azure_names"
+# Wellknown SCSI controllers
+ATTRS{device_id}=="{f8b3781a-1e82-4818-a1c3-63d806ec15bb}", ENV{fabric_scsi_controller}="scsi0", GOTO="azure_datadisk"
+ATTRS{device_id}=="{f8b3781b-1e82-4818-a1c3-63d806ec15bb}", ENV{fabric_scsi_controller}="scsi1", GOTO="azure_datadisk"
+ATTRS{device_id}=="{f8b3781c-1e82-4818-a1c3-63d806ec15bb}", ENV{fabric_scsi_controller}="scsi2", GOTO="azure_datadisk"
+ATTRS{device_id}=="{f8b3781d-1e82-4818-a1c3-63d806ec15bb}", ENV{fabric_scsi_controller}="scsi3", GOTO="azure_datadisk"
+GOTO="azure_end"
+
+# Retrieve LUN number for datadisks
+LABEL="azure_datadisk"
+ENV{DEVTYPE}=="partition", PROGRAM="/bin/sh -c 'readlink /sys/class/block/%k/../device|cut -d: -f4'", ENV{fabric_name}="$env{fabric_scsi_controller}/lun$result", GOTO="azure_names"
+PROGRAM="/bin/sh -c 'readlink /sys/class/block/%k/device|cut -d: -f4'", ENV{fabric_name}="$env{fabric_scsi_controller}/lun$result", GOTO="azure_names"
+GOTO="azure_end"
+
+# Create the symlinks
+LABEL="azure_names"
+ENV{DEVTYPE}=="disk", SYMLINK+="disk/azure/$env{fabric_name}"
+ENV{DEVTYPE}=="partition", SYMLINK+="disk/azure/$env{fabric_name}-part%n"
+
+LABEL="azure_end"

--- a/overlay.d/25rhcos-azure-udev-rules/usr/lib/udev/rules.d/99-azure-product-uuid.rules
+++ b/overlay.d/25rhcos-azure-udev-rules/usr/lib/udev/rules.d/99-azure-product-uuid.rules
@@ -1,0 +1,9 @@
+SUBSYSTEM!="dmi", GOTO="product_uuid-exit"
+ATTR{sys_vendor}!="Microsoft Corporation", GOTO="product_uuid-exit"
+ATTR{product_name}!="Virtual Machine", GOTO="product_uuid-exit"
+TEST!="/sys/devices/virtual/dmi/id/product_uuid", GOTO="product_uuid-exit"
+
+RUN+="/bin/chmod 0444 /sys/devices/virtual/dmi/id/product_uuid"
+
+LABEL="product_uuid-exit"
+

--- a/overlay.d/README.md
+++ b/overlay.d/README.md
@@ -32,3 +32,12 @@ defaults (https://bugzilla.redhat.com/show_bug.cgi?id=1828434),
 and handling in 20-chrony and chrony-helper using the defaults
 lands in downstream packages. See upstream thread:
 https://listengine.tuxfamily.org/chrony.tuxfamily.org/chrony-dev/2020/05/msg00022.html
+
+25rhcos-azure-udev-rules
+------------------------
+
+Ships udev rules for Azure. This works in tandem with the
+`25coreos-azure-udev` dracut module in 05core which ships
+them in the initramfs. In the future, we should be able to
+drop this overlay and instead ship `WALinuxAgent-udev` as we
+do in FCOS (https://bugzilla.redhat.com/show_bug.cgi?id=1913074).


### PR DESCRIPTION
Specifically,
- the ESP unraiding change (coreos/fedora-coreos-config#794)
- working around buggy udev (coreos/fedora-coreos-config#779)
- --copy-network regression (coreos/fedora-coreos-config#800)
- Azure udev rules in initramfs (coreos/fedora-coreos-config#786)

For the latter, also apply the same `|| exit 1` change from
coreos/fedora-coreos-config#800 to our own
dracut modules for good measure.

```
$ git shortlog --invert-grep --author='CoreOS Bot' 6c9f15c8857772f730cdb0b5b2df143e778c5d0d..8c07b7391473910ba3884ee0d3763743805ac78f
Benjamin Gilbert (6):
      40ignition-ostree: silence mkfs.xfs
      coreos-boot-mount-generator: stop mounting /boot/efi
      40ignition-ostree: rename mount_and_restore_filesystem
      40ignition-ostree: create mountpoint in mount_verbose
      40ignition-ostree: add get_partlabels_for_parttype helper
      40ignition-ostree: copy ESP contents as independent filesystems

Dusty Mabe (1):
      overrides: drop graduated overrides

Jonathan Lebon (7):
      40ignition-ostree/transposefs: also trigger udev on by-label link mismatch for ESP
      40ignition-ostree/transposefs: factor out function to restore fs
      40ignition-ostree/transposefs: relabel the root of reprovisioned filesystems
      40ignition-ostree/transposefs: load zram with num_devices=0
      Add rawhide repo file
      05core: re-order and rename some dracut modules
      05core: add `|| exit 1` to `systemctl add-{requires,wants}` calls

Kelvin Fan (1):
      overlay.d/15fcos: Stop utilizing c-l-h-m private dir

Luca BRUNO (1):
      overrides: drop stale Afterburn entries

Micah Abbott (2):
      use WALinuxAgent-udev package for Azure udev rules
      overlay: add new module for installing Azure udev rules

Prashanth Sundararaman (1):
      tests: Enable TPM test for all arches except s390x

Timothée Ravier (1):
      manifests/fedora-coreos-base: Mask systemd-repart
```