### PR TITLE
changes to master branch for RHCOS 4.9 builds

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "fedora-coreos-config"]
 	path = fedora-coreos-config
 	url = https://github.com/coreos/fedora-coreos-config
-	branch = rhcos-4.8
+	branch = testing-devel

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -32,10 +32,10 @@ repos:
   - rhel-8-server-ose
 
 # We include hours/minutes to avoid version number reuse
-automatic-version-prefix: "48.84.<date:%Y%m%d%H%M>"
+automatic-version-prefix: "49.84.<date:%Y%m%d%H%M>"
 # This ensures we're semver-compatible which OpenShift wants
 automatic-version-suffix: "-"
-mutate-os-release: "4.8"
+mutate-os-release: "4.9"
 
 documentation: false
 initramfs-args:

--- a/rhcos-packages.yaml
+++ b/rhcos-packages.yaml
@@ -10,7 +10,7 @@ packages:
   # installer iso packages
   - coreos-installer coreos-installer-bootinfra
   - ignition
-  - redhat-release-coreos-48.84 # Pinned for 8.4 Beta switch
+  - redhat-release-coreos
   ## Delivered via RHEL Base/Appstream (usually)
   # needed by rpm-ostree for managing users
   - nss-altfiles


### PR DESCRIPTION
`gitmodules: use testing-devel branch for fedora-coreos-config`

---

`gitmodules: use testing-devel branch for fedora-coreos-config`

Also bump submodule to HEAD of testing-devel

```
$ git shortlog --no-merges 6f39113b0bd0e40d783edcfedc69b93b0492b096..43eb8766112420a2a24d3f872da088bbd752aa48
Andy McCrae (1):
      Move comments in systemd services to own line

Colin Walters (3):
      coreos-boot-mount-generator: Move all "exit 0" checks to early on
      udev/90-coreos-device-mapper: Create label links in real root too
      coreos-boot-mount-generator: Always use mpath for /boot if rd.multipath

Dusty Mabe (1):
      overlay: initramfs teardown: add support for coreos.force_persist_ip karg

Jonathan Lebon (10):
      ignition-ostree-growfs: don't conditionalize on root= karg
      ignition-ostree-growfs: fix dependency to sysroot mount
      overlay: convert more unit descriptions to Title Case
      coreos-gpt-setup: log whether sgdisk was called
      ignition-ostree-uuid-root: also run if root= is provided
      live-generator: don't call `man bootup`
      Add support for multipath on firstboot
      coreos-gpt-setup: add support for multipath
      ignition-ostree-growfs: add support for multipath
      udev/90-coreos-device-mapper: ignore DM_ACTIVATION
```

---

`rhcos-packages: drop pin for 8.4 Beta`