### PR TITLE
s390x/kola-denylist: Re-enable var-mount.scsi-id test

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -12,13 +12,7 @@
   arches:
   - s390x
 - pattern: ext.config.shared.ignition.stable-boot
-  tracker: https://github.com/openshift/os/issues/710
-  snooze: 2022-04-19
-  arches:
-  - s390x
-- pattern: ext.config.shared.var-mount.scsi-id
-  tracker: https://github.com/openshift/os/issues/710
-  snooze: 2022-04-19
+  tracker: https://bugzilla.redhat.com/show_bug.cgi?id=2075085
   arches:
   - s390x
 - pattern: ext.config.shared.kdump.crash


### PR DESCRIPTION
The var-mount.scsi-id test is succeding with the rebase to RHEL 8.6.

Deactivate snooze for ignition.stable-boot test to wait for the fix.

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>