### PR TITLE
Bug 2017471: ensure nss-altfiles comes from AppStream

### DIFF
--- a/rhcos-packages.yaml
+++ b/rhcos-packages.yaml
@@ -13,7 +13,8 @@ packages:
   - redhat-release-coreos-48.84 # Pinned for 8.4 Beta switch
   ## Delivered via RHEL Base/Appstream (usually)
   # needed by rpm-ostree for managing users
-  - nss-altfiles
+  # pin to this version to ensure it comes from AppStream
+  - nss-altfiles-2.18.1-12.el8
   - ostree
   - rpm-ostree
   # part of container-tools module


### PR DESCRIPTION
In #637, it was observed that `nss-altfiles` could come from the RHAOS
repos, which is unnecessary since the same version exists in the RHEL8
AppStream repos.  The package has since been untagged from the RHAOS
repo, but to ensure that we always get the package from AppStream we'll
pin to the specific version.  (The version hasn't changed since Apr 2019)