### PR TITLE
refactors cosa session initialization

### DIFF
--- a/ci/build-test-qemu.sh
+++ b/ci/build-test-qemu.sh
@@ -5,8 +5,6 @@ dn=$(dirname $0)
 # Prow jobs don't support adding emptydir today
 export COSA_SKIP_OVERLAY=1
 # Create a temporary cosa workdir if COSA_DIR is not set.
-cosa_dir="${COSA_DIR:-$(mktemp -d)}"
-echo "Using $cosa_dir for build"
-cd "$cosa_dir"
-cosa init --transient /src
-exec ${dn}/prow-build-test-qemu.sh
+export COSA_DIR="${COSA_DIR:-$(mktemp -d)}"
+cd "$COSA_DIR"
+exec "${dn}/prow-build-test-qemu.sh"

--- a/ci/cosa-build.sh
+++ b/ci/cosa-build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -xeuo pipefail
+
+# This script assumes that `cosa init` has been run.
+cosa build
+cosa buildextend-extensions

--- a/ci/prow-build-test-qemu.sh
+++ b/ci/prow-build-test-qemu.sh
@@ -1,49 +1,12 @@
 #!/bin/bash
 set -xeuo pipefail
-# This script is called via build-test-qemu.sh which is the main Prow
-# entrypoint for PRs to this repo, as well as for PRs on other repos,
-# mainly coreos-assembler.  It assumes that `cosa init` has been run.
 
-REDIRECTOR_URL="https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/"
+dn="$(dirname "$0")"
 
-# record information about cosa + rpm-ostree
-if test -d /cosa; then
-    jq . < /cosa/coreos-assembler-git.json
-fi
-rpm-ostree --version
+# Create a temporary cosa workdir if COSA_DIR is not set.
+export COSA_DIR="${COSA_DIR:-$(mktemp -d)}"
 
-# We generate .repo files which write to the source, but
-# we captured the source as part of the Docker build.
-# In OpenShift default SCC we'll run as non-root, so we need
-# to make a new copy of the source.  TODO fix cosa to be happy
-# if src/config already exists instead of wanting to reference
-# it or clone it.  Or we could write our .repo files to a separate
-# place.
-if test '!' -w src/config; then
-    git clone --recurse src/config src/config.writable
-    rm src/config -rf
-    mv src/config.writable src/config
-fi
-
-#
-# NOTE: If you are adjusting how the repos are fetched in this script, you
-#        must also make the same change in the `prow-build.sh` script
-#
-# Grab the raw value of `mutate-os-release` and use sed to convert the value
-# to X-Y format
-ocpver=$(rpm-ostree compose tree --print-only src/config/manifest.yaml | jq -r '.["mutate-os-release"]')
-ocpver_mut=$(rpm-ostree compose tree --print-only src/config/manifest.yaml | jq -r '.["mutate-os-release"]' | sed 's|\.|-|')
-prev_build_url=${REDIRECTOR_URL}/rhcos-${ocpver}/
-# we want to use RHEL 8.5 for testing until we can start using 8.6
-# see https://github.com/openshift/release/pull/26193
-curl -L http://base-"${ocpver_mut}"-rhel85.ocp.svc.cluster.local > src/config/ocp.repo
-# fetch the 8.6 appstream repo to enable building of extensions
-# see: https://github.com/openshift/os/issues/795
-curl -Ls http://base-"${ocpver_mut}"-rhel86.ocp.svc.cluster.local | grep -A 3 rhel-8-appstream | sed '1,3 s/rhel-8-appstream/rhel-86-appstream/g' >> src/config/ocp.repo
-cosa buildfetch --url=${prev_build_url}
-cosa fetch
-cosa build
-cosa buildextend-extensions
+"$dn/prow-build.sh"
 cosa kola --basic-qemu-scenarios
 kola run-upgrade -b rhcos -v --find-parent-image --qemu-image-dir tmp/ --output-dir tmp/kola-upgrade
 cosa kola run --parallel 2

--- a/ci/prow-build.sh
+++ b/ci/prow-build.sh
@@ -1,53 +1,12 @@
 #!/bin/bash
 set -xeuo pipefail
 
-# Prow jobs don't support adding emptydir today
-export COSA_SKIP_OVERLAY=1
+dn="$(dirname "$0")"
+
 # Create a temporary cosa workdir if COSA_DIR is not set.
-cosa_dir="${COSA_DIR:-$(mktemp -d)}"
-echo "Using $cosa_dir for build"
-cd "$cosa_dir"
-cosa init --transient /src
+export COSA_DIR="${COSA_DIR:-$(mktemp -d)}"
+echo "Using $COSA_DIR for build"
+cd "$COSA_DIR"
 
-# This script is called via build.sh which is the main Prow
-# entrypoint for PRs to this repo, as well as for PRs on other repos,
-# mainly coreos-assembler.  It assumes that `cosa init` has been run.
-
-REDIRECTOR_URL="https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/"
-
-# record information about cosa + rpm-ostree
-if test -d /cosa; then
-    jq . < /cosa/coreos-assembler-git.json
-fi
-rpm-ostree --version
-
-# We generate .repo files which write to the source, but
-# we captured the source as part of the Docker build.
-# In OpenShift default SCC we'll run as non-root, so we need
-# to make a new copy of the source.  TODO fix cosa to be happy
-# if src/config already exists instead of wanting to reference
-# it or clone it.  Or we could write our .repo files to a separate
-# place.
-if test '!' -w src/config; then
-    git clone --recurse src/config src/config.writable
-    rm src/config -rf
-    mv src/config.writable src/config
-fi
-
-#
-# NOTE: If you are adjusting how the repos are fetched in this script, you
-#        must also make the same change in the `prow-build-test-qemu.sh` script
-#
-# Grab the raw value of `mutate-os-release` and use sed to convert the value
-# to X-Y format
-ocpver=$(rpm-ostree compose tree --print-only src/config/manifest.yaml | jq -r '.["mutate-os-release"]')
-ocpver_mut=$(rpm-ostree compose tree --print-only src/config/manifest.yaml | jq -r '.["mutate-os-release"]' | sed 's|\.|-|')
-prev_build_url=${REDIRECTOR_URL}/rhcos-${ocpver}/
-
-# Fetch RHEL 8.6 repos
-curl -L http://base-"${ocpver_mut}"-rhel86.ocp.svc.cluster.local > src/config/ocp.repo
-
-cosa buildfetch --url=${prev_build_url}
-cosa fetch
-cosa build
-cosa buildextend-extensions
+"$dn/prow-prepare.sh"
+"$dn/cosa-build.sh"

--- a/ci/prow-prepare.sh
+++ b/ci/prow-prepare.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+set -xeuo pipefail
+
+# This script sets up the cosa session for a given Prow CI run.
+
+# Prow jobs don't support adding emptydir today
+export COSA_SKIP_OVERLAY=1
+cosa init --transient /src
+
+# This script is called via prow-build.sh scripts which is the main Prow
+# entrypoint for PRs to this repo, as well as for PRs on other repos,
+# mainly coreos-assembler.  It assumes that `cosa init` has been run.
+
+REDIRECTOR_URL="https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/storage/releases/"
+
+# record information about cosa + rpm-ostree
+if test -d /cosa; then
+    jq . < /cosa/coreos-assembler-git.json
+fi
+rpm-ostree --version
+
+# We generate .repo files which write to the source, but
+# we captured the source as part of the Docker build.
+# In OpenShift default SCC we'll run as non-root, so we need
+# to make a new copy of the source.  TODO fix cosa to be happy
+# if src/config already exists instead of wanting to reference
+# it or clone it.  Or we could write our .repo files to a separate
+# place.
+if test '!' -w src/config; then
+    git clone --recurse src/config src/config.writable
+    rm src/config -rf
+    mv src/config.writable src/config
+fi
+
+#
+# NOTE: If you are adjusting how the repos are fetched in this script, you
+#        must also make the same change in the `prow-build-test-qemu.sh` script
+#
+# Grab the raw value of `mutate-os-release` and use sed to convert the value
+# to X-Y format
+ocpver=$(rpm-ostree compose tree --print-only src/config/manifest.yaml | jq -r '.["mutate-os-release"]')
+ocpver_mut=$(rpm-ostree compose tree --print-only src/config/manifest.yaml | jq -r '.["mutate-os-release"]' | sed 's|\.|-|')
+prev_build_url=${REDIRECTOR_URL}/rhcos-${ocpver}/
+
+# Fetch RHEL 8.6 repos
+curl -L http://base-"${ocpver_mut}"-rhel86.ocp.svc.cluster.local > src/config/ocp.repo
+
+cosa buildfetch --url=${prev_build_url}
+cosa fetch


### PR DESCRIPTION
Right now, the OpenShift CI jobs attached to this repository have the bottleneck of running `$ cosa build` within a container image build context. Because of how the OpenShift CI system is designed, it's not likely that we can use KVM within the container image build process to accelerate things. Despite this limitation, I've noticed that while the `cosa-build` image build itself usually does not time out, the 2+ hours it takes to run leaves us with very little headroom to run our test stages afterward. Despite this, we still need to produce the artifact in `cosa-build` in the way that we do. Here's how I plan to address this:

1. Separate the `$ cosa init` and `$ cosa build` steps in https://github.com/openshift/os/blob/master/ci/prow-build.sh.
2. Add another image build in openshift/release that only does the `$ cosa init` stuff (lets call this image `cosa-init` for now). This ensures we're using the same COSA session across all of the build and test stages.
3. Pass the `cosa-init` image into the current image build flow to do `$ cosa build` (this becomes the input to the `cosa-build` image build). This will still be the image that gets promoted if all the required tests pass.
4. We also pass the `cosa-init` image into the `test-qemu-*` test stages. Each test stage will run its own `$ cosa build` (with KVM acceleration) and execute the kola tests (also with KVM acceleration). These stages will run as soon as the `cosa-init` image is built and will run concurrently with the `cosa-build` image build.

This PR implements point 1) above by consolidating the `$ cosa init` (and the rest of the preparation steps) into the `ci/prow-prepare.sh` script. This also modifies `ci/prow-build-test-qemu.sh` and `ci/prow-build.sh` to make use of the new consolidated initialization flow. Points 2-4 are validated by https://github.com/openshift/release/pull/29187.

Once this PR is merged, we'll need another PR to openshift/release to add the `cosa-init` stage.