### PR TITLE
chrony NM dispatcher: Account for dhclient dispatcher script in /usr/lib/

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -299,4 +299,5 @@ remove-from-packages:
   - - dhcp-client
     - "/etc/dhcp/dhclient.conf"
     - "/etc/NetworkManager/dispatcher.d/11-dhclient"
+    - "/usr/lib/NetworkManager/dispatcher.d/11-dhclient"
     - "/usr/lib64/pm-utils/sleep.d/56dhclient"

--- a/overlay.d/21dhcp-chrony/etc/NetworkManager/dispatcher.d/20-coreos-chrony-dhcp
+++ b/overlay.d/21dhcp-chrony/etc/NetworkManager/dispatcher.d/20-coreos-chrony-dhcp
@@ -25,7 +25,7 @@ export LC_ALL=C
 # In RHCOS, 11-dhclient is excluded and not shipped with base image.
 [ -e /usr/sbin/dhclient ] && \
     [ -e /etc/dhcp/dhclient.d/chrony.sh ] && \
-    [ -e /etc/NetworkManager/dispatcher.d/11-dhclient ] && \
+    [ -e /etc/NetworkManager/dispatcher.d/11-dhclient -o -e /usr/lib/NetworkManager/dispatcher.d/11-dhclient ] && \
     exit 0
 
 interface=$1


### PR DESCRIPTION
In current dhcp-client Fedora RPMs,
the dhclient dispatcher script is placed at
`/usr/lib/NetworkManager/dispatcher.d/11-dhclient`
as opposed to
`/etc/NetworkManager/dispatcher.d/11-dhclient`
used before.

This changes the chrony dispatcher script to account for the
dhclient dispatcher script in either place.