### PR TITLE
Remove FDP puddle for aarch64

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -28,7 +28,6 @@ repos:
   - rhel-8-baseos
   - rhel-8-appstream
   - rhel-8-fast-datapath
-  - rhel-8-fast-datapath-aarch64
   - rhel-8-server-ose
 
 # We include hours/minutes to avoid version number reuse


### PR DESCRIPTION
Now that FDP is shipped for aarch64 we should not be using the FDP
puddle for Arm.