### PR TITLE
s390x: Temporarily disable scsi-id test until we rebase back to RHEL 8.6

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -27,3 +27,8 @@
   tracker: https://github.com/coreos/coreos-assembler/issues/2725
   arches:
   - ppc64le
+# Disable until we rebase back to RHEL 8.6
+- pattern: ext.config.shared.var-mount.scsi-id
+  tracker: https://github.com/openshift/os/issues/710
+  arches:
+  - s390x


### PR DESCRIPTION
The var-mount.scsi-id does not work with RHEL 8.5.
Disable the test until we rebase back to RHEL 8.6

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>