### PR TITLE
Bug 1945646: start gcp-routes.sh script directly

### DIFF
--- a/overlay.d/05rhcos/usr/lib/systemd/system/gcp-routes.service
+++ b/overlay.d/05rhcos/usr/lib/systemd/system/gcp-routes.service
@@ -6,8 +6,8 @@ After=network.target
 
 [Service]
 Type=simple
-ExecStart=/bin/bash /usr/sbin/gcp-routes.sh start
-ExecStopPost=/bin/bash /usr/sbin/gcp-routes.sh cleanup
+ExecStart=/usr/sbin/gcp-routes.sh start
+ExecStopPost=/usr/sbin/gcp-routes.sh cleanup
 User=root
 RestartSec=30
 Restart=always


### PR DESCRIPTION
Starting the script via bash puts the process in the initrc_t domain,
which is more restrictive than starting it directly and putting it
into unconfined_service_t. Starting the script direcrtly should quiet
some of the AVC messages that are being sent to the audit.log

See: https://bugzilla.redhat.com/show_bug.cgi?id=1945646#c11