### PR TITLE
image.yaml: Drop `random.trust_cpu=on` from default kargs

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -1,10 +1,6 @@
 # See https://github.com/coreos/coreos-assembler/pull/298
 size: 16
 
-# This pairs with the above so we can easily detect in the initrd
-extra-kargs:
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1830280
-  - random.trust_cpu=on
 # https://bugzilla.redhat.com/show_bug.cgi?id=1812276
 squashfs-compression: gzip
 


### PR DESCRIPTION
image.yaml: Drop `random.trust_cpu=on` from default kargs

We added this a long time ago when we discovered that the RHEL8
kernel didn't enable `CONFIG_RANDOM_TRUST_CPU=y`.  But that's
been true since
https://bugzilla.redhat.com/show_bug.cgi?id=1830280
(And see also https://bugzilla.redhat.com/show_bug.cgi?id=1778762 )
which has been quite a while; likely RHEL 8.3.

Motivated by the recent discussion around default kargs and looking
at what we have by default.

---

