### PR TITLE
gitmodules: use rhcos-4.11 branch from fedora-coreos-config

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "fedora-coreos-config"]
 	path = fedora-coreos-config
 	url = https://github.com/coreos/fedora-coreos-config
-	branch = testing-devel
+	branch = rhcos-4.11


### PR DESCRIPTION
`master` of `openshift/os` is tracking 4.12 now, so have
`release-4.11` track the `rhcos-4.11` branch in the submodule