### PR TITLE
ci: Also work around git checkout security check

### DIFF
--- a/ci/set-openshift-user.sh
+++ b/ci/set-openshift-user.sh
@@ -22,3 +22,9 @@ rm /tmp/passwd
 # Not strictly required, but nice for debugging.
 id
 whoami
+
+# Workaround for how we cache the cosa builds in Prow and juggle users,
+# see also https://github.com/actions/checkout/issues/760#issuecomment-1097461496
+if test -d src/config; then
+    git config --global --add safe.directory $PWD/src/config
+fi


### PR DESCRIPTION
See https://github.com/actions/checkout/issues/760#issuecomment-1097461496

Nothing malicious is happening here, we are just using the checkout
with various UIDs for complex reasons.

The name of this script is now kind of wrong, but changing it
would require a ratchet with the CI config in openshift/release.