### PR TITLE
s390x: Cleanup after fedora-coreos-config bump

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -27,3 +27,7 @@
   tracker: https://github.com/coreos/coreos-assembler/issues/2725
   arches:
   - ppc64le
+- pattern: ext.config.shared.files.file-directory-permissions
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1243
+  arches:
+  - s390x

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -27,8 +27,3 @@
   tracker: https://github.com/coreos/coreos-assembler/issues/2725
   arches:
   - ppc64le
-- pattern: ext.config.shared.binfmt.qemu
-  tracker: https://github.com/openshift/os/pull/874
-  arches:
-  - s390x
-  - aarch64


### PR DESCRIPTION
Cleaning up after https://github.com/openshift/os/pull/877 landed