### PR TITLE
ci: Rework again to aid execution via PRs to coreos-assembler

### DIFF
--- a/ci/build-test-qemu.sh
+++ b/ci/build-test-qemu.sh
@@ -1,42 +1,10 @@
 #!/bin/bash
 set -xeuo pipefail
-# record information about cosa + rpm-ostree
-if test -d /cosa; then
-    jq . < /cosa/coreos-assembler-git.json
-fi
-rpm-ostree --version
+# This script is the entrypoint for PRs to this repo via OpenShift Prow.
+dn=$(dirname $0)
 # Prow jobs don't support adding emptydir today
 export COSA_SKIP_OVERLAY=1
-# We generate .repo files which write to the source, but
-# we captured the source as part of the Docker build.
-# In OpenShift default SCC we'll run as non-root, so we need
-# to make a new copy of the source.  TODO fix cosa to be happy
-# if src/config already exists instead of wanting to reference
-# it or clone it.  Or we could write our .repo files to a separate
-# place.
-tmpsrc=$(mktemp -d)
 # Create a temporary cosa workdir
 cd "$(mktemp -d)"
-# This script runs on PRs to openshift/os *and* it should
-# support being called externally, in which case we expect
-# the git URI to be passed as an argument.
-if test -n "${1:-}"; then
-    git clone --depth=1 --recurse "$1" "${tmpsrc}/src"
-else
-    # We're being run in openshift/os as part of Prow, which
-    # built a `src` container with the code under test.
-    cp -a /src "${tmpsrc}"/src
-fi
-cosa init "${tmpsrc}"/src
-# Grab the raw value of `mutate-os-release` and use sed to convert the value
-# to X-Y format
-ocpver=$(rpm-ostree compose tree --print-only src/config/manifest.yaml | jq -r '.["mutate-os-release"]' | sed 's|\.|-|')
-curl -L http://base-"${ocpver}"-rhel8.ocp.svc.cluster.local > src/config/ocp.repo
-cosa fetch
-cosa build
-cosa buildextend-extensions
-cosa kola --basic-qemu-scenarios
-cosa kola run 'ext.*'
-# TODO: all tests in the future, but there are a lot
-# and we want multiple tiers, and we need to split them
-# into multiple pods and stuff.
+cosa init /src
+exec ${dn}/prow-build-test-qemu.sh

--- a/ci/prow-build-test-qemu.sh
+++ b/ci/prow-build-test-qemu.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+set -xeuo pipefail
+# This script is called via build-test-qemu.sh which is the main Prow
+# entrypoint for PRs to this repo, as well as for PRs on other repos,
+# mainly coreos-assembler.  It assumes that `cosa init` has been run.
+
+# record information about cosa + rpm-ostree
+if test -d /cosa; then
+    jq . < /cosa/coreos-assembler-git.json
+fi
+rpm-ostree --version
+
+# We generate .repo files which write to the source, but
+# we captured the source as part of the Docker build.
+# In OpenShift default SCC we'll run as non-root, so we need
+# to make a new copy of the source.  TODO fix cosa to be happy
+# if src/config already exists instead of wanting to reference
+# it or clone it.  Or we could write our .repo files to a separate
+# place.
+if test '!' -w src/config; then
+    git clone --recurse src/config src/config.writable
+    rm src/config -rf
+    mv src/config.writable src/config
+fi
+
+# Grab the raw value of `mutate-os-release` and use sed to convert the value
+# to X-Y format
+ocpver=$(rpm-ostree compose tree --print-only src/config/manifest.yaml | jq -r '.["mutate-os-release"]' | sed 's|\.|-|')
+curl -L http://base-"${ocpver}"-rhel8.ocp.svc.cluster.local > src/config/ocp.repo
+cosa fetch
+cosa build
+cosa buildextend-extensions
+cosa kola --basic-qemu-scenarios
+cosa kola run 'ext.*'
+# TODO: all tests in the future, but there are a lot
+# and we want multiple tiers, and we need to split them
+# into multiple pods and stuff.

--- a/ci/prow-thisrepo-entrypoint.sh
+++ b/ci/prow-thisrepo-entrypoint.sh
@@ -1,0 +1,1 @@
+build-test-qemu.sh


### PR DESCRIPTION
In working on https://github.com/openshift/release/pull/20929
I realized the previous PR https://github.com/openshift/os/pull/606
awkward to use.  Plus as jlebon pointed out we should support
branching.

Rework things so that as much shared code as possible lives in `prow-build-test-qemu.sh`
which assumes it's in a cosa workdir with a configured source git.

A key to avoiding duplication is using a conditional for testing
writability of `src/config`, and to do the clone dance internally
rather than externally.

The naming of scripts here is confusing; I created
`ci/prow-thisrepo-entrypoint.sh` which is a symlink to the existing
`build-test-qemu.sh`.  Then we can switch openshift/release over
to using the former, and drop the latter.