### PR TITLE
s390x: snooze failing tests till 2022-02-28

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -11,3 +11,13 @@
   tracker: https://bugzilla.redhat.com/show_bug.cgi?id=1899990
   arches:
   - s390x
+- pattern: ext.config.shared.ignition.stable-boot
+  tracker: https://github.com/openshift/os/issues/710
+  snooze: 2022-02-28
+  arches:
+  - s390x
+- pattern: ext.config.shared.var-mount.scsi-id
+  tracker: https://github.com/openshift/os/issues/710
+  snooze: 2022-02-28
+  arches:
+  - s390x


### PR DESCRIPTION
Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>