### PR TITLE
manifest: use default VMWare driver config in initramfs

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -43,8 +43,6 @@ mutate-os-release: "4.10"
 documentation: false
 initramfs-args:
   - "--no-hostonly"
-  - "--add-drivers"
-  - "mptspi vmw_pvscsi"
   - "--omit-drivers"
   - "nouveau"
   - "--omit"


### PR DESCRIPTION
During the initial bringup of RHCOS, we explicitly added the VMWare
drivers to the initramfs.  See #373 and the commit on the internal
`redhat-coreos` repo[1].

It was recently noticed that the instruction in the manifest to add
these drivers explicitly was failing on non-x86_64 platforms:

```
dracut-install: Failed to find module 'vmw_pvscsi'
dracut: FAILED:  /usr/lib/dracut/dracut-install -D /tmp/dracut/dracut.aNQ72V/initramfs -N nouveau --kerneldir /lib/modules/4.18.0-305.19.1.el8_4.ppc64le/ -m mptspi vmw_pvscsi
```

After some investigation, it was discovered that these drivers are
included in the initramfs by default on x86_64 platforms, so we can
remove the instructions in the manifest to have them included. This
should avoid the above error on non-x86_64 platforms in the future.

[1] https://url.corp.redhat.com/rhcos-pvscsi