### PR TITLE
manifest: Require `skopeo >= 2:1.7.0`

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -168,6 +168,8 @@ packages:
  - containernetworking-plugins
  # Pinned due to cosa on Fedora not honoring RHEL 8 modules as expected
  - container-selinux
+ # Needed for newer rpm-ostree
+ - "'skopeo >= 2:1.7.0'"
  - cri-o cri-tools
  # Networking
  - nfs-utils


### PR DESCRIPTION
This is needed for the latest rpm-ostree;
https://github.com/coreos/rpm-ostree/issues/3819