### PR TITLE
[release-4.7] Target fedora-coreos-config branch rhcos-4.7 and bump

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "fedora-coreos-config"]
 	path = fedora-coreos-config
 	url = https://github.com/coreos/fedora-coreos-config
-	branch = testing-devel
+	branch = rhcos-4.7


### PR DESCRIPTION
```
Jonathan Lebon (1):
      Revert "overlay/boot-mount-generator: Mount /boot read-only,nodev,nosuid"
```