### PR TITLE
manifest: force container-selinux from OSE repo

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -275,6 +275,10 @@ repo-packages:
       # eventually, we want the one from the container-tools module, but we're
       # not there yet
       - toolbox
+      # we tagged a new version of container-selinux so that we can include the fix
+      # for RHBZ#1999245 in RHCOS 4.9
+      # TODO: this should be dropped when the next RHEL 8.4.z release happens
+      - container-selinux
 
 modules:
   enable:


### PR DESCRIPTION
We tagged a new version of `container-selinux` for inclusion in RHCOS
4.9 in order to fix RHBZ#1999245. So we have to specify that we want
it to come from the `rhel-8-ose-server` repo instead of the normal
RHEL repo.