### PR TITLE
image: Switch to `ostree-format: oci`

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -11,3 +11,5 @@ squashfs-compression: gzip
 # Disable networking by default on firstboot. We can drop this once cosa stops
 # defaulting to `ip=dhcp,dhcp6 rd.neednet=1` when it doesn't see this key.
 ignition-network-kcmdline: []
+
+ostree-format: "oci"


### PR DESCRIPTION
This is a re-submit; we reverted in https://github.com/openshift/os/pull/601
but the issue is fixed with newer rpm-ostree.

This is the RHCOS version of https://github.com/coreos/fedora-coreos-config/pull/1097

I was hoping to land this in FCOS first but I'm kind of blocked
on that in https://github.com/coreos/fedora-coreos-pipeline/issues/359, so
let's settle for parallel.

NOTE!  This **does not change** the effect of `cosa upload-oscontainer` etc.
Some discussion on that here:
https://github.com/ostreedev/ostree-rs-ext/issues/23
and I will file more issues related to that.

However, what this *will* do is allow us to push this *additional* image
arounnd and make `podman run registry.ci.openshift.org/rhcos/rhcos:4.8` e.g.
work.  In other words to start this will just be something *we* use
to quickly inspect rhcos-as-container, not something we actually ship.
(OK that's kind of a lie, it will end up in a place like e.g.
 http://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/pre-release/4.9.0-0.nightly-2021-07-20-014024/
 instead of the existing `ostree.tar` so in theory other people outside
 of our group could run it too, but 🤫)