### PR TITLE
Bug 1908462: manifest: Re-add dhclient

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -294,13 +294,9 @@ remove-from-packages:
     - "/"
   # In newer dracut-network dhclient isn't required if you have NM 1.20
   # https://github.com/dracutdevs/dracut/commit/e863807
-  # Let's go ahead and get rid of it now.
+  # Let's keep only the binaries so users still relying on them can continue
+  # to use them in the real root as long as they provide the configuration themselves.
   - - dhcp-client
-    # we want to delete all files ("/") but can't because
-    # `remove-from-packages` is being overzealous:
-    # https://github.com/coreos/rpm-ostree/issues/2068
     - "/etc/dhcp/dhclient.conf"
     - "/etc/NetworkManager/dispatcher.d/11-dhclient"
     - "/usr/lib64/pm-utils/sleep.d/56dhclient"
-    - "/usr/sbin/dhclient"
-    - "/usr/sbin/dhclient-script"

--- a/overlay.d/21dhcp-chrony/etc/NetworkManager/dispatcher.d/20-coreos-chrony-dhcp
+++ b/overlay.d/21dhcp-chrony/etc/NetworkManager/dispatcher.d/20-coreos-chrony-dhcp
@@ -20,9 +20,13 @@ export LC_ALL=C
     exit 0
 
 # If a dhclient installation is present, avoid a redundant operation
-# with dhclient which handles NTP server config through its own
-# NetworkManager dispatcher script 11-dhclient.
-[ -e /usr/sbin/dhclient ] && exit 0
+# if dhclient handles NTP server config through its own chrony config script,
+# exec'ed by NetworkManager's 11-dhclient dispatcher script.
+# In RHCOS, 11-dhclient is excluded and not shipped with base image.
+[ -e /usr/sbin/dhclient ] && \
+    [ -e /etc/dhcp/dhclient.d/chrony.sh ] && \
+    [ -e /etc/NetworkManager/dispatcher.d/11-dhclient ] && \
+    exit 0
 
 interface=$1
 action=$2

--- a/tests/kola/dhclient/config.ign
+++ b/tests/kola/dhclient/config.ign
@@ -1,0 +1,10 @@
+{
+  "ignition": { "version": "3.0.0" },
+  "storage": {
+    "files": [{
+      "path": "/etc/NetworkManager/conf.d/dhcp-client.conf",
+      "mode": 420,
+      "contents": { "source": "data:text/plain;base64,W21haW5dCmRoY3A9ZGhjbGllbnQ=" }
+    }]
+  }
+}

--- a/tests/kola/dhclient/test.sh
+++ b/tests/kola/dhclient/test.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -xeuo pipefail
+
+ok() {
+    echo "ok" "$@"
+}
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+if ! journalctl -b 0 -u NetworkManager --grep=dhclient | grep -q dhclient; then
+    echo "no dhclient logs found" >&2
+    fail=1
+fi
+
+if [ -z "${fail:-}" ]; then
+    ok "success: dhclient is running"
+else
+    fatal "fail: dhclient not running"
+fi

--- a/tests/kola/misc-ro/misc-ro.sh
+++ b/tests/kola/misc-ro/misc-ro.sh
@@ -137,3 +137,8 @@ if [[ ! $(rpm -q NetworkManager) =~ 'rhaos4.7' ]]; then
     fatal "NetworkManager package changed from rhaos4.7 branch. Needs investigation."
 fi
 echo "ok NetworkManager package comes from rhaos4.7 branch."
+
+# Ensure NM's internal DHCP client runs by default
+if ! journalctl -b 0 -u NetworkManager --grep=dhcp | grep -q "Using DHCP client 'internal'"; then
+  fatal "NetworkManager's internal DHCP client is not running"
+fi


### PR DESCRIPTION
With this, the dhclient binaries are added back to the RHCOS base.
Usage of dhclient as DHCP client in the initramfs remains unsupported.
In the real root, dhclient can be used as long as a configuration is provided.

In order to activate dhclient and use it instead of NetworkManager's internal DHCP client in the real root,
the user has to provide a configuration snippet via Ignition to configure NM to use dhclient,
e.g. in `/etc/NetworkManager/conf.d/dhclient.conf`:
```
[main]
dhcp=dhclient
```

Notably, the NetworkManager dispatcher script for dhclient.d config snippets remains excluded from the image.
This means if the admin desires to e.g. configure NTP via DHCP using dhclient,
a NM dispatcher script must be provided and placed at `/etc/NetworkManager/dispatcher.d/11-dhclient` ([1]),
so the `/etc/dhcp/dhclient.d/chrony.sh` script that is shipped with the chrony package is executed.

[1] https://src.fedoraproject.org/rpms/dhcp/blob/master/f/11-dhclient

RHBZ: https://bugzilla.redhat.com/show_bug.cgi?id=1908462