### PR TITLE
Bug 2052666: change gitmodules to rhcos-4.10 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "fedora-coreos-config"]
 	path = fedora-coreos-config
 	url = https://github.com/coreos/fedora-coreos-config
-	branch = testing-devel
+	branch = rhcos-4.10


### PR DESCRIPTION
Point the gitmodules to the rhcos-4.10 branch of fedora-coreos-config