### PR TITLE
[rhel8.5 revert] Use RHEL8.6 repo for kata-containers

### DIFF
--- a/ci/prow-build-test-qemu.sh
+++ b/ci/prow-build-test-qemu.sh
@@ -33,6 +33,9 @@ prev_build_url=${REDIRECTOR_URL}/rhcos-${ocpver}/
 # we want to use RHEL 8.5 for testing until we can start using 8.6
 # see https://github.com/openshift/release/pull/26193
 curl -L http://base-"${ocpver_mut}"-rhel85.ocp.svc.cluster.local > src/config/ocp.repo
+# fetch the 8.6 appstream repo to enable building of extensions
+# see: https://github.com/openshift/os/issues/795
+curl -Ls http://base-"${ocpver_mut}"-rhel86.ocp.svc.cluster.local | grep -A 3 rhel-8-appstream | sed '1,3 s/rhel-8-appstream/rhel-86-appstream/g' >> src/config/ocp.repo
 cosa buildfetch --url=${prev_build_url}
 cosa fetch
 cosa build

--- a/extensions.yaml
+++ b/extensions.yaml
@@ -57,6 +57,6 @@ extensions:
       enable:
         - virt:rhel
     repos:
-      - rhel-8-appstream
+      - rhel-86-appstream
     packages:
       - kata-containers


### PR DESCRIPTION
Reverting back to RHEL 8.5 content caused extension building to fail
because the newer kata-container has a requirement on a qemu-kvm-core
version that is newer than the one in the rhel-8-advanced-virt repo.

Get the kata-containers dependencies from RHEL8.6 appstream.

See: https://github.com/openshift/os/issues/795