### PR TITLE
kola-denylist: exclude multipath.day1 temporarily on s390x

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -12,3 +12,7 @@
    - s390x
 - pattern: coreos.ignition.journald-log
   tracker: https://github.com/coreos/coreos-assembler/issues/1173
+- pattern: multipath.day1
+  tracker: https://github.com/openshift/os/issues/615
+  arches:
+   - s390x


### PR DESCRIPTION
multipath.day1 test is failing on s390x because coreos-installer has not been updated to the latest to include the fix to run zipl (https://github.com/coreos/coreos-installer/pull/533)
@jschintag has opened https://src.osci.redhat.com/rpms/coreos-installer/pull-request/28 which updates coreos-installer to 0.10.0, but in the meanwhile, exclude the test so pipeline builds are not blocked.

Update: Now this test is blocked by https://bugzilla.redhat.com/show_bug.cgi?id=1974411