### PR TITLE
Add temporary repo for aarch64 fast-datapath packages

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -28,6 +28,7 @@ repos:
   - rhel-8-baseos
   - rhel-8-appstream
   - rhel-8-fast-datapath
+  - rhel-8-fast-datapath-aarch64
   - rhel-8-server-ose
 
 # We include hours/minutes to avoid version number reuse


### PR DESCRIPTION
Fast Datapath has yet to ship for ARM; the pulp repo now exists for
aarch64 but is empty. Once it starts shipping on ARM, this should be
reverted.

IIUC the corresponding change to redhat-coreos needs to merge first.

/cc @andymcc 
