### PR TITLE
Switch back to RHEL 8.4 GA content

### DIFF
--- a/ci/build-test-qemu.sh
+++ b/ci/build-test-qemu.sh
@@ -17,7 +17,7 @@ cosa init "${tmpsrc}"/src
 # Grab the raw value of `mutate-os-release` and use sed to convert the value
 # to X-Y format
 ocpver=$(rpm-ostree compose tree --print-only src/config/manifest.yaml | jq -r '.["mutate-os-release"]' | sed 's|\.|-|')
-curl -L http://base-"${ocpver}"-rhel84.ocp.svc.cluster.local > src/config/ocp.repo
+curl -L http://base-"${ocpver}"-rhel8.ocp.svc.cluster.local > src/config/ocp.repo
 cosa fetch
 cosa build
 cosa buildextend-extensions

--- a/ci/build-test-qemu.sh
+++ b/ci/build-test-qemu.sh
@@ -21,12 +21,7 @@ curl -L http://base-"${ocpver}"-rhel8.ocp.svc.cluster.local > src/config/ocp.rep
 cosa fetch
 cosa build
 cosa buildextend-extensions
-# Manually exclude Secure Boot testing for pre-release RHEL content.
-# This will be removed once RHEL 8.4 is GA.
-# See https://github.com/openshift/os/pull/527
-# cosa kola --basic-qemu-scenarios
-cosa kola run --qemu-nvme=true basic
-cosa kola run --qemu-firmware=uefi basic
+cosa kola --basic-qemu-scenarios
 cosa kola run 'ext.*'
 # TODO: all tests in the future, but there are a lot
 # and we want multiple tiers, and we need to split them


### PR DESCRIPTION
Revert "ci: Temporarily force 8.4 Beta repos"

This reverts commit 8ce67f32128b7fc966eb87454da83773f9e7aa02.

---

Revert "ci: Temporarily exclude Secure Boot testing"

This reverts commit af43105f4ce9db2e2a04fc3947b8bcf374e34a47.