### PR TITLE
Modify CI scripts to use RHEL 8.6 repos

### DIFF
--- a/ci/prow-build-test-qemu.sh
+++ b/ci/prow-build-test-qemu.sh
@@ -34,9 +34,7 @@ fi
 ocpver=$(rpm-ostree compose tree --print-only src/config/manifest.yaml | jq -r '.["mutate-os-release"]')
 ocpver_mut=$(rpm-ostree compose tree --print-only src/config/manifest.yaml | jq -r '.["mutate-os-release"]' | sed 's|\.|-|')
 prev_build_url=${REDIRECTOR_URL}/rhcos-${ocpver}/
-# we want to use RHEL 8.5 for testing until we can start using 8.6
-# see https://github.com/openshift/release/pull/26193
-curl -L http://base-"${ocpver_mut}"-rhel85.ocp.svc.cluster.local > src/config/ocp.repo
+curl -L http://base-"${ocpver_mut}"-rhel86.ocp.svc.cluster.local > src/config/ocp.repo
 cosa buildfetch --url=${prev_build_url}
 cosa fetch
 cosa build

--- a/ci/prow-build-test-qemu.sh
+++ b/ci/prow-build-test-qemu.sh
@@ -37,9 +37,6 @@ prev_build_url=${REDIRECTOR_URL}/rhcos-${ocpver}/
 # we want to use RHEL 8.5 for testing until we can start using 8.6
 # see https://github.com/openshift/release/pull/26193
 curl -L http://base-"${ocpver_mut}"-rhel85.ocp.svc.cluster.local > src/config/ocp.repo
-# fetch the 8.6 appstream repo to enable building of extensions
-# see: https://github.com/openshift/os/issues/795
-curl -Ls http://base-"${ocpver_mut}"-rhel86.ocp.svc.cluster.local | grep -A 3 rhel-8-appstream | sed '1,3 s/rhel-8-appstream/rhel-86-appstream/g' >> src/config/ocp.repo
 cosa buildfetch --url=${prev_build_url}
 cosa fetch
 cosa build


### PR DESCRIPTION
We've switched to using RHEL 8.6 in the manifest + downstream, so update the CI scripts accordingly.
