### PR TITLE
overlay: add empty statoverride files in all overlays

### DIFF
--- a/overlay.d/05rhcos/statoverride
+++ b/overlay.d/05rhcos/statoverride
@@ -1,0 +1,2 @@
+# Config file for overriding permission bits on overlay files/dirs
+# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/06gcp-routes/statoverride
+++ b/overlay.d/06gcp-routes/statoverride
@@ -1,0 +1,2 @@
+# Config file for overriding permission bits on overlay files/dirs
+# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/15rhcos-logrotate/statoverride
+++ b/overlay.d/15rhcos-logrotate/statoverride
@@ -1,0 +1,2 @@
+# Config file for overriding permission bits on overlay files/dirs
+# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/15rhcos-tuned-bits/statoverride
+++ b/overlay.d/15rhcos-tuned-bits/statoverride
@@ -1,0 +1,2 @@
+# Config file for overriding permission bits on overlay files/dirs
+# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/21dhcp-chrony/statoverride
+++ b/overlay.d/21dhcp-chrony/statoverride
@@ -1,0 +1,2 @@
+# Config file for overriding permission bits on overlay files/dirs
+# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/25rhcos-azure-udev-rules/statoverride
+++ b/overlay.d/25rhcos-azure-udev-rules/statoverride
@@ -1,0 +1,2 @@
+# Config file for overriding permission bits on overlay files/dirs
+# Format: =<file mode in decimal> <absolute path to a file or directory>


### PR DESCRIPTION
This is a no-op, but helps document the functionality.

Part of https://github.com/coreos/coreos-assembler/pull/2293.