### PR TITLE
s390x/kola-kola-denylist.yaml: Extend snooze for failling tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -13,12 +13,12 @@
   - s390x
 - pattern: ext.config.shared.ignition.stable-boot
   tracker: https://github.com/openshift/os/issues/710
-  snooze: 2022-03-29
+  snooze: 2022-04-19
   arches:
   - s390x
 - pattern: ext.config.shared.var-mount.scsi-id
   tracker: https://github.com/openshift/os/issues/710
-  snooze: 2022-03-29
+  snooze: 2022-04-19
   arches:
   - s390x
 - pattern: ext.config.shared.kdump.crash


### PR DESCRIPTION
Extend the snooze, as the tests have not been fixed yet.

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>