### PR TITLE
kola-denylist: drop the crio.base test from the list

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -5,11 +5,6 @@
   tracker: https://bugzilla.redhat.com/show_bug.cgi?id=1782026
   arches:
    - s390x
-- pattern: crio.base
-  tracker: https://github.com/kubernetes/kubernetes/issues/87325
-  arches:
-   - s390x
-   - ppc64le
 # for s390x by-partlabel can't be used and even if that is avoided by using part-uuid, still depends on the cpi fix below
 - pattern: ext.config.var-mount
   tracker: https://github.com/ibm-s390-tools/s390-tools/pull/82


### PR DESCRIPTION
The upstream issue linked for the denylist entry was fixed/closed back
in Feb 2020, so let's turn on the tests again and see how we do.