### PR TITLE
tests/misc-ro: drop `ls /boot/efi` check

### DIFF
--- a/tests/kola/misc-ro/misc-ro.sh
+++ b/tests/kola/misc-ro/misc-ro.sh
@@ -113,9 +113,6 @@ echo ok qemu guest agent
 
 case "$(arch)" in
     x86_64|aarch64)
-        if runuser -u core -- ls /boot/efi &>/dev/null; then
-            fatal "Was able to access /boot/efi as non-root"
-        fi
         # This is just a basic sanity check; at some point we
         # will implement "project-owned tests run in the pipeline"
         # and be able to run the existing bootupd tests:


### PR DESCRIPTION
We don't mount `/boot/efi` anymore, so the `ls` invocation succeeds
because it's just targeting an empty dir.

Matches https://github.com/coreos/fedora-coreos-config/pull/794.