### PR TITLE
Revert "image: Switch to `ostree-format: oci`"

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -11,5 +11,3 @@ squashfs-compression: gzip
 # Disable networking by default on firstboot. We can drop this once cosa stops
 # defaulting to `ip=dhcp,dhcp6 rd.neednet=1` when it doesn't see this key.
 ignition-network-kcmdline: []
-
-ostree-format: "oci"


### PR DESCRIPTION
This reverts commit 7a4d1bcc96719ecdb605597cc64e1be9b255ac8b.

Need to fix the rhcos upgrade test in coreos-assembler.