### PR TITLE
COS-2611: Use deploy-via-container

### DIFF
--- a/image-c9s.yaml
+++ b/image-c9s.yaml
@@ -1,6 +1,9 @@
 # See https://github.com/coreos/coreos-assembler/pull/298
 size: 16
 
+# We default to a container image
+deploy-via-container: true
+
 # Disable networking by default on firstboot. We can drop this once cosa stops
 # defaulting to `ip=dhcp,dhcp6 rd.neednet=1` when it doesn't see this key.
 ignition-network-kcmdline: []

--- a/image-rhel-9.2.yaml
+++ b/image-rhel-9.2.yaml
@@ -1,6 +1,9 @@
 # See https://github.com/coreos/coreos-assembler/pull/298
 size: 16
 
+# We default to a container image
+deploy-via-container: true
+
 # Disable networking by default on firstboot. We can drop this once cosa stops
 # defaulting to `ip=dhcp,dhcp6 rd.neednet=1` when it doesn't see this key.
 ignition-network-kcmdline: []


### PR DESCRIPTION
Use `deploy-via-container`

This will cause us to run through the ostree-native container
stack when generating the disk images.

Today for RHCOS we're using the "custom origin" stuff which
lets us inject metadata about the built source, but rpm-ostree
doesn't understand it.

With this in the future (particularly after https://github.com/coreos/coreos-assembler/issues/2685)
`rpm-ostree status` will show the booted container and *understand it*;
for example in theory we could have `rpm-ostree upgrade` work (if
we provisioned from a tag instead of a digest).

A side benefit is this should fix https://github.com/coreos/coreos-assembler/issues/2685
because we're now pulling a single large file over 9p instead of lots
of little ones.

---

