### PR TITLE
Revert "manifest: force container-selinux from OSE repo"

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -275,10 +275,6 @@ repo-packages:
       # eventually, we want the one from the container-tools module, but we're
       # not there yet
       - toolbox
-      # we tagged a new version of container-selinux so that we can include the fix
-      # for RHBZ#1999245 in RHCOS 4.9
-      # TODO: this should be dropped when the next RHEL 8.4.z release happens
-      - container-selinux
 
 modules:
   enable:


### PR DESCRIPTION
This reverts commit cb6bfa845cc9d0d8ed01323a7719d118e67515c1.

This should allow us to build RHCOS from `master` (i.e. 4.10), but
causes us to lose the fix for RHBZ#1999245.

The version of `container-selinux` that includes the fix for the BZ
has been requested to be tagged for 4.10, so we can revert this revert
once that happens.