### PR TITLE
refactors the prow build scripts

### DIFF
--- a/ci/prow-build.sh
+++ b/ci/prow-build.sh
@@ -48,9 +48,3 @@ cosa buildfetch --url=${prev_build_url}
 cosa fetch
 cosa build
 cosa buildextend-extensions
-
-# Give the newly-built OCI archive a predictable filename to make OCI archive extraction simpler
-arch="x86_64"
-cosa_build_id="$(cat "${COSA_DIR}/builds/builds.json" | jq -r '.builds[0].id')"
-current_build_dir="${COSA_DIR}/builds/latest/${arch}"
-mv "${current_build_dir}/rhcos-${cosa_build_id}-ostree.${arch}.ociarchive" "${current_build_dir}/rhcos.${arch}.ociarchive"

--- a/ci/set-openshift-user.sh
+++ b/ci/set-openshift-user.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# This script is used to update the /etc/passwd file within the COSA container
+# at test-time. The need for this comes from the fact that OpenShift will run a
+# container with a randomized user ID by default to enhance security. Because
+# COSA runs with an unprivileged user ("builder") instead of (container) root,
+# this presents special challenges for file and disk permissions. This particular
+# pattern was inspired by:
+# - https://cloud.redhat.com/blog/jupyter-on-openshift-part-6-running-as-an-assigned-user-id
+# - https://cloud.redhat.com/blog/a-guide-to-openshift-and-uids
+
+set -xeuo
+
+user_id="$(id -u)"
+group_id="$(id -g)"
+
+cat /etc/passwd | grep -v "^builder" > /tmp/passwd
+echo "builder:x:${user_id}:${group_id}::/home/builder:/bin/bash" >> /tmp/passwd
+cat /tmp/passwd > /etc/passwd
+rm /tmp/passwd
+
+# Not strictly required, but nice for debugging.
+id
+whoami

--- a/ci/simplify-ociarchive-path.sh
+++ b/ci/simplify-ociarchive-path.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+# Give the newly-built OCI archive a predictable filename to make OCI archive
+# extraction / ingestion simpler in Prow.
+
+set -xeuo
+
+arch="x86_64"
+cosa_build_id="$(cat "${COSA_DIR}/builds/builds.json" | jq -r '.builds[0].id')"
+current_build_dir="${COSA_DIR}/builds/latest/${arch}"
+mv "${current_build_dir}/rhcos-${cosa_build_id}-ostree.${arch}.ociarchive" "${current_build_dir}/rhcos.${arch}.ociarchive"


### PR DESCRIPTION
After a bit of experimenting, it was discovered that:

- Kola tests expect the OCI archive to still have the build number attached to it. This means we'll need to modify the OCI archive extraction / ingestion process slightly.
- Because OpenShift runs a container with a random user ID, we need to ensure that the `builder` user can be looked up by the random OpenShift user ID as well as to ensure that it has the necessary permissions to read and write files within the COSA_DIR directory.
