### PR TITLE
adds the derived image test scripts for prow

### DIFF
--- a/ci/derived-image-test.sh
+++ b/ci/derived-image-test.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# This script performs the following tasks:
+#
+# 1. Logs into the rhcos-devel service account to get the image push credential
+# so we can push to the registry.ci.openshift.org/rhcos-devel namespace.
+#
+# 2. Kicks off the build-test-qemu.sh script to build and test an RHCOS image
+# with Kola tests.
+#
+# 3. Pushes the resulting image to the image registry using the Prow build ID
+# as the tag since we need to have the image in this registry so our derived
+# image build test can use it.
+#
+# 3. Kicks off the derived OS image testing binary which pulls the newly built
+# image, builds a derived image from it, applies it to an underlying OpenShift
+# cluster node, verifies that it was successfully applied, then rolls the node
+# back.
+
+set -euo pipefail
+
+# Note: The oc binary will be injected by the Prow CI process. It
+# is not present in ci/Dockerfile.
+oc login https://api.ci.l2s4.p1.openshiftapps.com:6443 --token="$(cat /service-account-token/image-pusher-service-account-token)"
+oc registry login --registry=registry.ci.openshift.org --to="$SHARED_DIR/dockercfg.json"
+
+export COSA_DIR="/tmp/cosa"
+mkdir -p "$COSA_DIR"
+
+# Run the cosa build / test
+/src/ci/build-test-qemu.sh
+
+export REGISTRY_AUTH_FILE="$SHARED_DIR/dockercfg.json"
+
+# Ensure we're in the designated cosa directory so the push-container commands work
+cd "$COSA_DIR"
+
+# Tags with the cosa build ID / arch - unique to this specific build
+cosa push-container registry.ci.openshift.org/rhcos-devel/rhel-coreos
+
+# Tag with the Prow Build ID because we don't want to overwrite our well-known
+# tags yet, but our test cluster needs the image to be pushed someplace so we
+# can ingest it. We use the BUILD_ID value because its unique to each job so
+# they won't stomp on each other if running concurrently.
+#
+# TODO: Aim to push this to the ephemeral CI namespace registry before making
+# the final push at the end.
+export BASE_IMAGE_PULLSPEC="registry.ci.openshift.org/rhcos-devel/rhel-coreos:$BUILD_ID"
+cosa push-container "$BASE_IMAGE_PULLSPEC"
+
+# Perform the derived OS image build tests
+/usr/local/bin/layering_test -test.v -test.failfast -test.timeout 35m -build-log="$ARTIFACT_DIR/derived-image-build.log"

--- a/ci/tag-final-image.sh
+++ b/ci/tag-final-image.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# This script performs the following tasks:
+#
+# 1. Reads the jobspec to get the active branch so we know what tag
+# to use.
+#
+# 2. Tags the image tagged with the Prow build ID to one of our
+# well-known tags (e.g., master, 4.11, latest, etc.)
+
+set -euo pipefail
+
+# We can't use PULL_BASE_REF or OPENSHIFT_BUILD_REFERENCE to get the
+# branch since this is a periodic job which originates from
+# openshift/release, not the openshift/os repository. We then strip
+# release- from the branch name so we're left with the number (e.g.,
+# release-4.11 -> 4.11).
+BRANCH="$(echo "$JOB_SPEC" | jq -r '.extra_refs[0].base_ref | sub("release-"; "")')"
+export REGISTRY_AUTH_FILE="$SHARED_DIR/dockercfg.json"
+
+skopeo copy "docker://registry.ci.openshift.org/rhcos-devel/rhel-coreos:$BUILD_ID" "docker://registry.ci.openshift.org/rhcos-devel/rhel-coreos:$BRANCH"
+
+# Only push latest tag on master branch
+if [[ "$BRANCH" == "master"  ]]; then
+    skopeo copy "docker://registry.ci.openshift.org/rhcos-devel/rhel-coreos:$BUILD_ID" "docker://registry.ci.openshift.org/rhcos-devel/rhel-coreos:latest"
+fi

--- a/tests/layering/build_helper_test.go
+++ b/tests/layering/build_helper_test.go
@@ -21,11 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-// Gets the RHCOS base image tag from the BASE_IMAGE_TAG environment variable.
-func getBaseImageTag() string {
-	return getEnvVarOrDefault("BASE_IMAGE_TAG", "latest")
-}
-
 // Gets the value of an environment variable or defaults to the provided
 // default.
 func getEnvVarOrDefault(envVarName, defaultValue string) string {
@@ -108,13 +103,12 @@ func (b *builder) createImageStream(ctx context.Context) (*imagev1.ImageStream, 
 
 // Actually perform the OS derivation build and waits for it to complete.
 func (b *builder) buildDerivedOSImage(ctx context.Context) error {
-	baseImageBuildArg := fmt.Sprintf(imagePullSpec, getBaseImageTag())
-
+	baseImagePullSpec := getEnvVarOrDefault("BASE_IMAGE_PULLSPEC", "registry.ci.openshift.org/rhcos-devel/rhel-coreos:latest")
 	derivationRepoURL := getEnvVarOrDefault("DERIVATION_REPO_URL", "https://github.com/coreos/fcos-derivation-example")
 	derivationRepoRef := getEnvVarOrDefault("DERIVATION_REPO_REF", "rhcos")
 	dockerfilePath := getEnvVarOrDefault("DERIVATION_DOCKERFILE_PATH", "Dockerfile")
 
-	b.t.Log("base image pullspec:", baseImageBuildArg)
+	b.t.Log("base image pullspec:", baseImagePullSpec)
 	b.t.Log("derivation repo URL:", derivationRepoURL)
 	b.t.Log("derivation repo ref:", derivationRepoRef)
 	b.t.Log("dockerfile path:", dockerfilePath)
@@ -139,7 +133,7 @@ func (b *builder) buildDerivedOSImage(ctx context.Context) error {
 						BuildArgs: []corev1.EnvVar{
 							{
 								Name:  "RHEL_COREOS_IMAGE",
-								Value: baseImageBuildArg,
+								Value: baseImagePullSpec,
 							},
 						},
 					},

--- a/tests/layering/layering_test.go
+++ b/tests/layering/layering_test.go
@@ -24,7 +24,6 @@ const (
 
 	buildName       = imageStreamName
 	helloWorldPath  = "/usr/bin/hello-world"
-	imagePullSpec   = "registry.ci.openshift.org/rhcos-devel/rhel-coreos:%s"
 	imageRegistry   = "image-registry.openshift-image-registry.svc:5000"
 	imageStreamName = "test-boot-in-cluster-image"
 	imageURL        = ostreeUnverifiedRegistry + ":" + imageRegistry + "/" + mcoNamespace + "/" + imageStreamName


### PR DESCRIPTION
Instead of having complex Bash scripts embedded in YAML structures, it would be better if the scripts that were written and refined in https://github.com/openshift/release/pull/26912 lived in this repo. This allows additional benefits such as static analysis, reuse, etc.
