### PR TITLE
overlay: Add 15rhcos-logrotate (BZ#1780079)

### DIFF
--- a/overlay.d/05rhcos/usr/lib/systemd/system-preset/43-manifest-rhcos.preset
+++ b/overlay.d/05rhcos/usr/lib/systemd/system-preset/43-manifest-rhcos.preset
@@ -13,6 +13,8 @@ enable auditd.service
 disable nis-domainname.service
 disable rpcbind.service
 disable rpcbind.socket
+# See BZ#1780079 and overlay.d/15rhcos-logrotate
+enable logrotate.timer
 # Enable systemd unit required for console-login-helper-messages v0.19
 # This preset should be removed once fedora-coreos-config is updated
 # to include at least commit 3fbd175b16ae2d5dbb26519b89792a590ce07565.

--- a/overlay.d/15rhcos-logrotate/usr/lib/systemd/system/logrotate.service
+++ b/overlay.d/15rhcos-logrotate/usr/lib/systemd/system/logrotate.service
@@ -1,0 +1,23 @@
+# Backported from Fedora for https://bugzilla.redhat.com/show_bug.cgi?id=1780079
+[Unit]
+Description=Rotate log files
+Documentation=man:logrotate(8) man:logrotate.conf(5)
+RequiresMountsFor=/var/log
+ConditionACPower=true
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/logrotate /etc/logrotate.conf
+
+# performance options
+Nice=19
+IOSchedulingClass=best-effort
+IOSchedulingPriority=7
+
+# hardening options; trimmed to be sure this works on RHEL8
+PrivateDevices=true
+PrivateTmp=true
+ProtectSystem=full
+RestrictNamespaces=true
+RestrictRealtime=true
+

--- a/overlay.d/15rhcos-logrotate/usr/lib/systemd/system/logrotate.timer
+++ b/overlay.d/15rhcos-logrotate/usr/lib/systemd/system/logrotate.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Daily rotation of log files
+Documentation=man:logrotate(8) man:logrotate.conf(5)
+
+[Timer]
+OnCalendar=daily
+AccuracySec=1h
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+

--- a/tests/kola/misc-ro/misc-ro.sh
+++ b/tests/kola/misc-ro/misc-ro.sh
@@ -130,6 +130,9 @@ if ! test -f /etc/iscsi/initiatorname.iscsi; then
 fi
 echo "ok iSCSI initiator name"
 
+systemctl is-enabled logrotate.timer
+echo "ok logrotate"
+
 rpm -q conntrack-tools
 test ! -f /usr/lib/systemd/system/conntrackd.service
 echo "ok conntrack tools without daemon"


### PR DESCRIPTION
We landed the package addition in FCOS, but the package
there ships with a timer unit, but not in RHEL8.  That
seems like it's not going to happen, so backport the timer
unit manually.

For https://bugzilla.redhat.com/show_bug.cgi?id=1780079