### PR TITLE
denylist: add crio.base

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -7,3 +7,5 @@
    - s390x
 - pattern: coreos.ignition.journald-log
   tracker: https://github.com/coreos/coreos-assembler/issues/1173
+- pattern: crio.base
+  tracker: https://github.com/openshift/os/issues/674


### PR DESCRIPTION
This is failing on all arches right now and no resolution in sight;
let's skip this test for now.

See: https://github.com/openshift/os/issues/674