### PR TITLE
40rhcos-fips: drop redundant zipl run with coreos-installer 0.10.0

### DIFF
--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/module-setup.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/module-setup.sh
@@ -17,12 +17,6 @@ install() {
         bwrap \
         env
 
-    local _arch=${DRACUT_ARCH:-$(uname -m)}
-    if [[ "$_arch" == "s390x" ]]; then
-        inst_multiple zipl
-        inst /lib/s390-tools/stage3.bin
-    fi
-
     inst_script "$moddir/rhcos-fips.sh" \
         "/usr/sbin/rhcos-fips"
     inst_script "$moddir/coreos-dummy-ignition-files-run.sh" \

--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips.service
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips.service
@@ -17,10 +17,7 @@ After=ignition-fetch.service
 Before=ignition-disks.service
 
 # We need to run either before or after the Ignition kargs stage to avoid
-# racing over the /boot mount and BLS changes.  The kargs stage uses
-# rdcore kargs --create-if-changed, which currently insists that the flag
-# file doesn't already exist, so we're currently constrained to run after
-# kargs: https://github.com/coreos/coreos-installer/pull/577
+# racing over the /boot mount and BLS changes.
 After=ignition-kargs.service
 
 # We may signal the reboot service to reboot the machine


### PR DESCRIPTION
cc @jlebon @nikita-dubrovskii 