### PR TITLE
extensions: add kerberos extension

### DIFF
--- a/extensions.yaml
+++ b/extensions.yaml
@@ -10,6 +10,10 @@ extensions:
   usbguard:
     packages:
       - usbguard
+  kerberos:
+    packages:
+      - krb5-workstation
+      - libkadm5
   # https://github.com/kmods-via-containers/kmods-via-containers/issues/3
   # https://gitlab.cee.redhat.com/coreos/redhat-coreos/merge_requests/866
   # These are currently overlaid onto the host so that they can be bind-mounted


### PR DESCRIPTION
Allows users to use kerberized NFS mounts on the host and increase
auditing of nodes.