### PR TITLE
ci: fix prow-build.sh to fetch same repos

### DIFF
--- a/ci/prow-build-test-qemu.sh
+++ b/ci/prow-build-test-qemu.sh
@@ -25,6 +25,10 @@ if test '!' -w src/config; then
     mv src/config.writable src/config
 fi
 
+#
+# NOTE: If you are adjusting how the repos are fetched in this script, you
+#        must also make the same change in the `prow-build.sh` script
+#
 # Grab the raw value of `mutate-os-release` and use sed to convert the value
 # to X-Y format
 ocpver=$(rpm-ostree compose tree --print-only src/config/manifest.yaml | jq -r '.["mutate-os-release"]')


### PR DESCRIPTION
The introduction of new Prow periodic jobs (openshift/release#27779)
means we have to keep the `prow-build.sh` and
`prow-build-test-qemu.sh` scripts in sync, with regards to fetching
the repo configs.

This brings `prow-build.sh` in sync with the changes from #796.

Closes #801