### PR TITLE
[release-4.8] test: add test to check rhaos package versions

### DIFF
--- a/tests/kola/misc-ro/misc-ro.sh
+++ b/tests/kola/misc-ro/misc-ro.sh
@@ -166,3 +166,9 @@ if test -f /usr/lib/systemd/system/console-login-helper-messages-issuegen.servic
   fi
 fi
 echo "ok console-login-helper-messages presets present"
+
+# Check that rhaos packages do not match the OpenShift version
+if [[ $(rpm -qa | grep rhaos | grep -v $OPENSHIFT_VERSION) ]]; then
+  fatal "Error: rhaos packages do not match OpenShift version"
+fi
+


### PR DESCRIPTION
Add test to verify that rhaos package versions match the OpenShift
version.

This is a cherry-pick of https://github.com/openshift/os/pull/635