### PR TITLE
image: Switch to `oci-chunked` format

### DIFF
--- a/image-rhel-8.6.yaml
+++ b/image-rhel-8.6.yaml
@@ -8,7 +8,9 @@ squashfs-compression: gzip
 # defaulting to `ip=dhcp,dhcp6 rd.neednet=1` when it doesn't see this key.
 ignition-network-kcmdline: []
 
-ostree-format: "oci"
+# See https://github.com/coreos/coreos-assembler/pull/3014 - this
+# will hopefully be the default soon, but trying to enable it here first.
+ostree-format: "oci-chunked-v1"
 
 # vmware-secure-boot changes the EFI secure boot option.
 # set false here due to https://bugzilla.redhat.com/show_bug.cgi?id=2106055


### PR DESCRIPTION
Now that we have rpm-ostree v2022.2 in the bootimage, we should
be able to switch to the chunked image format.

This matches https://github.com/coreos/fedora-coreos-config/pull/1698