### PR TITLE
manifest: chmod 600 /etc/sudoers.d/*

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -161,6 +161,13 @@ postprocess:
      # NB: we don't use -f here so we break when this is no longer needed
      rm -v /etc/iscsi/initiatorname.iscsi
 
+  # Make security scanners happy
+  # https://bugzilla.redhat.com/show_bug.cgi?id=1981979
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    chmod 600 /etc/sudoers.d/*
+
 etc-group-members:
   - wheel
   - sudo


### PR DESCRIPTION
Apparently there are security scanners that object to mode 644.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1981979.