### PR TITLE
manifest: Explicitly set rpmdb: bdb

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -31,6 +31,9 @@ repos:
   - rhel-8-fast-datapath-aarch64
   - rhel-8-server-ose
 
+# https://bugzilla.redhat.com/show_bug.cgi?id=1938928
+rpmdb: b-d-b
+
 # We include hours/minutes to avoid version number reuse
 automatic-version-prefix: "49.84.<date:%Y%m%d%H%M>"
 # This ensures we're semver-compatible which OpenShift wants


### PR DESCRIPTION
Since that's what it needs to be.  There is read-only
sqlite support queued in
https://bugzilla.redhat.com/show_bug.cgi?id=1938928
But we need read-write for package layering etc.

xref https://github.com/openshift/os/issues/552

This is effectively a no-op right now because the default
backend in F33 rpm-ostree is bdb, but by setting this
explicitly we'll get a useful error message after
https://github.com/coreos/rpm-ostree/pull/2978

And then ideally we teach rpm-ostree how to actually deal
with this.