### PR TITLE
manifest: bump to openvswitch2.16

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -224,7 +224,7 @@ packages:
  - cri-o cri-tools
  # Networking
  - nfs-utils
- - openvswitch2.15
+ - openvswitch2.16
  - dnsmasq
  - NetworkManager-ovs
  # Extra runtime


### PR DESCRIPTION
We want to keep host OVS and container OVS synchronized as much
as possible, plus OVS 2.16 is the first release that can take
advantage of kernel features like per-cpu dispatch (if the kernel
has it).

@trozet 