### PR TITLE
manifest: bump to openvswitch2.17

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -314,7 +314,7 @@ packages:
  - cri-o cri-tools
  # Networking
  - nfs-utils
- - openvswitch2.16
+ - openvswitch2.17
  - dnsmasq
  - NetworkManager-ovs
  # Extra runtime


### PR DESCRIPTION
We want to keep host OVS and container OVS synchronized as much
as possible. We've bumped to 2.17 in ovn-kubernetes containers,
plus 2.17 has a number of code sanitizer fixes, and 2.17 will be
the new LTS release that OSP also uses.

@trozet @jcaamano @tssurya 