### PR TITLE
manifest.yaml: document pinned container-tools packages

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -285,15 +285,24 @@ repo-packages:
       # eventually, we want the one from the container-tools module, but we're
       # not there yet
       - toolbox
-      # we are going to start pulling the whole container-tools stack from the
-      # OCP repo
+      # These are the only container stack packages we don't get from modularity
+      # nor from base RHEL for various reasons. See:
+      # https://github.com/openshift/os/pull/681#issuecomment-1022443830
+      #
+      # newer than what is included in RHEL 8.4.Z EUS, but addresses some BZs
+      # that customers were encountering
       - container-selinux
+      # newer than what is included in RHEL 8.4.Z EUS, because the k8s folks
+      # wanted to start testing with 1.x versions of crun
       - crun
+      # slightly newer than what is included in RHEL 8.4.Z EUS, because we had
+      # previously shipped a newer version in OCP/RHCOS 4.9 and had to preserve
+      # the upgrade path
       - runc
 
 modules:
   enable:
-    # podman stack
+    # podman stack; see https://github.com/openshift/os/pull/681#issuecomment-1022443830
     - container-tools:rhel8
     # qemu-guest-agent
     - virt:rhel


### PR DESCRIPTION
For the container stack, we currently default to obtaining everything
from `container-tools:rhel8` but there are some exceptions. Document
them as per:

https://github.com/openshift/os/pull/681#issuecomment-1022443830