### PR TITLE
denylist: Skip coreos.boot-mirror and coreos.boot-mirror.luks on ppc64le

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -25,11 +25,11 @@
   tracker: https://github.com/coreos/coreos-assembler/issues/2725
   arches:
   - ppc64le
-- pattern: coreos.boot-mirror.luks/detach-primary
+- pattern: coreos.boot-mirror.luks
   tracker: https://github.com/coreos/coreos-assembler/issues/2725
   arches:
   - ppc64le
-- pattern: coreos.boot-mirror/detach-primary
+- pattern: coreos.boot-mirror
   tracker: https://github.com/coreos/coreos-assembler/issues/2725
   arches:
   - ppc64le


### PR DESCRIPTION
 - Looks the denylist works different than I thought/tested.
 It won't skip coreos.boot-mirror.luks/detach-primary and coreos.boot-mirror/detach-primary
 since they are called by coreos.boot-mirror tests, even though it shows a message as it would be skipped,
 they are only skipped if they are called separately. We probably have some area for improvements here.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>