### PR TITLE
Add WALinuxAgent-udev package

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -343,6 +343,8 @@ packages:
  # https://bugzilla.redhat.com/show_bug.cgi?id=1925698
  # https://github.com/openshift/machine-config-operator/pull/2421
  - conntrack-tools
+ # Upstream PR https://github.com/coreos/fedora-coreos-config/pull/786
+ - WALinuxAgent-udev
 
 repo-packages:
   # we always want the kernel from BaseOS


### PR DESCRIPTION
Need WALinuxAgent-udev as it includes azure udev rules.
See:
- https://bugzilla.redhat.com/show_bug.cgi?id=1972102
- https://github.com/coreos/fedora-coreos-config/pull/786

Fix https://github.com/openshift/os/issues/822