### PR TITLE
kola-denylist: skip crio test on x86_64

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -5,11 +5,15 @@
   tracker: https://bugzilla.redhat.com/show_bug.cgi?id=1782026
   arches:
    - s390x
+# making two entries for crio.base because they are separate issues
 - pattern: crio.base
   tracker: https://github.com/kubernetes/kubernetes/issues/87325
   arches:
    - s390x
    - ppc64le
+- pattern: crio.base
+  tracker: https://bugzilla.redhat.com/show_bug.cgi?id=1917470
+   - x86_64
 # for s390x by-partlabel can't be used and even if that is avoided by using part-uuid, still depends on the cpi fix below
 - pattern: ext.config.var-mount
   tracker: https://github.com/ibm-s390-tools/s390-tools/pull/82


### PR DESCRIPTION
We are seeing crio failures that appear to be network related which
are blocking RHCOS 4.7 builds.  It doesn't appear to be an explicit
crio issue, but needs further investigation.

See https://bugzilla.redhat.com/show_bug.cgi?id=1917470