### PR TITLE
rhcos-fde: tpm2_pcrlist is now tpm2_pcrread

### DIFF
--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fde/module-setup.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fde/module-setup.sh
@@ -64,7 +64,7 @@ install() {
         tpm2_createpolicy
         tpm2_createprimary
         tpm2_load
-        tpm2_pcrlist
+        tpm2_pcrread
         tpm2_unseal
         tr
         umount


### PR DESCRIPTION
Happened to see this error while building RHCOS:

```
dracut-install: ERROR: installing 'tpm2_pcrlist'
dracut: FAILED: /usr/lib/dracut/dracut-install -D /tmp/dracut/dracut.ibNvrR/initramfs -a -f blockdev base64 chmod clevis clevis-decrypt clevis-decrypt-sss clevis-decrypt-tpm2 clevis-encrypt-sss clevis-encrypt-tang clevis-encrypt-tpm2 clevis-luks-bind clevis-luks-common-functions clevis-luks-unbind clevis-luks-unlock cryptsetup cryptsetup-reencrypt curl cut dd dirname growpart head jose jq luksmeta mktemp nc pwmake sfdisk sync systemd-detect-virt touch tpm2_create tpm2_createpolicy tpm2_createprimary tpm2_load tpm2_pcrlist tpm2_unseal tr umount
```

Found https://bugzilla.redhat.com/show_bug.cgi?id=1847983 which states
that `tpm2_pcrlist` has been renamed to `tpm2_pcrread`