### PR TITLE
kola/tests: snooze rhcos.upgrade.from-ocp-rhcos

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -11,3 +11,6 @@
   tracker: https://bugzilla.redhat.com/show_bug.cgi?id=1899990
   arches:
   - s390x
+- pattern: rhcos.upgrade.from-ocp-rhcos
+  tracker: https://github.com/openshift/os/issues/857
+  snooze: 2022-06-27


### PR DESCRIPTION
Test is failing because the machine-os-content got pushed before the
build was actually successful resulting in a build that doesn't exist.

Snoozing until scheduled 4.10.20 as 4.10.19 has been dropped.

See https://github.com/openshift/os/issues/857