### PR TITLE
25rhcos-azure-udev-rules: add 50-azure-ptp.rules

### DIFF
--- a/overlay.d/25rhcos-azure-udev-rules/usr/lib/udev/rules.d/50-azure-ptp.rules
+++ b/overlay.d/25rhcos-azure-udev-rules/usr/lib/udev/rules.d/50-azure-ptp.rules
@@ -1,0 +1,5 @@
+# Manual backport of:
+# https://github.com/systemd/systemd/commit/32e868f058da8b90add00b2958c516241c532b70
+# Can drop once we get to RHEL 8.6:
+# https://bugzilla.redhat.com/show_bug.cgi?id=1991834
+SUBSYSTEM=="ptp", ATTR{clock_name}=="hyperv", SYMLINK += "ptp_hyperv"

--- a/tests/kola/version/drop-azure-ptp
+++ b/tests/kola/version/drop-azure-ptp
@@ -1,0 +1,13 @@
+#!/bin/bash
+# kola: { "exclusive": false }
+set -xeuo pipefail
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+if [ -e /usr/lib/udev/rules.d/50-azure-ptp.rules ] && \
+    grep ptp_hyperv /usr/lib/udev/rules.d/50-udev-default.rules; then
+  fatal "50-udev-default.rules includes ptp_hyperv symlink; drop 50-azure-ptp.rules"
+fi


### PR DESCRIPTION
This will create the `/dev/ptp_hyperv` symlink. We'll need this once our
chrony generator uses it:

https://github.com/coreos/fedora-coreos-config/pull/1355