### PR TITLE
kola-denylist: enable crio test for all arches

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -5,8 +5,6 @@
   tracker: https://bugzilla.redhat.com/show_bug.cgi?id=1782026
   arches:
    - s390x
-- pattern: crio.base
-  tracker: "https://github.com/kubernetes/kubernetes/issues/87325 && https://bugzilla.redhat.com/show_bug.cgi?id=1986239"
 # for s390x by-partlabel can't be used and even if that is avoided by using part-uuid, still depends on the cpi fix below
 - pattern: ext.config.var-mount
   tracker: https://github.com/ibm-s390-tools/s390-tools/pull/82


### PR DESCRIPTION
With https://github.com/coreos/coreos-assembler/pull/2359 landing and now that the pause image has been building on all arches for a while, enable the crio test for all arches.