### PR TITLE
Add presets for CLHM's `issuegen`-related units

### DIFF
--- a/overlay.d/05rhcos/usr/lib/systemd/system-preset/43-manifest-rhcos.preset
+++ b/overlay.d/05rhcos/usr/lib/systemd/system-preset/43-manifest-rhcos.preset
@@ -15,7 +15,9 @@ disable rpcbind.service
 disable rpcbind.socket
 # See BZ#1780079 and overlay.d/15rhcos-logrotate
 enable logrotate.timer
-# Enable systemd unit required for console-login-helper-messages v0.19
-# This preset should be removed once fedora-coreos-config is updated
-# to include at least commit 3fbd175b16ae2d5dbb26519b89792a590ce07565.
-enable console-login-helper-messages-gensnippet-ssh-keys.service
+# console-login-helper-messages - https://github.com/coreos/console-login-helper-messages
+# CLHM v0.21+ used in FCOS no longer has `{issue,motd}gen`-related units, but RHCOS is
+# still on older versions of CLHM that require these units. These presets should be
+# removed once RHCOS catches up to CLHM v0.21+.
+enable console-login-helper-messages-issuegen.service
+enable console-login-helper-messages-issuegen.path

--- a/tests/kola/misc-ro/misc-ro.sh
+++ b/tests/kola/misc-ro/misc-ro.sh
@@ -146,3 +146,15 @@ if ! test -f /usr/sbin/dhclient; then
     fatal "Missing dhclient binary"
 fi
 echo "ok dhclient binary present" 
+
+# Check that we have the proper presets for console-login-helper-messages in RHCOS.
+# Versions of CLHM prior to v0.21 have `issuegen`-related systemd units.
+if test -f /usr/lib/systemd/system/console-login-helper-messages-issuegen.service; then
+  if ! systemctl is-enabled console-login-helper-messages-issuegen.path; then
+    fatal "console-login-helper-messages-issuegen.path required but not enabled"
+  fi
+  if ! systemctl is-enabled console-login-helper-messages-issuegen.service; then
+    fatal "console-login-helper-messages-issuegen.service required but not enabled"
+  fi
+fi
+echo "ok console-login-helper-messages presets present"


### PR DESCRIPTION
CLHM v0.21+ used in FCOS no longer has `{issue,motd}gen`-related units,
but RHCOS is still on older versions of CLHM that require these units.
These presets should be removed once RHCOS catches up to CLHM v0.21+.