### PR TITLE
image.yaml: drop `ostree-format` key

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -12,8 +12,6 @@ squashfs-compression: gzip
 # defaulting to `ip=dhcp,dhcp6 rd.neednet=1` when it doesn't see this key.
 ignition-network-kcmdline: []
 
-ostree-format: "oci"
-
 vmware-os-type: rhel8_64Guest
 # VMware hardware versions: https://kb.vmware.com/s/article/1003746
 # Supported VMware versions: https://lifecycle.vmware.com/


### PR DESCRIPTION
`oci` is the default now and soon will be the only option:
https://github.com/coreos/coreos-assembler/pull/2784