### PR TITLE
rhcos-afterburn: Add original downstream commit message

### DIFF
--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/30rhcos-afterburn-checkin/rhcos-afterburn-checkin.service
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/30rhcos-afterburn-checkin/rhcos-afterburn-checkin.service
@@ -2,6 +2,19 @@
 Description=Afterburn (Check In - from the initramfs)
 ConditionKernelCommandLine=ignition.platform.id=azure
 
+# The history of this file dates to:
+# commit 008db31a69405f68f8927cfdb41666af7bdc8351
+# Commit:     Yu Qi Zhang <jerzhang@redhat.com>
+# CommitDate: Tue Aug 13 13:38:01 2019 -0400
+# Add an RHCOS specific initramfs checkin for Azure. Also disable
+# the checkin from the real root as that is redundant.
+# Context: this is for installer UX considerations. The provision
+# success check masks issues with Ignition configs because it runs
+# after Ignition (which may never conclude). Terraform will also
+# report that nothing is progressing (as it is waiting for the checkin
+# even though things are. Kube will do the actual health handling
+# for the machine.
+
 # Since we don't care about the actual success of the boot
 # from the OS perspective, check in as soon as we are able.
 #


### PR DESCRIPTION
When we imported the internal git repo to here we lost all the
history.  Since we touched this file recently and I found
myself wondering why it exists, let's copy the exact git commit
message (and timestamp) here so it isn't lost.

This file already has a comment which this partially duplicates,
but the commit message e.g. references Terraform and kube
which the existing comment does not.

I think we should try to dig up more of the original discussion
around this because we're already being bitten by this
nontrivial divergence between FCOS/RHCOS and we should think
really hard about a way to have OpenShift/Terraform work
well without this divergence.