### PR TITLE
packages: Install NetworkManager-config-server

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -227,6 +227,7 @@ packages:
  - openvswitch2.15
  - dnsmasq
  - NetworkManager-ovs
+ - NetworkManager-config-server
  # Extra runtime
  - sssd
  # Common tools used by scripts and admins interactively


### PR DESCRIPTION
There is a bug [1] related to kubernetes-nmstate since nmstate does not
support multipath. This change add the mentioned RPM to fix the issue.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2048988#c15