### PR TITLE
MCO-280: extensions: Add container to serve repository with extensions

### DIFF
--- a/ci/get-ocp-repo.sh
+++ b/ci/get-ocp-repo.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# TODO: share this with ci/prow-entrypoint.sh
+ocpver=$(rpm-ostree compose tree --print-only manifest.yaml | jq -r '.["mutate-os-release"]')
+ocpver_mut=$(rpm-ostree compose tree --print-only manifest.yaml | jq -r '.["mutate-os-release"]' | sed 's|\.|-|')
+rhelver=$(rpm-ostree compose tree --print-only manifest.yaml | jq -r '.["automatic-version-prefix"]' | cut -f2 -d.)
+
+curl -L "http://base-${ocpver_mut}-rhel${rhelver}.ocp.svc.cluster.local" -o "ocp.repo"

--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -1,0 +1,48 @@
+ARG RHCOS_VERSION=latest
+#Build a newer rpm-ostree
+FROM quay.io/centos/centos:stream8 as rpm-ostree
+RUN sed -i -e 's,enabled=0,enabled=1,' /etc/yum.repos.d/CentOS-Stream-PowerTools.repo
+RUN yum -y group install "Development Tools"
+
+RUN git clone https://github.com/coreos/rpm-ostree.git
+WORKDIR rpm-ostree
+RUN git checkout rhel8
+RUN ./ci/installdeps.sh
+RUN PATH=$PATH:/rpm-ostree/target/cxxbridge/bin/
+RUN git submodule update --init
+RUN env CFLAGS='-ggdb -Og' CXXFLAGS='-ggdb -Og' ./autogen.sh --prefix=/usr --libdir=/usr/lib64 --sysconfdir=/etc
+RUN make
+
+## Downloads the extensions given the extensions.yaml
+FROM registry.ci.openshift.org/rhcos-devel/rhel-coreos:${RHCOS_VERSION} as os
+
+# Install new rpm-ostree
+COPY --from=rpm-ostree /rpm-ostree/target/debug/rpm-ostree /usr/bin/rpm-ostree
+
+# Expects os to be cloned and this build run from the top level dir like:
+# podman build -f extensions/Dockerfile .
+# also expects submodules to be initialized
+RUN mkdir /os
+WORKDIR /os
+ADD . .
+RUN if [ ! -f ocp.repo  ]; then ci/get-ocp-repo.sh ; fi
+
+RUN rpm-ostree compose extensions --rootfs=/ --output-dir=/usr/share/rpm-ostree/extensions/ {manifest,extensions}.yaml
+
+## Creates the repo metadata for the extensions & builds the go binary
+FROM quay.io/centos/centos:stream8 as builder
+COPY --from=os /usr/share/rpm-ostree/extensions/ /usr/share/rpm-ostree/extensions/
+RUN dnf install -y createrepo_c golang
+ADD extensions/repo-server/main.go .
+RUN mkdir /build
+RUN go build -o /build/webserver main.go
+
+RUN createrepo_c /usr/share/rpm-ostree/extensions/
+
+## Final container that has the extensions and webserver
+FROM registry.access.redhat.com/ubi8/ubi:latest
+COPY --from=builder /build/webserver /usr/bin/webserver
+COPY --from=builder /usr/share/rpm-ostree/extensions/ /usr/share/rpm-ostree/extensions/
+
+CMD ["./usr/bin/webserver"]
+EXPOSE 9091/tcp

--- a/extensions/repo-server/main.go
+++ b/extensions/repo-server/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+)
+
+var (
+	// flagPort is the open port the application listens on
+	flagPort = flag.String("port", "9091", "Port to listen on")
+)
+
+func main() {
+	extensions := http.FileServer(http.Dir("/usr/share/rpm-ostree/extensions/"))
+	flag.Parse()
+	mux := http.NewServeMux()
+	mux.Handle("/", extensions)
+
+	log.Printf("listening on port %s", *flagPort)
+	log.Fatal(http.ListenAndServe(":"+*flagPort, mux))
+}

--- a/extensions/test/Dockerfile
+++ b/extensions/test/Dockerfile
@@ -1,0 +1,7 @@
+FROM registry.ci.openshift.org/rhcos-devel/rhel-coreos:latest
+#We want to test it's only using the extensions repo
+RUN rm -rf /etc/yum.repos.d/*
+ADD ext.repo /etc/yum.repos.d/extension.repo
+#Install usbguard as provided by the repo
+RUN rpm-ostree install usbguard
+RUN usbguard

--- a/extensions/test/ext.repo
+++ b/extensions/test/ext.repo
@@ -1,0 +1,5 @@
+[ext]
+name=extensions
+baseurl=http://localhost:9091/
+enabled=1
+gpgcheck=1


### PR DESCRIPTION
depends on: https://github.com/coreos/rpm-ostree/pull/3562

This container will create a small service that will host the extensions rpms that we will be shipping. The idea is that this new container will be shipped alongside the machine-os and would provide a way for users layering extensions a way to do so without depending of connections outside of the cluster.

https://issues.redhat.com/browse/MCO-288