### PR TITLE
05rhcos: add /etc/mke2fs.conf to the initrd to fix mkfs.ext4

### DIFF
--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/50rhcos-mke2fs/module-setup.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/50rhcos-mke2fs/module-setup.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# -*- mode: shell-script; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# ex: ts=8 sw=4 sts=4 et filetype=sh
+
+install() {
+    # mke2fs in RHEL fails without /etc/mke2fs.conf
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1889464
+    # https://bugzilla.redhat.com/show_bug.cgi?id=1916382
+    inst /etc/mke2fs.conf
+}


### PR DESCRIPTION
RHEL e2fsprogs has a bug where mke2fs will fail if it falls back on the compiled-in mke2fs.conf.

https://bugzilla.redhat.com/show_bug.cgi?id=1889464
https://bugzilla.redhat.com/show_bug.cgi?id=1916382