### PR TITLE
Temporarily revert back to RHEL 8.5

### DIFF
--- a/kernel-rhel-85.yaml
+++ b/kernel-rhel-85.yaml
@@ -1,6 +1,0 @@
-# Temporarily use RHEL 8.5 Kernel for s390x, until RHEL 8.6 gets a new kernel (Build 370+)
-# See: https://bugzilla.redhat.com/show_bug.cgi?id=2047242
-repo-packages:
-  - repo: rhel-85-baseos
-    packages:
-      - kernel

--- a/kernel-rhel-86.yaml
+++ b/kernel-rhel-86.yaml
@@ -1,6 +1,0 @@
-# Temporarily use RHEL 8.5 Kernel for s390x, until RHEL 8.6 gets a new kernel (Build 370+)
-# See: https://bugzilla.redhat.com/show_bug.cgi?id=2047242
-repo-packages:
-  - repo: rhel-8-baseos
-    packages:
-      - kernel

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -29,23 +29,14 @@ arch-include:
   x86_64:
     - fedora-coreos-config/manifests/grub2-removals.yaml
     - fedora-coreos-config/manifests/bootupd.yaml
-    - kernel-rhel-86.yaml
-  ppc64le:
-    - fedora-coreos-config/manifests/grub2-removals.yaml
-    - kernel-rhel-86.yaml
+  ppc64le: fedora-coreos-config/manifests/grub2-removals.yaml
   aarch64:
     - fedora-coreos-config/manifests/grub2-removals.yaml
     - fedora-coreos-config/manifests/bootupd.yaml
-    - kernel-rhel-86.yaml
-  s390x:
-    # Temporarily use RHEL 8.5 Kernel for s390x, until RHEL 8.6 gets a new kernel (Build 370+)
-    # See: https://bugzilla.redhat.com/show_bug.cgi?id=2047242
-    - kernel-rhel-85.yaml
 
 # See README.md
 # and https://github.com/openshift/release/blob/master/core-services/release-controller/README.md#rpm-mirrors
 repos:
-  - rhel-85-baseos
   - rhel-8-baseos
   - rhel-8-appstream
   - rhel-8-fast-datapath
@@ -55,7 +46,7 @@ repos:
 rpmdb: bdb
 
 # We include hours/minutes to avoid version number reuse
-automatic-version-prefix: "411.86.<date:%Y%m%d%H%M>"
+automatic-version-prefix: "411.85.<date:%Y%m%d%H%M>"
 # This ensures we're semver-compatible which OpenShift wants
 automatic-version-suffix: "-"
 # Keep this is sync with the version in postprocess
@@ -360,15 +351,10 @@ packages:
  - conntrack-tools
 
 repo-packages:
-  - repo: rhel-85-baseos
-    packages:
-      - sssd
   # we always want the kernel from BaseOS
-  # Temporarily use RHEL 8.5 Kernel for s390x, until RHEL 8.6 gets a new kernel (Build 370+)
-  # See: https://bugzilla.redhat.com/show_bug.cgi?id=2047242
-  # - repo: rhel-8-baseos
-  #   packages:
-  #     - kernel
+  - repo: rhel-8-baseos
+    packages:
+      - kernel
   # we want the one shipping in RHEL, not the equivalently versioned one in RHAOS
   - repo: rhel-8-appstream
     packages:

--- a/overlay.d/25rhcos-azure-udev-rules/usr/lib/udev/rules.d/50-azure-ptp.rules
+++ b/overlay.d/25rhcos-azure-udev-rules/usr/lib/udev/rules.d/50-azure-ptp.rules
@@ -1,0 +1,5 @@
+# Manual backport of:
+# https://github.com/systemd/systemd/commit/32e868f058da8b90add00b2958c516241c532b70
+# Can drop once we get to RHEL 8.6:
+# https://bugzilla.redhat.com/show_bug.cgi?id=1991834
+SUBSYSTEM=="ptp", ATTR{clock_name}=="hyperv", SYMLINK += "ptp_hyperv"

--- a/tests/kola/version/drop-azure-ptp
+++ b/tests/kola/version/drop-azure-ptp
@@ -1,0 +1,13 @@
+#!/bin/bash
+# kola: { "exclusive": false }
+set -xeuo pipefail
+
+fatal() {
+    echo "$@" >&2
+    exit 1
+}
+
+if [ -e /usr/lib/udev/rules.d/50-azure-ptp.rules ] && \
+    grep ptp_hyperv /usr/lib/udev/rules.d/50-udev-default.rules; then
+  fatal "50-udev-default.rules includes ptp_hyperv symlink; drop 50-azure-ptp.rules"
+fi


### PR DESCRIPTION
We have undiagnosed failures on Azure and we need master to be working for other parts of the stack.

See: https://bugzilla.redhat.com/show_bug.cgi?id=2077052

This reverts the following commits:

- Revert "Revert "25rhcos-azure-udev-rules: add 50-azure-ptp.rules""
  This reverts commit fd8a0c8f32bf47f83e318cfee6c3313a6bb32cf1.
- Revert "manifest.yaml: update automatic-version-prefix to 86"
  This reverts commit 4f0fe7f8f113b9191483100200d0fdf6d2aa9f87.
- Revert "manifest.yaml: pin sssd to a rhel-8.5 version"
  This reverts commit c6f8c9022edaa4cd3dacfbfd7026d358181afb1e.
- Revert "s390x: Use RHEL 8.5 Kernel until 8.6 has a new kernel"
  This reverts commit 541bb888aefe25b51a4e101598b0db6cd47ee32d.
- Revert "ci: Temporarily exclude Secure Boot testing"
  This reverts commit 9153cce40c14abf97c94acbbb52164f5c7cdfc68.
- Revert "ci: Temporarily using 8.6 Beta repos"
  This reverts commit d53404b1ea427be814cb15d1f5b242b1c8de85a1.