### PR TITLE
manifest: adapt for rpm-ostree modularity support

### DIFF
--- a/extensions.yaml
+++ b/extensions.yaml
@@ -6,6 +6,11 @@ repos:
   - rhel-8-advanced-virt
   - rhel-8-nfv
 
+modules:
+  enable:
+    # for qemu-kiwi
+    - virt:av
+
 extensions:
   # https://github.com/coreos/fedora-coreos-tracker/issues/326
   usbguard:

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -261,6 +261,28 @@ packages:
  # https://github.com/openshift/machine-config-operator/pull/2421
  - conntrack-tools
 
+repo-packages:
+  # we always want the kernel from BaseOS
+  - repo: rhel-8-baseos
+    packages:
+      - kernel
+  # we want the one shipping in RHEL, not the equivalently versioned one in RHAOS
+  - repo: rhel-8-appstream
+    packages:
+      - nss-altfiles
+  - repo: rhel-8-server-ose
+    packages:
+      # eventually, we want the one from the container-tools module, but we're
+      # not there yet
+      - toolbox
+
+modules:
+  enable:
+    # podman stack
+    - container-tools:rhel8
+    # qemu-guest-agent
+    - virt:rhel
+
 packages-x86_64:
   # Temporary add of open-vm-tools. Should be removed when containerized
   - open-vm-tools

--- a/rhcos-packages.yaml
+++ b/rhcos-packages.yaml
@@ -16,7 +16,6 @@ packages:
   - nss-altfiles
   - ostree
   - rpm-ostree
-  # part of container-tools module
   - toolbox
   # for kdump:
   # https://github.com/coreos/fedora-coreos-tracker/issues/622


### PR DESCRIPTION
With the latest rpm-ostree support for modules, rpm-ostree will no
longer pull in modular packages by default, which is something we've
been relying on so far. So if we don't adapt, composes would start
failing. This is a good thing, because it forces us to be more explicit
wrt modularity:
1. enable the `container-tools:rhel8` module for the podman stack
2. enable the `virt:rhel` module for `qemu-guest-agent`

While we're here, use the new `repo-packages` key to clarify some more
of our intentions:
1. always pull in the `kernel` from BaseOS
2. always pull in `nss-altfiles` from AppStream
3. always pull in `toolbox` from RHAOS until we move over to the
   `container-tools:rhel8` one
4. always pull in `cri-o` and `conmon` from RHAOS to ensure they're
   synced

All of the choices above should just be a reflection of our current
stance. I've derived them from the various `exclude=` hacks we have in
our repo files internally, and analyzing where we're currently getting
what from. So this shouldn't significantly change our composes here.
Though I will note that we now drop quite a few `Perl`-related modular
packages, which I don't think we were pulling in intentionally.

This then also allows us to drop all the `exclude=` hacks as well.

Closes: https://github.com/coreos/rpm-ostree/issues/3035