### PR TITLE
manifest.yaml: use `rpmdb: bdb`

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -32,7 +32,7 @@ repos:
   - rhel-8-server-ose
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1938928
-rpmdb: b-d-b
+rpmdb: bdb
 
 # We include hours/minutes to avoid version number reuse
 automatic-version-prefix: "49.84.<date:%Y%m%d%H%M>"


### PR DESCRIPTION
Both f33 and f34 rpm-ostree have
https://github.com/coreos/rpm-ostree/pull/2808, which fixed the casing
(and broke the broken casing). So we can safely use the correct one and
it'll work transparently on `cosa:rhcos-4.8` and `cosa:latest` once we
can move there.