### PR TITLE
denylist: skip multipath.partition on ppc64le

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -12,3 +12,8 @@
    - s390x
 - pattern: coreos.ignition.journald-log
   tracker: https://github.com/coreos/coreos-assembler/issues/1173
+- pattern: multipath.partition
+  tracker: https://github.com/openshift/os/issues/743
+  arches:
+    - ppc64le
+


### PR DESCRIPTION
This test has been rather consistently failing since the latest RHEL
8.4.z update.