### PR TITLE
manifest.yaml: Do not install rdma-core on s390x

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -218,8 +218,6 @@ packages:
  - nano
  # Red Hat CA certs
  - subscription-manager-rhsm-certificates
- # rdma-core cleanly covers some key bare metal use cases
- - rdma-core
  # Used on the bootstrap node
  - systemd-journal-remote
  # Extras
@@ -262,12 +260,17 @@ packages-x86_64:
   # Until we sort out 4.2 -> 4.3 upgrades, we need to carry this.
   # See also https://github.com/ostreedev/ostree/pull/1929
   - ostree-grub2
+  # rdma-core cleanly covers some key bare metal use cases
+  - rdma-core
+
 
 packages-ppc64le:
   - irqbalance
   - librtas
   - powerpc-utils-core
   - ppc64-diag-rtas
+  - rdma-core
+
 
 remove-from-packages:
   - - filesystem


### PR DESCRIPTION
rdma-core is needed for the infiniband subsystem which is not supported for s390x. This is causing a couple of systemd units to fail
when booting a system with RoCE cards (https://bugzilla.redhat.com/show_bug.cgi?id=1782876). Disabling the rdma-core as it is not needed for mellanox RoCE cards.