### PR TITLE
Bug 1971738: overaly: Keep /boot RW when kdump is enabled

### DIFF
--- a/overlay.d/12kdump
+++ b/overlay.d/12kdump
@@ -1,0 +1,1 @@
+../fedora-coreos-config/overlay.d/12kdump


### PR DESCRIPTION
Keep /boot RW (only when kdump is enabled) until [1] is backported to
RHEL's kexec-tools.

[1] https://src.fedoraproject.org/rpms/kexec-tools/c/75bdcb7399b6fe48032a8db534e18b01206601bc?branch=rawhide

https://bugzilla.redhat.com/show_bug.cgi?id=1971738