### PR TITLE
manifest.yaml: explicitly use `rpmdb: bdb`

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -13,6 +13,11 @@ include:
   # RHCOS owned packages
   - rhcos-packages.yaml
 
+# The Fedora default is sqlite now, but we want to stick with bdb.
+# XXX: set back to `bdb` once rpm-ostree is fixed:
+# https://github.com/coreos/rpm-ostree/pull/2808
+rpmdb: b-d-b
+
 arch-include:
   x86_64:
     - fedora-coreos-config/manifests/grub2-removals.yaml


### PR DESCRIPTION
With cosa moving to f34, the rpm-ostree default rpmdb backend there
changed to sqlite. But for RHCOS we want to stick with bdb since that's
what el8 rpm understands.