### PR TITLE
extensions: Add oci-seccomp-bpf-hook

### DIFF
--- a/extensions.yaml
+++ b/extensions.yaml
@@ -11,6 +11,11 @@ extensions:
   usbguard:
     packages:
       - usbguard
+  # https://github.com/coreos/fedora-coreos-tracker/issues/887
+  # CMP-927
+  oci-seccomp-bpf-hook:
+    packages:
+      - oci-seccomp-bpf-hook
   # https://github.com/kmods-via-containers/kmods-via-containers/issues/3
   # https://gitlab.cee.redhat.com/coreos/redhat-coreos/merge_requests/866
   # These are currently overlaid onto the host so that they can be bind-mounted


### PR DESCRIPTION
The oci-seccomp-bpf-hook package enables recording of secomp profiles,
which, apart from being useful on its own, is a part of the Security
Profiles Operator:
    https://github.com/openshift/enhancements/pull/745

This package was previously evaluated for inclusion into FCOS:
    https://github.com/coreos/fedora-coreos-tracker/issues/887
and it was recommended that we try adding the hook as an extension
instead.

Note that bcc (a dependency of oci-seccomp-bpf-hook) seems to have a weak
dependency on bcc-tools which is not needed for this case. I'm unsure
if there is a way to tell the extensions system to not install the weak
dependency though.