### PR TITLE
Bug 2009652: [release-4.9] Enable multipath.day1 test again for s390x

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -12,7 +12,3 @@
    - s390x
 - pattern: coreos.ignition.journald-log
   tracker: https://github.com/coreos/coreos-assembler/issues/1173
-- pattern: multipath.day1
-  tracker: https://github.com/openshift/os/issues/615
-  arches:
-   - s390x


### PR DESCRIPTION
The coreos-installer rpm has been updated with the fix.
Re-enable multipath.day1 test for s390x.

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>