### PR TITLE
s390x: add 'genprotimg' tool

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -236,6 +236,11 @@ packages-ppc64le:
   - ppc64-diag-rtas
   - rdma-core
 
+packages-s390x:
+  # Required for IBM Secure Execution. Now is part of s390utils-base.rpm
+  # https://github.com/coreos/fedora-coreos-tracker/issues/1217
+  - /usr/bin/genprotimg
+
 remove-from-packages:
   - - filesystem
     - "/usr/share/backgrounds"


### PR DESCRIPTION
This tool is required for IBM Secure Execution. Now it comes with
`s390utils-base` rpm, which depends on `perl-*` packages. Those are
already part of RHCOS, but not FCOS. Once the tool moves to `s390utils-core`
package, we can revert this patch.

https://github.com/coreos/fedora-coreos-tracker/issues/1217
