### PR TITLE
fixes in-cluster derivation test

### DIFF
--- a/tests/layering/fixtures/Dockerfile
+++ b/tests/layering/fixtures/Dockerfile
@@ -1,0 +1,16 @@
+# This file is consumed by the layering test. It is embedded into
+# the layering test binary via an embed directive in the
+# fixtures.go file.
+ARG BASE_OS_IMAGE="registry.ci.openshift.org/rhcos-devel/rhel-coreos:latest"
+FROM registry.access.redhat.com/ubi8/ubi:latest as builder
+WORKDIR /build
+COPY . .
+RUN yum -y install go-toolset
+RUN go build hello-world.go
+
+FROM $BASE_OS_IMAGE
+# Inject our Golang binary into our OS base image
+COPY --from=builder /build/hello-world /usr/bin
+# And add our unit file
+ADD hello-world.service /etc/systemd/system/hello-world.service
+RUN ostree container commit

--- a/tests/layering/fixtures/fixtures.go
+++ b/tests/layering/fixtures/fixtures.go
@@ -1,0 +1,12 @@
+package fixtures
+
+import _ "embed"
+
+//go:embed Dockerfile
+var Dockerfile string
+
+//go:embed hello-world.go.fixture
+var HelloWorldSrc string
+
+//go:embed hello-world.service
+var HelloWorldService string

--- a/tests/layering/fixtures/hello-world.go.fixture
+++ b/tests/layering/fixtures/hello-world.go.fixture
@@ -1,0 +1,12 @@
+// This file is consumed by the layering test. It is embedded into
+// the layering test binary via an embed directive in the
+// fixtures.go file.
+package main
+
+import (
+	"fmt"
+)
+
+func main() {
+	fmt.Println("Hello, world!")
+}

--- a/tests/layering/fixtures/hello-world.service
+++ b/tests/layering/fixtures/hello-world.service
@@ -1,0 +1,11 @@
+# This file is consumed by the layering test. It is embedded into
+# the layering test binary via an embed directive in the
+# fixtures.go file.
+[Unit]
+Description=A hello world unit!
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/hello-world
+[Install]
+WantedBy=multi-user.target

--- a/tests/layering/helpers_test.go
+++ b/tests/layering/helpers_test.go
@@ -125,7 +125,6 @@ func assertNotInDerivedImage(t *testing.T, cs *framework.ClientSet, node *corev1
 func checkUsingImage(t *testing.T, cs *framework.ClientSet, node *corev1.Node, usingImage bool, status *Status) {
 	// These files are placed on the node by the derived container build process.
 	expectedFiles := []string{
-		"/usr/lib64/libpixman-1.so.0",
 		"/etc/systemd/system/hello-world.service",
 		helloWorldPath,
 	}

--- a/tests/layering/layering_test.go
+++ b/tests/layering/layering_test.go
@@ -22,12 +22,13 @@ const (
 	// If this moves from /run, make sure files get cleaned up
 	authfilePath = "/run/ostree/auth.json"
 
-	buildName       = imageStreamName
-	helloWorldPath  = "/usr/bin/hello-world"
-	imageRegistry   = "image-registry.openshift-image-registry.svc:5000"
-	imageStreamName = "test-boot-in-cluster-image"
-	imageURL        = ostreeUnverifiedRegistry + ":" + imageRegistry + "/" + mcoNamespace + "/" + imageStreamName
-	mcoNamespace    = "openshift-machine-config-operator"
+	buildName          = imageStreamName
+	buildConfigMapName = buildName + "-config-map"
+	helloWorldPath     = "/usr/bin/hello-world"
+	imageRegistry      = "image-registry.openshift-image-registry.svc:5000"
+	imageStreamName    = "test-boot-in-cluster-image"
+	imageURL           = ostreeUnverifiedRegistry + ":" + imageRegistry + "/" + mcoNamespace + "/" + imageStreamName
+	mcoNamespace       = "openshift-machine-config-operator"
 
 	// ostreeUnverifiedRegistry means no GPG or container signatures are used.
 	// Right now we're usually relying on digested pulls. See
@@ -60,9 +61,11 @@ func TestBootInClusterImage(t *testing.T) {
 	if deleteBuild != nil && *deleteBuild == true {
 		defer func() {
 			t.Log("Deleting the ImageStream")
-			require.Nil(t, cs.ImageStreams(mcoNamespace).Delete(context.TODO(), imageStreamName, metav1.DeleteOptions{}))
+			require.Nil(t, cs.ImageStreams(mcoNamespace).Delete(ctx, imageStreamName, metav1.DeleteOptions{}))
 			t.Log("Deleting the Image Build")
-			require.Nil(t, cs.BuildV1Interface.Builds(mcoNamespace).Delete(context.TODO(), buildName, metav1.DeleteOptions{}))
+			require.Nil(t, cs.BuildV1Interface.Builds(mcoNamespace).Delete(ctx, buildName, metav1.DeleteOptions{}))
+			t.Log("Deleting the Image Build ConfigMap")
+			require.Nil(t, cs.CoreV1Interface.ConfigMaps(mcoNamespace).Delete(ctx, buildConfigMapName, metav1.DeleteOptions{}))
 		}()
 	}
 


### PR DESCRIPTION
This relocates the Dockerfile, hello-world source, etc. used for the in-cluster derivation test into this repository so we do not have to rely upon https://github.com/coreos/coreos-layering-examples. The reasoning is because coreos-layering-examples does not currently have CI set up to validate that the Dockerfiles it contains can be built.
