### PR TITLE
ci: enable use of buildfetch

### DIFF
--- a/ci/prow-build-test-qemu.sh
+++ b/ci/prow-build-test-qemu.sh
@@ -4,6 +4,8 @@ set -xeuo pipefail
 # entrypoint for PRs to this repo, as well as for PRs on other repos,
 # mainly coreos-assembler.  It assumes that `cosa init` has been run.
 
+REDIRECTOR_URL="https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/"
+
 # record information about cosa + rpm-ostree
 if test -d /cosa; then
     jq . < /cosa/coreos-assembler-git.json
@@ -26,7 +28,9 @@ fi
 # Grab the raw value of `mutate-os-release` and use sed to convert the value
 # to X-Y format
 ocpver=$(rpm-ostree compose tree --print-only src/config/manifest.yaml | jq -r '.["mutate-os-release"]' | sed 's|\.|-|')
+prev_build_url=${REDIRECTOR_URL}/rhcos-${ocpver}/
 curl -L http://base-"${ocpver}"-rhel8.ocp.svc.cluster.local > src/config/ocp.repo
+cosa buildfetch --url=${prev_build_url}
 cosa fetch
 cosa build
 cosa buildextend-extensions


### PR DESCRIPTION
This changes the CI job to fetch the last previous build metadata available
from the redirector URL, so that we are able to have some ability to
see what kind of RPM changes (if any) are introduced by changes in the upstream
repos/environment.