### PR TITLE
Bump fedora-coreos-config to latest rhcos-4.8 commit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "fedora-coreos-config"]
 	path = fedora-coreos-config
 	url = https://github.com/coreos/fedora-coreos-config
-	branch = testing-devel
+	branch = rhcos-4.8


### PR DESCRIPTION
There's a bunch of fixes in there, but mostly we need these for the
following multipath-related RHBZs:
- https://bugzilla.redhat.com/show_bug.cgi?id=1944660
- https://bugzilla.redhat.com/show_bug.cgi?id=1954025

```
Andy McCrae (1):
      Move comments in systemd services to own line

Colin Walters (3):
      coreos-boot-mount-generator: Move all "exit 0" checks to early on
      udev/90-coreos-device-mapper: Create label links in real root too
      coreos-boot-mount-generator: Always use mpath for /boot if rd.multipath

Jonathan Lebon (10):
      ignition-ostree-growfs: don't conditionalize on root= karg
      ignition-ostree-growfs: fix dependency to sysroot mount
      overlay: convert more unit descriptions to Title Case
      coreos-gpt-setup: log whether sgdisk was called
      ignition-ostree-uuid-root: also run if root= is provided
      live-generator: don't call `man bootup`
      Add support for multipath on firstboot
      coreos-gpt-setup: add support for multipath
      ignition-ostree-growfs: add support for multipath
      udev/90-coreos-device-mapper: ignore DM_ACTIVATION
```