### PR TITLE
manifest: bump version strings to 4.10

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -35,10 +35,10 @@ repos:
 rpmdb: bdb
 
 # We include hours/minutes to avoid version number reuse
-automatic-version-prefix: "49.84.<date:%Y%m%d%H%M>"
+automatic-version-prefix: "410.84.<date:%Y%m%d%H%M>"
 # This ensures we're semver-compatible which OpenShift wants
 automatic-version-suffix: "-"
-mutate-os-release: "4.9"
+mutate-os-release: "4.10"
 
 documentation: false
 initramfs-args:


### PR DESCRIPTION
Our `master` branch is now targeting 4.10, so update the manifest
accordingly.