### PR TITLE
overlay: combine reboots for FIPS and Ignition kargs

### DIFF
--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/30rhcos-afterburn-checkin/rhcos-afterburn-checkin.service
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/30rhcos-afterburn-checkin/rhcos-afterburn-checkin.service
@@ -22,12 +22,13 @@ ConditionKernelCommandLine=ignition.platform.id=azure
 # userdata, so we need to wait until after Ignition fetch.
 # (Waiting for fetch-offline is not sufficient if the config
 # references network resources, which it usually does in RHCOS.)
-#
-# In addition, the kargs stage might reboot the machine, after
-# which we need to be able to fetch the config again.  Removal
-# of the virtual CD persists across reboots, so we need to defer
-# it until after the kargs reboot.
-After=ignition-fetch.service ignition-kargs.service
+After=ignition-fetch.service
+
+# FIPS or Ignition kargs may schedule a reboot of the machine, which
+# happens in coreos-kargs-reboot.service.  Afterward we need to be
+# able to fetch the config again.  Removal of the virtual CD persists
+# across reboots, so defer it until after the kargs reboot.
+After=coreos-kargs-reboot.service
 
 [Service]
 Environment=AFTERBURN_OPT_PROVIDER=--cmdline

--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips.service
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips.service
@@ -16,11 +16,15 @@ Requires=dev-disk-by\x2dlabel-boot.device
 After=ignition-fetch.service
 Before=ignition-disks.service
 
-# We want to run to completion before check-in: if we immediately reboot for
-# FIPS, it'd be more appropriate to say we're up on that second boot. Also on
-# some platforms (like Azure), check-in "ejects" the user-data drive, so
-# Ignition can't fetch the config again.
-Before=rhcos-afterburn-checkin.service
+# We need to run either before or after the Ignition kargs stage to avoid
+# racing over the /boot mount and BLS changes.  The kargs stage uses
+# rdcore kargs --create-if-changed, which currently insists that the flag
+# file doesn't already exist, so we're currently constrained to run after
+# kargs: https://github.com/coreos/coreos-installer/pull/577
+After=ignition-kargs.service
+
+# We may signal the reboot service to reboot the machine
+Before=coreos-kargs-reboot.service
 
 # See comment about this in ignition-complete.target.
 OnFailure=emergency.target

--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips.sh
@@ -86,8 +86,10 @@ firstboot() {
            --parmfile $optfile
     fi
 
-    echo "Rebooting"
-    systemctl --force reboot
+    echo "Scheduling reboot"
+    # Write to /run/coreos-kargs-reboot to inform the reboot service so we
+    # can apply both kernel arguments & FIPS without multiple reboots
+    > /run/coreos-kargs-reboot
 }
 
 finish() {

--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips.sh
@@ -28,7 +28,6 @@ firstboot() {
     ign_usercfg_msg=$(journalctl -q MESSAGE_ID=57124006b5c94805b77ce473e92a8aeb IGNITION_CONFIG_TYPE=user)
     if [ -z "${ign_usercfg_msg}" ]; then
         noop "No Ignition config provided."
-        exit 0
     fi
     if [ ! -f "${IGNITION_CONFIG}" ]; then
         fatal "Missing ${IGNITION_CONFIG}"

--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips.sh
@@ -53,16 +53,10 @@ firstboot() {
             ;;
     esac
 
-    echo "FIPS mode required; updating BLS entries"
+    echo "FIPS mode required; updating BLS entry"
 
-    mkdir -p "${tmpsysroot}/boot"
-    mount /dev/disk/by-label/boot "${tmpsysroot}/boot"
-
-    for f in "${tmpsysroot}"/boot/loader/entries/*.conf; do
-        echo "Appending 'fips=1 boot=LABEL=boot' to ${f}"
-        sed -e "/^options / s/$/ fips=1 boot=LABEL=boot/" -i "$f"
-    done
-    sync -f "${tmpsysroot}/boot"
+    rdcore kargs --boot-device /dev/disk/by-label/boot \
+        --append fips=1 --append boot=LABEL=boot
 
     if [[ $(uname -m) = s390x ]]; then
       # Similar to https://github.com/coreos/coreos-assembler/commit/100c2e512ecb89786a53bfb1c81abc003776090d in the coreos-assembler


### PR DESCRIPTION
The FIPS and Ignition kargs reboots are entirely separate right now, and also race with each other.  Afterburn checkin also races with Ignition kargs because `ignition-kargs.service` doesn't handle the reboot itself.  Sequence all of these to avoid the races, and have the FIPS code write the same flag file read by `coreos-kargs-reboot.service` so it handles reboots for both.

Also use `rdcore kargs` to update the BLS entry rather than open-coding it, and do some other minor cleanups.

This should be covered by the existing kargs and FIPS tests.