### PR TITLE
Bug 2023836: gitmodules: change f-c-c branch to rhcos-4.9

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "fedora-coreos-config"]
 	path = fedora-coreos-config
 	url = https://github.com/coreos/fedora-coreos-config
-	branch = testing-devel
+	branch = rhcos-4.9


### PR DESCRIPTION
I pushed an `rhcos-4.9` branch to fedora-coreos-config (based on
coreos/fedora-coreos-config@7d3c177f43af646bac634bd0e8fbcedab27e887e),
so we should start using that branch for 4.9 builds.