### PR TITLE
BZ 1956836: overlay: Add rhcos-usrlocal-selinux-fixup.service

### DIFF
--- a/overlay.d/05rhcos/usr/lib/systemd/system-preset/43-manifest-rhcos.preset
+++ b/overlay.d/05rhcos/usr/lib/systemd/system-preset/43-manifest-rhcos.preset
@@ -3,6 +3,8 @@
 # live in the manifest and some of them from the redhat-release-coreos
 # package.
 
+# Upgrade fixes
+enable rhcos-usrlocal-selinux-fixup.service
 # Enable the iscsi workaround
 enable coreos-generate-iscsi-initiatorname.service
 # Enable GCP routes

--- a/overlay.d/05rhcos/usr/lib/systemd/system/rhcos-usrlocal-selinux-fixup.service
+++ b/overlay.d/05rhcos/usr/lib/systemd/system/rhcos-usrlocal-selinux-fixup.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=RHCOS Fix SELinux Labeling For /usr/local/sbin
+Documentation=https://bugzilla.redhat.com/1956836
+DefaultDependencies=false
+After=systemd-tmpfiles-setup.service local-fs.target
+Before=sysinit.target
+ConditionPathExists=/var/usrlocal/sbin
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# Run every time because systemd-tmpfiles will reset it to the incorrect
+# context on each boot.
+ExecStart=chcon -v --reference=/usr/sbin /usr/local/sbin
+# Only do this recursive relabeling once.
+ExecStart=/bin/sh -c 'if ! test -f /var/lib/.coreos-usrlocal-fixup.stamp; then find /var/usrlocal/sbin -executable -mount -exec chcon -v --reference=/usr/sbin {} \; && touch /var/lib/.coreos-usrlocal-fixup.stamp; fi'
+
+[Install]
+WantedBy=sysinit.target

--- a/tests/kola/misc-ro/misc-ro.sh
+++ b/tests/kola/misc-ro/misc-ro.sh
@@ -133,6 +133,14 @@ echo "ok iSCSI initiator name"
 systemctl is-enabled logrotate.timer
 echo "ok logrotate"
 
+bin_ctx=$(stat -c %C /usr/sbin)
+usrlocal_sbin_ctx=$(stat -c %C /var/usrlocal/sbin)
+if test "${bin_ctx}" != "${usrlocal_sbin_ctx}"; then
+  fatal "/usr/sbin is ${bin_ctx} but /var/usrlocal/sbin is ${usrlocal_sbin_ctx}"
+fi
+test -f /var/lib/.coreos-usrlocal-fixup.stamp
+echo "ok usr/local/sbin fixup"
+
 rpm -q conntrack-tools
 test ! -f /usr/lib/systemd/system/conntrackd.service
 echo "ok conntrack tools without daemon"


### PR DESCRIPTION
A fix is inbound for policy, but we really should fixup existing
systems in place.