### PR TITLE
ci/prow-entrypoint: No-op `cosa init` if already initialized

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -29,6 +29,10 @@ setup_user() {
 }
 
 cosa_init() {
+    if test -d builds; then
+        echo "Already in an initialized cosa dir"
+        return
+    fi
     # Always create a writable copy of the source repo
     tmp_src="$(mktemp -d)"
     cp -a /src "${tmp_src}/os"


### PR DESCRIPTION
This is going to be necessary for keeping coreos-assembler's `ci/prow/rhcos`
working.

cc https://github.com/coreos/coreos-assembler/pull/2922