### PR TITLE
Bug 2094799: manifest: pull conmon from RHAOS repo for 4.9

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -274,6 +274,8 @@ repo-packages:
       # eventually, we want the one from the container-tools module, but we're
       # not there yet
       - toolbox
+      # newer than what is included in RHEL 8.4.Z EUS, needed to match cri-o changes
+      - conmon
 
 modules:
   enable:


### PR DESCRIPTION
This allows us to land OCP specific changes to conmon and
potentially ship newer versions than what would available in the module.