### PR TITLE
manifest: pull container-tools content from RHAOS repo

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -353,32 +353,24 @@ repo-packages:
       - nss-altfiles
   - repo: rhel-8-server-ose
     packages:
-      # eventually, we want the one from the container-tools module, but we're
-      # not there yet
-      - toolbox
-      # These are the only container stack packages we don't get from modularity
-      # nor from base RHEL for various reasons. See:
-      # https://github.com/openshift/os/pull/681#issuecomment-1022443830
-      #
-      # newer than what is included in RHEL 8.4.Z EUS, but addresses some BZs
-      # that customers were encountering
+      # Starting with 4.11, we are working with the Containers team to build
+      # certain container-tools RPMs in the RHAOS branches for RHCOS + RHEL
+      # worker nodes.
+      - conmon
       - container-selinux
-      # newer than what is included in RHEL 8.4.Z EUS, because the k8s folks
-      # wanted to start testing with 1.x versions of crun
-      - crun
-      # slightly newer than what is included in RHEL 8.4.Z EUS, because we had
-      # previously shipped a newer version in OCP/RHCOS 4.9 and had to preserve
-      # the upgrade path
-      - runc
-      # Need an updated skopeo for https://github.com/containers/skopeo/pull/1476
-      # for coreos layering work
+      - containernetworking-plugins
       - containers-common
+      - criu
+      - crun
+      - fuse-overlayfs
+      - podman
+      - runc
       - skopeo
+      - slirp4netns
+      - toolbox
 
 modules:
   enable:
-    # podman stack; see https://github.com/openshift/os/pull/681#issuecomment-1022443830
-    - container-tools:rhel8
     # qemu-guest-agent
     - virt:rhel
 


### PR DESCRIPTION
We've worked with the Containers team to enable builds of certain
container-tools RPMs from the RHAOS repo. This allows us to land OCP
specific changes to these packages and potentially ship newer versions
of these packages than what would available in the module.