### PR TITLE
kola-denylist: use string instead of list for tracker

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -6,9 +6,7 @@
   arches:
    - s390x
 - pattern: crio.base
-  tracker:
-    - https://github.com/kubernetes/kubernetes/issues/87325a
-    - https://bugzilla.redhat.com/show_bug.cgi?id=1986239
+  tracker: "https://github.com/kubernetes/kubernetes/issues/87325 && https://bugzilla.redhat.com/show_bug.cgi?id=1986239"
 # for s390x by-partlabel can't be used and even if that is avoided by using part-uuid, still depends on the cpi fix below
 - pattern: ext.config.var-mount
   tracker: https://github.com/ibm-s390-tools/s390-tools/pull/82


### PR DESCRIPTION
I strongly believe that I tested the use of a list in the denylist as
part of #595, but evidence says otherwise.