### PR TITLE
ci: Run upgrade tests and all kola tests (--parallel 2)

### DIFF
--- a/ci/prow-build-test-qemu.sh
+++ b/ci/prow-build-test-qemu.sh
@@ -31,7 +31,6 @@ cosa fetch
 cosa build
 cosa buildextend-extensions
 cosa kola --basic-qemu-scenarios
-cosa kola run 'ext.*'
-# TODO: all tests in the future, but there are a lot
-# and we want multiple tiers, and we need to split them
-# into multiple pods and stuff.
+kola run-upgrade -b rhcos -v --find-parent-image --qemu-image-dir tmp/ --output-dir tmp/kola-upgrade
+cosa kola run --parallel 2
+


### PR DESCRIPTION
Turns out the `image-format: oci` change broke the rhcos upgrade
test, let's add coverage of that.

While we have the patient open, also run all kola tests.