### PR TITLE
s390x/aarch64: Deny binfmt.qemu test for now until f-c-c bump lands

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -27,3 +27,8 @@
   tracker: https://github.com/coreos/coreos-assembler/issues/2725
   arches:
   - ppc64le
+- pattern: ext.config.shared.binfmt.qemu
+  tracker: https://github.com/openshift/os/pull/874
+  arches:
+  - s390x
+  - aarch64


### PR DESCRIPTION
The test will be properly set to fcos-only by #874
Disable it until that PR can land.

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>