### PR TITLE
ci: add debug information about cosa/rpm-ostree

### DIFF
--- a/ci/build-test-qemu.sh
+++ b/ci/build-test-qemu.sh
@@ -2,6 +2,9 @@
 set -xeuo pipefail
 # Prow jobs don't support adding emptydir today
 export COSA_SKIP_OVERLAY=1
+# record information about cosa + rpm-ostree
+jq . < /cosa/coreos-assembler-git.json
+rpm-ostree --version
 # We generate .repo files which write to the source, but
 # we captured the source as part of the Docker build.
 # In OpenShift default SCC we'll run as non-root, so we need


### PR DESCRIPTION
Similar to the downstream pipeline, let's record the information about
`coreos-assembler` and `rpm-ostree` being used in CI.