### PR TITLE
Add sandboxed-containers extension

### DIFF
--- a/extensions.yaml
+++ b/extensions.yaml
@@ -43,10 +43,13 @@ extensions:
       - kernel-rt-modules
       - kernel-rt-modules-extra
       - kernel-rt-devel
-  # https://github.com/openshift/machine-config-operator/pull/2376/
+  # https://github.com/openshift/machine-config-operator/pull/2456
+  # https://github.com/openshift/enhancements/blob/master/enhancements/sandboxed-containers/sandboxed-containers-tech-preview.md
   # GRPA-3123
-  qemu-kiwi:
+  # - kata-containers (RHAOS)
+  #   - qemu-kiwi (advanced-virt)
+  sandboxed-containers:
     architectures:
       - x86_64
     packages:
-      - qemu-kiwi
+      - kata-containers


### PR DESCRIPTION
This reworks af93514887350da53e035d1b841eea36542cdd42 as, since it was
merged, a few changes happened in the enhancement proposal and it's been
decided to go with a "sandboxed-containers" extensions instead.

As the "qemu-kiwi" extension is no longer needed, we're removing it
(well, reworking it) and adding the "sandboxed-containers" one instead.

The sandboxed-containers extension is added to the MCO with by the
following PR:
https://github.com/openshift/machine-config-operator/pull/2456

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>