### PR TITLE
manifest: bump version strings to 4.11

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -47,10 +47,10 @@ repos:
 rpmdb: bdb
 
 # We include hours/minutes to avoid version number reuse
-automatic-version-prefix: "410.84.<date:%Y%m%d%H%M>"
+automatic-version-prefix: "411.84.<date:%Y%m%d%H%M>"
 # This ensures we're semver-compatible which OpenShift wants
 automatic-version-suffix: "-"
-mutate-os-release: "4.10"
+mutate-os-release: "4.11"
 
 documentation: false
 initramfs-args:


### PR DESCRIPTION
Our `master` branch is now targeting 4.11, so update the manifest
accordingly.