### PR TITLE
manifest: Exclude unneeded udisks2

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -185,6 +185,8 @@ exclude-packages:
   # https://github.com/coreos/rpm-ostree/pull/1789/files/a0cd999a8acd5b40ec1024a794a642916fbc8ff8#diff-fc2076dc46933204a7a798f544ce3734
   # People need to use `rpm-ostree kargs` instead.
   - grubby
+  # udisks2 is a fwupd recommends only need for encrypted swap checks
+  - udisks2
 
 # Try to maintain this list ordering by "in RHEL, then not in RHEL".
 # To verify, disable all repos except the ootpa ones and then comment


### PR DESCRIPTION
With RHEL 8.4, fwupd got pulled in as provider of dbxtool and that also
included udisks2 as a recommends. But udisks2 is apparently only needed
for encrypted swap checks in fwupd and is not even included in FCOS, so
manually exclude it.

For BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1953105