### PR TITLE
Add new extension qemu-kiwi

### DIFF
--- a/extensions.yaml
+++ b/extensions.yaml
@@ -3,6 +3,7 @@
 # and https://github.com/coreos/fedora-coreos-tracker/issues/401
 
 repos:
+  - rhel-8-advanced-virt
   - rhel-8-nfv
 
 extensions:
@@ -42,3 +43,10 @@ extensions:
       - kernel-rt-modules
       - kernel-rt-modules-extra
       - kernel-rt-devel
+  # https://github.com/openshift/machine-config-operator/pull/2376/
+  # GRPA-3123
+  qemu-kiwi:
+    architectures:
+      - x86_64
+    packages:
+      - qemu-kiwi


### PR DESCRIPTION
This adds qemu-kiwi as another extension to the list. 
The qemu-kiwi extension is added to MCO with this PR https://github.com/openshift/machine-config-operator/pull/2376
qemu-kiwi is a shrunk-down version of the qemu-kvm package with fewer dependencies. 8 rpms and ~20MB in size when installed