### PR TITLE
Bug 2099812: manifest: bump to openvswitch2.16

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -223,7 +223,7 @@ packages:
  - cri-o cri-tools
  # Networking
  - nfs-utils
- - openvswitch2.15
+ - openvswitch2.16
  - dnsmasq
  - NetworkManager-ovs
  # Extra runtime


### PR DESCRIPTION
- We want to keep host OVS and container OVS the same versions; we're using
  2.16 in ovn-kubernetes containers
- 2.16 has larger netlink buffers for upcalls which in high-traffic/upcall
  situations keeps things flowing well
- 2.16 was part of the 4.11 dev cycle from mid-Feb -> late-April and
  did not show data plane regressions in CI or perf/scale testing

@trozet @fleitner