### PR TITLE
Revert "image: Switch to `ostree-format: oci`"

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -11,5 +11,3 @@ squashfs-compression: gzip
 # Disable networking by default on firstboot. We can drop this once cosa stops
 # defaulting to `ip=dhcp,dhcp6 rd.neednet=1` when it doesn't see this key.
 ignition-network-kcmdline: []
-
-ostree-format: "oci"


### PR DESCRIPTION
This reverts commit 8e0a9d20e8e286cf87ebe9442ba663c75bf3006e.

We need to ship https://github.com/ostreedev/ostree-rs-ext/pull/58
before we can do this.