### PR TITLE
tests/kola/version rhel-major-version: ensure packages from rhel major version are included

### DIFF
--- a/tests/kola/version/rhel-major-version
+++ b/tests/kola/version/rhel-major-version
@@ -1,0 +1,18 @@
+#!/bin/bash
+# kola: { "exclusive": false }
+set -xeuo pipefail
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+# checks to ensure that the only packages from the RHEL major version are included
+
+source /etc/os-release 
+var=$(echo "${RHEL_VERSION}" | cut -d. -f1)
+for x in $(rpm -qa --queryformat='%{RELEASE}\n' | grep -oP 'el\s*\K\d+'); do
+    if [[ "$var" -ne $((x)) ]]; then 
+        fatal "Error RHEL packages do not match current version"
+    fi
+done


### PR DESCRIPTION
I added a test to ensure packages from the RHEL major version are included, this allows us to make sure we're not mixing up versions while also staying up to date