### PR TITLE
Bug 2068148: /etc/redhat-release symlink is broken

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -167,8 +167,8 @@ postprocess:
      ${NAME} release ${VERSION_ID}
      EOF
      rm -f /etc/system-release /etc/redhat-release
-     ln -s /usr/lib/system-release /etc/system-release
-     ln -s /usr/lib/system-release /etc/redhat-release
+     ln -s ../usr/lib/redhat-release /etc/system-release
+     ln -s ../usr/lib/redhat-release /etc/redhat-release
      )
 
      # Tweak /usr/lib/issue


### PR DESCRIPTION
The symbolic links for /etc/system-release and /etc/redhat-release
are pointing a non-existent file and are absolute sym links which
is breaking some workflows / use cases. Update the links to point
to a valid file and make them relative.