### PR TITLE
ci: Allow build-test-qemu.sh to be called externally too

### DIFF
--- a/ci/build-test-qemu.sh
+++ b/ci/build-test-qemu.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 set -xeuo pipefail
+# record information about cosa + rpm-ostree
+if test -d /cosa; then
+    jq . < /cosa/coreos-assembler-git.json
+fi
+rpm-ostree --version
 # Prow jobs don't support adding emptydir today
 export COSA_SKIP_OVERLAY=1
-# record information about cosa + rpm-ostree
-jq . < /cosa/coreos-assembler-git.json
-rpm-ostree --version
 # We generate .repo files which write to the source, but
 # we captured the source as part of the Docker build.
 # In OpenShift default SCC we'll run as non-root, so we need
@@ -13,9 +15,18 @@ rpm-ostree --version
 # it or clone it.  Or we could write our .repo files to a separate
 # place.
 tmpsrc=$(mktemp -d)
-cp -a /src "${tmpsrc}"/src
 # Create a temporary cosa workdir
 cd "$(mktemp -d)"
+# This script runs on PRs to openshift/os *and* it should
+# support being called externally, in which case we expect
+# the git URI to be passed as an argument.
+if test -n "${1:-}"; then
+    git clone --depth=1 --recurse "$1" "${tmpsrc}/src"
+else
+    # We're being run in openshift/os as part of Prow, which
+    # built a `src` container with the code under test.
+    cp -a /src "${tmpsrc}"/src
+fi
 cosa init "${tmpsrc}"/src
 # Grab the raw value of `mutate-os-release` and use sed to convert the value
 # to X-Y format


### PR DESCRIPTION
Alternative to https://github.com/coreos/coreos-assembler/pull/2335
so that we can add CI on coreos-assembler that builds RHCOS.