### PR TITLE
manifest: Add conntrack (tools) but without the daemon

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -270,6 +270,10 @@ packages:
  # https://bugzilla.redhat.com/show_bug.cgi?id=1877905
  # https://bugzilla.redhat.com/show_bug.cgi?id=1886201
  - perl-interpreter
+ # https://github.com/coreos/fedora-coreos-tracker/issues/404
+ # https://bugzilla.redhat.com/show_bug.cgi?id=1925698
+ # https://github.com/openshift/machine-config-operator/pull/2421
+ - conntrack-tools
 
 packages-x86_64:
   # Temporary add of open-vm-tools. Should be removed when containerized
@@ -301,3 +305,7 @@ remove-from-packages:
     - "/etc/NetworkManager/dispatcher.d/11-dhclient"
     - "/usr/lib/NetworkManager/dispatcher.d/11-dhclient"
     - "/usr/lib64/pm-utils/sleep.d/56dhclient"
+  # Remove the systemd unit; we only want the binary to be used
+  # by MCD or kubelet.  See above.
+  - - conntrack-tools
+    - /usr/lib/systemd/system

--- a/tests/kola/misc-ro/misc-ro.sh
+++ b/tests/kola/misc-ro/misc-ro.sh
@@ -130,6 +130,9 @@ if ! test -f /etc/iscsi/initiatorname.iscsi; then
 fi
 echo "ok iSCSI initiator name"
 
+rpm -q conntrack-tools
+test ! -f /usr/lib/systemd/system/conntrackd.service
+echo "ok conntrack tools without daemon"
 
 # Let's make sure the NetworkManager we use is one of the one-off
 # rebuilds while we're following RHEL 8.3.


### PR DESCRIPTION
https://github.com/coreos/fedora-coreos-tracker/issues/404
https://bugzilla.redhat.com/show_bug.cgi?id=1925698
https://github.com/openshift/machine-config-operator/pull/2421

This will help us work around a believed kernel bug for OpenShift right now.  We may remove this later.