### PR TITLE
overlay/rhcos-fde: Drop `cryptsetup-reencrypt`

### DIFF
--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fde/module-setup.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fde/module-setup.sh
@@ -43,7 +43,6 @@ install() {
         clevis-luks-unbind
         clevis-luks-unlock
         cryptsetup
-        cryptsetup-reencrypt
         curl
         cut
         dd


### PR DESCRIPTION
We no longer use this since 2fba76ec51001e6402d62bb3df13fb484fce5130
The current LUKS code in this repository is only for the legacy use
case of unlocking an old-style volume before Ignition had native
LUKS.

We don't need `cryptsetup-reencrypt` which is not part of RHEL9
right now.