### PR TITLE
s390x: Temporary fix for cpictl permissions

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -97,6 +97,13 @@ postprocess:
      EOF
      fi
 
+     # TEMPORARY: Fix file permission for cpictl until fix is backported to RHEL 8.6
+     # See https://bugzilla.redhat.com/show_bug.cgi?id=2024102
+     if [ "$(uname -m)" == "s390x" ]; then
+     [ "$(stat -c '%a' /usr/lib/s390-tools/cpictl)" == "755" ] && echo "Permission for /usr/lib/s390-tools/cpictl is fixed, remove temporary hack"
+     chmod 755 /usr/lib/s390-tools/cpictl
+     fi
+
      # Nuke network.service from orbit
      # https://github.com/openshift/os/issues/117
      rm -rf /etc/rc.d/init.d/network /etc/rc.d/rc*.d/*network


### PR DESCRIPTION
Fix file permission for cpictl until fix is backported to RHEL 8.6
https://bugzilla.redhat.com/show_bug.cgi?id=2024102

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>