### PR TITLE
extensions: adapt for new rpm-ostree support

### DIFF
--- a/extensions.yaml
+++ b/extensions.yaml
@@ -1,26 +1,35 @@
 # RPMs as operating system extensions, distinct from the base ostree commit/image
 # https://github.com/openshift/enhancements/blob/master/enhancements/rhcos/extensions.md
 # and https://github.com/coreos/fedora-coreos-tracker/issues/401
-# We currently explicitly list dependencies for each extension; see
-# https://github.com/coreos/rpm-ostree/issues/2055
+
+repos:
+  - rhel-8-nfv
 
 extensions:
   # https://github.com/coreos/fedora-coreos-tracker/issues/326
   usbguard:
     packages:
       - usbguard
-      - libqb
-      - protobuf
-  # kernel-devel
   # https://github.com/kmods-via-containers/kmods-via-containers/issues/3
   # https://gitlab.cee.redhat.com/coreos/redhat-coreos/merge_requests/866
+  # These are currently overlaid onto the host so that they can be bind-mounted
+  # into build containers... in the future they should be a `development`
+  # extension: https://github.com/openshift/machine-config-operator/pull/2143.
   kernel-devel:
     packages:
       - kernel-devel
-      - kernel-core
       - kernel-headers
+    match-base-evr: kernel
+  # These are already in the base, so they're not OS extensions, but they're
+  # useful to have in RPM form to install in kmod build containers.
+  kernel:
+    kind: development
+    packages:
+      - kernel
+      - kernel-core
       - kernel-modules
       - kernel-modules-extra
+    match-base-evr: kernel
   # GRPA-2822
   # https://github.com/openshift/machine-config-operator/pull/1330
   # https://github.com/openshift/enhancements/blob/master/enhancements/support-for-realtime-kernel.md

--- a/oscontainer.yaml
+++ b/oscontainer.yaml
@@ -1,2 +1,9 @@
 # Configuration for oscontainer uploads; this is the base image.
 base: registry.access.redhat.com/ubi8/ubi:latest
+# These are the packages whose NEVRAs are included as labels on the image.
+labeled-packages:
+  - kernel kernel-rt-core
+  - ostree rpm-ostree
+  - ignition
+  - systemd
+  - runc cri-o


### PR DESCRIPTION
With https://github.com/coreos/rpm-ostree/pull/2439 and
https://github.com/coreos/coreos-assembler/pull/2028, support for
extensions is now more robust.

The extensions.yaml file is now fed directly to rpm-ostree. We just need
to do some minor tweaks:
- drop listing usbguard deps, rpm-ostree fetches them automatically
- split the devel bits into two extensions: one is an OS extension which
  contains the devel and headers packages, and the other is a
  development extension containing kernel packages already in the base
  (marking it as a development extension will signal the MCO that it's
  not intended to be directly layered on the host)
- use `match-base-evr: kernel` on those to enforce that the kernel
  development packages have the same EVR as the base kernel package in
  the OSTree