### PR TITLE
Revert "denylist: add crio.base"

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -7,5 +7,3 @@
    - s390x
 - pattern: coreos.ignition.journald-log
   tracker: https://github.com/coreos/coreos-assembler/issues/1173
-- pattern: crio.base
-  tracker: https://github.com/openshift/os/issues/674


### PR DESCRIPTION
`crio-1.23.0-24` has the `crio.conf` change discussed in #674 reverted
and is now passing the `crio.base` test again.

This reverts commit 58e7e8f05e2ea45ebdee8c39569c5c1778d5d0c1.