### PR TITLE
Add dhcp-client to manifest for dhclient binary

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -206,6 +206,9 @@ packages:
  - openvswitch2.13
  - dnsmasq
  - NetworkManager-ovs
+ # Need to keep providing dhclient binary
+ # See: https://bugzilla.redhat.com/show_bug.cgi?id=1908462
+ - dhcp-client
  # Extra runtime
  - sssd
  # Common tools used by scripts and admins interactively

--- a/tests/kola/misc-ro/misc-ro.sh
+++ b/tests/kola/misc-ro/misc-ro.sh
@@ -141,3 +141,8 @@ echo "ok conntrack tools without daemon"
 if ! journalctl -b 0 -u NetworkManager --grep=dhcp | grep -q "Using DHCP client 'internal'"; then
   fatal "NetworkManager's internal DHCP client is not running"
 fi
+# Ensure that dhclient is available on the host
+if ! test -f /usr/sbin/dhclient; then
+    fatal "Missing dhclient binary"
+fi
+echo "ok dhclient binary present" 


### PR DESCRIPTION
During the switch to using RHEL 8.4 Beta, the `dhcp-client` package dropped out of the content set.  (Was not able to quickly determine why)

This re-adds the package to the manifest, as we have OCP customers that are still relying on the `dhclient` binary for their network setup.  See:  https://bugzilla.redhat.com/show_bug.cgi?id=1908462

This also adds a test to ensure that the `dhclient` binary does not fall out of the compose.