### PR TITLE
ci: add same tests as downstream pipeline

### DIFF
--- a/ci/prow-build-test-qemu.sh
+++ b/ci/prow-build-test-qemu.sh
@@ -38,4 +38,19 @@ cosa buildextend-extensions
 cosa kola --basic-qemu-scenarios
 kola run-upgrade -b rhcos -v --find-parent-image --qemu-image-dir tmp/ --output-dir tmp/kola-upgrade
 cosa kola run --parallel 2
-
+# Build metal + installer now so we can test them
+cosa buildextend-metal && cosa buildextend-metal4k && cosa buildextend-live
+# compress the metal and metal4k images now so we're testing
+# installs with the image format we ship
+cosa compress --artifact=metal --artifact=metal4k
+# Running testiso scenarios on metal artifact
+kola testiso -S --scenarios pxe-install,pxe-offline-install,iso-install,iso-offline-install,iso-live-login,iso-as-disk --output-dir tmp/kola-metal
+# iso-install scenario to sanity-check the metal4k media
+kola testiso -S --qemu-native-4k --qemu-multipath --scenarios iso-install --output-dir tmp/kola-metal4k
+if [ $(uname -i) = x86_64 ] || [ $(uname -i) = aarch64 ]; then
+    mkdir -p tmp/kola-uefi
+    kola testiso -S --qemu-firmware uefi --scenarios iso-live-login,iso-as-disk --output-dir tmp/kola-uefi/insecure
+    if [ $(uname -i) = x86_64 ]; then
+        kola testiso -S --qemu-firmware uefi-secure --scenarios iso-live-login,iso-as-disk --output-dir tmp/kola-uefi/secure
+    fi
+fi


### PR DESCRIPTION
Expand CI jobs to run same tests as downstream pipeline so we get more feedback early and often.

Jira: https://issues.redhat.com/browse/COS-793