### PR TITLE
honor COSA_DIR env var

### DIFF
--- a/ci/build-test-qemu.sh
+++ b/ci/build-test-qemu.sh
@@ -4,7 +4,9 @@ set -xeuo pipefail
 dn=$(dirname $0)
 # Prow jobs don't support adding emptydir today
 export COSA_SKIP_OVERLAY=1
-# Create a temporary cosa workdir
-cd "$(mktemp -d)"
+# Create a temporary cosa workdir if COSA_DIR is not set.
+cosa_dir="${COSA_DIR:-$(mktemp -d)}"
+echo "Using $cosa_dir for build"
+cd "$cosa_dir"
 cosa init /src
 exec ${dn}/prow-build-test-qemu.sh


### PR DESCRIPTION
To make Prow CI a bit more friendly, this script should honor the `$COSA_DIR` env var so that the dir can be specified from outside of this script.
