### PR TITLE
Verify kata-osbuilder-generate.service as part of the default presets

### DIFF
--- a/tests/kola/files/kata-osbuilder
+++ b/tests/kola/files/kata-osbuilder
@@ -1,0 +1,22 @@
+#!/bin/bash
+# kola: { "exclusive": false }
+# check that `kata-osbuilder-generate.service` as part of the default presets
+# - defined in /usr/lib/systemd/system-preset/45-rhcos-extensions.preset
+# See:
+# - https://bugzilla.redhat.com/show_bug.cgi?id=1941342
+# - https://github.com/openshift/os/pull/524
+
+set -xeuo pipefail
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+config="/usr/lib/systemd/system-preset/45-rhcos-extensions.preset"
+
+service="enable kata-osbuilder-generate.service"
+if ! grep -q "${service}" ${config}; then
+    fatal "Error: missing '${service}' in ${config}"
+fi
+echo "ok verify '${service}' in ${config}"


### PR DESCRIPTION
See:
- https://bugzilla.redhat.com/show_bug.cgi?id=1941342
- https://github.com/openshift/os/pull/524/files