### PR TITLE
set COSA_DIR in Dockerfile

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -8,5 +8,14 @@ RUN go test -v -c -o layering_test ./tests/layering
 
 FROM registry.svc.ci.openshift.org/coreos/coreos-assembler:latest
 WORKDIR /src
+ENV COSA_DIR=/tmp/cosa
 COPY --from=builder /go/src/github.com/openshift/os/layering_test /usr/local/bin/layering_test
 COPY . .
+RUN mkdir -p "${COSA_DIR}"
+# We need to make sure that root can read / write to the COSA_DIR so that
+# when this container is actually run, we have permissions to read and
+# write to the COSA_DIR to allow the Kola tests to run.
+USER root
+RUN chgrp -Rf root "${COSA_DIR}" && \
+  chmod -Rf g+w "${COSA_DIR}"
+USER builder

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -19,3 +19,4 @@ USER root
 RUN chgrp -Rf root "${COSA_DIR}" && \
   chmod -Rf g+w "${COSA_DIR}"
 USER builder
+WORKDIR /tmp/cosa

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -9,6 +9,8 @@ RUN go test -v -c -o layering_test ./tests/layering
 FROM registry.svc.ci.openshift.org/coreos/coreos-assembler:latest
 WORKDIR /src
 ENV COSA_DIR=/tmp/cosa
+# Prow doesn't support emptydir for jobs today
+ENV COSA_SKIP_OVERLAY=1
 COPY --from=builder /go/src/github.com/openshift/os/layering_test /usr/local/bin/layering_test
 COPY . .
 RUN mkdir -p "${COSA_DIR}"

--- a/ci/prow-build-test-qemu.sh
+++ b/ci/prow-build-test-qemu.sh
@@ -48,7 +48,9 @@ cosa kola --basic-qemu-scenarios
 kola run-upgrade -b rhcos -v --find-parent-image --qemu-image-dir tmp/ --output-dir tmp/kola-upgrade
 cosa kola run --parallel 2
 # Build metal + installer now so we can test them
-cosa buildextend-metal && cosa buildextend-metal4k && cosa buildextend-live
+cosa buildextend-metal
+cosa buildextend-metal4k
+cosa buildextend-live
 # compress the metal and metal4k images now so we're testing
 # installs with the image format we ship
 cosa compress --artifact=metal --artifact=metal4k


### PR DESCRIPTION
With the introduction of https://github.com/openshift/release/pull/29187, the test stages no longer have an explicitly set COSA_DIR value. Instead, they are calling `$ mktemp -d`.
