### PR TITLE
tests/kola/version/toolbox: check we have the correct toolbox version

### DIFF
--- a/tests/kola/version/toolbox
+++ b/tests/kola/version/toolbox
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This is RHCOS only, we ship a different version of toolbox in FCOS
+
+# kola: { "exclusive": false }
+set -xeuo pipefail
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+# make it a var so we can change when/if we switch to containers/toolbox
+url="https://github.com/coreos/toolbox"
+
+if [ "$(rpm -q --qf '%{URL}' toolbox)" != "${url}" ]; then
+    fatal "Error: toolbox is not a shell script as expected"
+fi


### PR DESCRIPTION
We want to keep shipping the version of `toolbox` from
https://github.com/coreos/toolbox in RHCOS for the time being. But it
is easy for the RHEL dist-git of `toolbox` to get updated without us
being notified, so let's put a simple check in place to make sure we
are getting the bash script version and not the golang version.