### PR TITLE
updates for OCP 4.8

### DIFF
--- a/ci/build-test.sh
+++ b/ci/build-test.sh
@@ -9,8 +9,8 @@ export COSA_SKIP_OVERLAY=1
 gitdir=$(pwd)
 cd $(mktemp -d)
 cosa init ${gitdir}
-# TODO query the 4-7 bits from manifest.yaml or so
-curl -L http://base-4-7-rhel8.ocp.svc.cluster.local > src/config/ocp.repo
+# TODO query the 4-8 bits from manifest.yaml or so
+curl -L http://base-4-8-rhel8.ocp.svc.cluster.local > src/config/ocp.repo
 cosa fetch
 cosa build
 cosa kola --basic-qemu-scenarios

--- a/docs/building.md
+++ b/docs/building.md
@@ -56,5 +56,5 @@ See https://github.com/openshift/release/blob/master/core-services/release-contr
 Use this:
 ```
 $ cosa init https://github.com/openshift/os
-$ curl -L http://base-4-7-rhel8.ocp.svc.cluster.local > src/config/ocp.repo
+$ curl -L http://base-4-8-rhel8.ocp.svc.cluster.local > src/config/ocp.repo
 ```

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -28,10 +28,10 @@ repos:
   - rhel-8-server-ose
 
 # We include hours/minutes to avoid version number reuse
-automatic-version-prefix: "47.83.<date:%Y%m%d%H%M>"
+automatic-version-prefix: "48.83.<date:%Y%m%d%H%M>"
 # This ensures we're semver-compatible which OpenShift wants
 automatic-version-suffix: "-"
-mutate-os-release: "4.7"
+mutate-os-release: "4.8"
 
 documentation: false
 initramfs-args:


### PR DESCRIPTION
Now that 4.8 has branched, we can start using `master` to track
development of that release.