### PR TITLE
manifest: Cleanups to prepare for manifest split

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -315,11 +315,7 @@ packages:
  - systemd-journal-gateway
  # RHEL7 compatibility
  - compat-openssl10
- # Make sure we pull in at least clevis 15; it drops the rd.neednet=1 hardcode
- # and has a few other patches we need.
- # https://bugzilla.redhat.com/show_bug.cgi?id=1853651
- - "'clevis >= 15-1.el8' 'clevis-luks >= 15-1.el8' 'clevis-dracut >= 15-1.el8'"
- - cryptsetup-reencrypt tpm2-tools
+ - cryptsetup-reencrypt
  # Used to update PAM configuration to work with SSSD
  # https://bugzilla.redhat.com/show_bug.cgi?id=1774154
  - authselect

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -315,7 +315,6 @@ packages:
  - systemd-journal-gateway
  # RHEL7 compatibility
  - compat-openssl10
- - cryptsetup-reencrypt
  # Used to update PAM configuration to work with SSSD
  # https://bugzilla.redhat.com/show_bug.cgi?id=1774154
  - authselect


### PR DESCRIPTION
manifest: Drop explicit clevis version requirements

- clevis and its subpackages are explicitly mentionned in
  fedora-coreos-config/manifests/ignition-and-ostree.yaml
- https://bugzilla.redhat.com/show_bug.cgi?id=1853651 is fixed in 8.4+.
- tpm2-tools is an explicity dependency in clevis in 8.6+.

---

manifest: Drop cryptsetup-reencrypt

The use of `cryptsetup-reencrypt` goes back to the null-cipher LUKS
container that we used to do disk encryption in early, early OCP 4 days.

As part of [1], the `rhcos-fde` dracut module dropped the requirement on
this package, so we should be able to safely drop it from the manifest
as well.

[1] https://github.com/openshift/os/pull/788