### PR TITLE
rhcos-packages: Make bootupd arch dependend

### DIFF
--- a/rhcos-packages.yaml
+++ b/rhcos-packages.yaml
@@ -5,8 +5,6 @@ packages:
   ## Delivered via RHAOS puddles
   # Extra runtime
   - afterburn
-  # Bootloader updater
-  - bootupd
   # User experience
   - console-login-helper-messages-issuegen console-login-helper-messages-profile
   # installer iso packages
@@ -23,3 +21,9 @@ packages:
   # for kdump:
   # https://github.com/coreos/fedora-coreos-tracker/issues/622
   - kexec-tools
+
+# See https://github.com/coreos/bootupd
+packages-x86_64:
+   - bootupd
+packages-aarch64:
+   - bootupd


### PR DESCRIPTION
Do not include bootupd for s390x and ppc64le

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>