### PR TITLE
overlay.d: s390x: add to ramdisk missing zipl

### DIFF
--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/module-setup.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/module-setup.sh
@@ -17,6 +17,12 @@ install() {
         bwrap \
         env
 
+    local _arch=${DRACUT_ARCH:-$(uname -m)}
+    if [[ "$_arch" == "s390x" ]]; then
+        inst_multiple zipl
+        inst /lib/s390-tools/stage3.bin
+    fi
+
     inst_script "$moddir/rhcos-fips.sh" \
         "/usr/sbin/rhcos-fips"
     inst_script "$moddir/coreos-dummy-ignition-files-run.sh" \

--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips.sh
@@ -76,7 +76,9 @@ firstboot() {
               echo $(grep $line $f) >> $tmpfile
           done
       done
-      grep options $tmpfile | cut -d ' ' -f2- > $optfile
+      echo "Appending 'ignition.firstboot' to ${optfile}"
+      options="$(grep options $tmpfile | cut -d ' ' -f2-) ignition.firstboot"
+      echo $options > "$optfile"
       zipl --verbose \
            --target "${tmpsysroot}/boot" \
            --image $tmpsysroot/boot/"$(grep linux $tmpfile | cut -d' ' -f2)" \

--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips.sh
@@ -70,16 +70,18 @@ firstboot() {
       # We need to call zipl with the kernel image and ramdisk as running it without these options would require a zipl.conf and chroot
       # into rootfs
       tmpfile=$(mktemp)
+      optfile=$(mktemp)
       for f in "${tmpsysroot}"/boot/loader/entries/*.conf; do
           for line in title version linux initrd options; do
               echo $(grep $line $f) >> $tmpfile
           done
       done
+      grep options $tmpfile | cut -d ' ' -f2- > $optfile
       zipl --verbose \
            --target "${tmpsysroot}/boot" \
            --image $tmpsysroot/boot/"$(grep linux $tmpfile | cut -d' ' -f2)" \
            --ramdisk $tmpsysroot/boot/"$(grep initrd $tmpfile | cut -d' ' -f2)" \
-           --parmfile $tmpfile
+           --parmfile $optfile
     fi
 
     echo "Rebooting"


### PR DESCRIPTION
This is a fix for https://bugzilla.redhat.com/show_bug.cgi?id=1955621
When starting OCP in fips mode it immediate fails during install:
```
systemd[1]: Starting Check for FIPS mode...
rhcos-fips[763]: Found /etc/ignition-machine-config-encapsulated.json in Ignition config
rhcos-fips[763]: FIPS mode required; updating BLS entries
rhcos-fips[763]: Appending 'fips=1 boot=LABEL=boot' to /run/rhcos-fips/sysroot/boot/loader/entries/ostree-1-rhcos.conf
rhcos-fips[763]: /usr/sbin/rhcos-fips: line 78: zipl: command not found
```

Signed-off-by: Nikita Dubrovskii <nikita@linux.ibm.com>