### PR TITLE
Revert "Revert "manifest: force container-selinux from OSE repo""

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -275,6 +275,10 @@ repo-packages:
       # eventually, we want the one from the container-tools module, but we're
       # not there yet
       - toolbox
+      # we tagged a new version of container-selinux so that we can include the fix
+      # for RHBZ#1999245 in RHCOS 4.9
+      # TODO: this should be dropped when the next RHEL 8.4.z release happens
+      - container-selinux
 
 modules:
   enable:


### PR DESCRIPTION
This reverts commit 03db2130ecaf3c3a0bb6e4a18b7a037695bd8b9e.

The necessary build of `container-selinux` is available in the 4.10
plashet, so we can start requiring it come from the OSE repo again.