### PR TITLE
manifest.yaml: pin sssd to a rhel-8.5 version

### DIFF
--- a/ci/prow-build-test-qemu.sh
+++ b/ci/prow-build-test-qemu.sh
@@ -30,9 +30,11 @@ fi
 ocpver=$(rpm-ostree compose tree --print-only src/config/manifest.yaml | jq -r '.["mutate-os-release"]')
 ocpver_mut=$(rpm-ostree compose tree --print-only src/config/manifest.yaml | jq -r '.["mutate-os-release"]' | sed 's|\.|-|')
 prev_build_url=${REDIRECTOR_URL}/rhcos-${ocpver}/
-# we want to use RHEL 8.5 for testing until we can start using 8.6
-# see https://github.com/openshift/release/pull/26193
+# temporarily also fetch 8.5 repo for sssd
+# https://bugzilla.redhat.com/show_bug.cgi?id=2072050
 curl -L http://base-"${ocpver_mut}"-rhel86.ocp.svc.cluster.local > src/config/ocp.repo
+curl -L http://base-"${ocpver_mut}"-rhel85.ocp.svc.cluster.local > src/config/ocp85.repo
+sed -i -e 's,\[rhel-8-,\[rhel-85-,' src/config/ocp85.repo
 cosa buildfetch --url=${prev_build_url}
 cosa fetch
 cosa build

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -37,6 +37,7 @@ arch-include:
 # See README.md
 # and https://github.com/openshift/release/blob/master/core-services/release-controller/README.md#rpm-mirrors
 repos:
+  - rhel-85-baseos
   - rhel-8-baseos
   - rhel-8-appstream
   - rhel-8-fast-datapath
@@ -351,6 +352,9 @@ packages:
  - conntrack-tools
 
 repo-packages:
+  - repo: rhel-85-baseos
+    packages:
+      - sssd
   # we always want the kernel from BaseOS
   - repo: rhel-8-baseos
     packages:


### PR DESCRIPTION
`sssd` is crashing and restarting in a loop. Lets pin it to an older
version for now.