### PR TITLE
Bug 2009467: Revert "Revert "Revert "manifest: force container-selinux from OSE repo"""

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -275,10 +275,6 @@ repo-packages:
       # eventually, we want the one from the container-tools module, but we're
       # not there yet
       - toolbox
-      # we tagged a new version of container-selinux so that we can include the fix
-      # for RHBZ#1999245 in RHCOS 4.9
-      # TODO: this should be dropped when the next RHEL 8.4.z release happens
-      - container-selinux
 
 modules:
   enable:


### PR DESCRIPTION
There was an async release of the `container-tools` module that has
the necessary `container-selinux` RPM we want, so we can start
consuming this from RHEL proper.

https://access.redhat.com/errata/RHBA-2021:3661

This reverts commit d5bb0ecb4e565514869575d6d69ce5bb23007c3c.

(cherry picked from commit 5a069ff5990c75c237d15672c29db7c6bf887d5c)