### PR TITLE
ci: fix url passed to buildfetch

### DIFF
--- a/ci/prow-build-test-qemu.sh
+++ b/ci/prow-build-test-qemu.sh
@@ -27,9 +27,10 @@ fi
 
 # Grab the raw value of `mutate-os-release` and use sed to convert the value
 # to X-Y format
-ocpver=$(rpm-ostree compose tree --print-only src/config/manifest.yaml | jq -r '.["mutate-os-release"]' | sed 's|\.|-|')
+ocpver=$(rpm-ostree compose tree --print-only src/config/manifest.yaml | jq -r '.["mutate-os-release"]')
+ocpver_mut=$(rpm-ostree compose tree --print-only src/config/manifest.yaml | jq -r '.["mutate-os-release"]' | sed 's|\.|-|')
 prev_build_url=${REDIRECTOR_URL}/rhcos-${ocpver}/
-curl -L http://base-"${ocpver}"-rhel8.ocp.svc.cluster.local > src/config/ocp.repo
+curl -L http://base-"${ocpver_mut}"-rhel8.ocp.svc.cluster.local > src/config/ocp.repo
 cosa buildfetch --url=${prev_build_url}
 cosa fetch
 cosa build


### PR DESCRIPTION
The URL that is currently passed to `cosa buildfetch` does not exist
because we were using the mutated string that is used for the yum
repos.  Change the URL to be the un-mutated version for `buildfetch`
and the mutated version for the yum repos.