### PR TITLE
common: Add magic symlinks to enable librhsm (subscriptions)

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -106,6 +106,13 @@ postprocess:
     #!/usr/bin/bash
     mkdir -p /etc/yum.repos.d
 
+  # These enable librhsm which enables host subscriptions to work in containers
+  # https://github.com/rpm-software-management/librhsm/blob/fcd972cbe7c8a3907ba9f091cd082b1090231492/rhsm/rhsm-context.c#L30
+  - |
+    #!/usr/bin/bash
+    ln -sr /run/secrets/etc-pki-entitlement /etc/pki/entitlement-host
+    ln -sr /run/secrets/rhsm /etc/rhsm-host
+
   # This updates the PAM configuration to reference all of the SSSD modules.
   # Removes the `authselect` binary afterwards since `authselect` does not play well with `nss-altfiles`
   # (https://github.com/pbrezina/authselect/issues/48).


### PR DESCRIPTION
These enable librhsm which enables host subscriptions to work in containers
https://github.com/rpm-software-management/librhsm/blob/fcd972cbe7c8a3907ba9f091cd082b1090231492/rhsm/rhsm-context.c#L30

Part of https://github.com/openshift/enhancements/blob/master/enhancements/ocp-coreos-layering.md

You can see this in the rhel8-minimal UBI image:

```
$ podman run --rm -ti registry.access.redhat.com/ubi8-minimal:latest cat /root/anaconda-ks.cfg  | grep -2 'entitlement-host'

ln -s /run/secrets/etc-pki-entitlement /etc/pki/entitlement-host
ln -s /run/secrets/rhsm /etc/rhsm-host
$
```

(Where the public source for that kickstart is, no idea)