### PR TITLE
Use new `overlay.d/cosa-no-autolayer` option

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -14,6 +14,17 @@ include:
   # RHCOS owned packages
   - rhcos-packages.yaml
 
+ostree-layers:
+  - overlay/01fcos
+  - overlay/02fcos-nouveau
+  - overlay/05rhcos
+  - overlay/06gcp-routes
+  - overlay/15rhcos-logrotate
+  - overlay/15rhcos-tuned-bits
+  - overlay/20platform-chrony
+  - overlay/21dhcp-chrony
+  - overlay/25rhcos-azure-udev-rules
+
 arch-include:
   x86_64:
     - fedora-coreos-config/manifests/grub2-removals.yaml

--- a/overlay.d/README.md
+++ b/overlay.d/README.md
@@ -1,3 +1,8 @@
+These overlay directories are automatically committed to the build OSTree repo
+by coreos-assembler. They are then explicitly included in our various manifest
+files via `ostree-layers` (this used to be done automatically, but that's no
+longer the case).
+
 01fcos
 ------
 


### PR DESCRIPTION
Tell coreos-assembler to not automatically add the overlays to the final
manifest. Add references to the auto-generated OSTree layers in our
manifest.

This isn't strictly necessary for RHCOS like it is for FCOS because the
branching model is simpler here. But doing this will allow us to not
support it both ways in cosa and make this the default behaviour so we
can drop the stamp file.

Requires: https://github.com/coreos/coreos-assembler/pull/2641