### PR TITLE
ci: Use `cosa init --transient`

### DIFF
--- a/ci/build-test-qemu.sh
+++ b/ci/build-test-qemu.sh
@@ -8,5 +8,5 @@ export COSA_SKIP_OVERLAY=1
 cosa_dir="${COSA_DIR:-$(mktemp -d)}"
 echo "Using $cosa_dir for build"
 cd "$cosa_dir"
-cosa init /src
+cosa init --transient /src
 exec ${dn}/prow-build-test-qemu.sh

--- a/ci/prow-build.sh
+++ b/ci/prow-build.sh
@@ -7,7 +7,7 @@ export COSA_SKIP_OVERLAY=1
 cosa_dir="${COSA_DIR:-$(mktemp -d)}"
 echo "Using $cosa_dir for build"
 cd "$cosa_dir"
-cosa init /src
+cosa init --transient /src
 
 # This script is called via build.sh which is the main Prow
 # entrypoint for PRs to this repo, as well as for PRs on other repos,


### PR DESCRIPTION
Opt into the faster infrastructure from
https://github.com/coreos/coreos-assembler/pull/2889
for CI builds where we do not maintain any state across builds.