### PR TITLE
Bug 2096508: [4.9]: manifest: move runc to rhaos channel

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -276,6 +276,8 @@ repo-packages:
       - toolbox
       # newer than what is included in RHEL 8.4.Z EUS, needed to match cri-o changes
       - conmon
+      # newer than what is included in RHEL 8.4.Z EUS, needed to patch for BZ#2096508
+      - runc
 
 modules:
   enable:


### PR DESCRIPTION
to pickup fix in runc 1.0.1

Signed-off-by: Peter Hunt <pehunt@redhat.com>