### PR TITLE
Bug 2003743: tests/kdump: Only run on x86_64 & aarch64

### DIFF
--- a/tests/kola/kdump/test.sh
+++ b/tests/kola/kdump/test.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 set -xeuo pipefail
 # https://docs.fedoraproject.org/en-US/fedora-coreos/debugging-kernel-crashes/
-# Only run on QEMU for now:
+# Only run on QEMU and x86_64 & aarch64 for now:
 # https://github.com/coreos/fedora-coreos-tracker/issues/860
-# kola: {"platforms": "qemu-unpriv", "minMemory": 4096, "tags": "skip-base-checks"}
+# kola: {"platforms": "qemu-unpriv", "minMemory": 4096, "tags": "skip-base-checks", "architectures": "x86_64 aarch64"}
 
 fatal() {
     echo "$@" >&2


### PR DESCRIPTION
The test is currently failing on ppc64le & s390x. Limit to x86_64 &
aarch64 only to unblock the pipelines while we figure out the issue.