### PR TITLE
manifest: only install vmw_pvscsi on x86_64

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -17,6 +17,7 @@ arch-include:
   x86_64:
     - fedora-coreos-config/manifests/grub2-removals.yaml
     - fedora-coreos-config/manifests/bootupd.yaml
+    - x86_64_initramfs.yaml
   ppc64le: fedora-coreos-config/manifests/grub2-removals.yaml
   aarch64:
     - fedora-coreos-config/manifests/grub2-removals.yaml
@@ -44,7 +45,7 @@ documentation: false
 initramfs-args:
   - "--no-hostonly"
   - "--add-drivers"
-  - "mptspi vmw_pvscsi"
+  - "mptspi"
   - "--omit-drivers"
   - "nouveau"
   - "--omit"

--- a/x86_64_initramfs.yaml
+++ b/x86_64_initramfs.yaml
@@ -1,0 +1,9 @@
+# This contains x86_64 specific configuration for the RHCOS initramfs.
+
+# It appears the VMWare paravirtualized SCSI driver is only available on
+# x86_64, so trying to install it as a dracut module in the initramfs fails
+# on other platforms.
+initramfs-args:
+  - "--add-drivers"
+  - "vmw_pvscsi"
+


### PR DESCRIPTION
While reviewing the RHCOS build logs for s390x + ppc64le, it was
observed that the installation of the `vmw_pvscsi` module in the
initramfs failed with:

```
dracut-install: Failed to find module 'vmw_pvscsi'
dracut: FAILED:  /usr/lib/dracut/dracut-install -D /tmp/dracut/dracut.aNQ72V/initramfs -N nouveau --kerneldir /lib/modules/4.18.0-305.19.1.el8_4.ppc64le/ -m mptspi vmw_pvscsi
```

From an inspection of the downstream kernel build logs and
`kernel*.rpm`, it appears that module is not built for non-x86_64
arches.

This change splits out the inclusion of that module in the initramfs
to an x86_64-only manifest file.