### PR TITLE
.gitignore: add content_sets.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /*.repo
+/content_sets.yaml


### PR DESCRIPTION
Along with the repo files, it's copied over from the internal
redhat-coreos repo.