### PR TITLE
Bug 2094777: manifest: pull conmon pkg from RHAOS repo for 4.10

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -298,6 +298,8 @@ repo-packages:
       # previously shipped a newer version in OCP/RHCOS 4.9 and had to preserve
       # the upgrade path
       - runc
+      # newer than what is included in RHEL 8.4.Z EUS, needed to match cri-o changes
+      - conmon
 
 modules:
   enable:


### PR DESCRIPTION
This allows us to land OCP specific changes to conmon and
potentially ship newer versions than what would available in the module.