### PR TITLE
extensions/Dockerfile: remove build arg

### DIFF
--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -1,4 +1,3 @@
-ARG RHCOS_VERSION=latest
 #Build a newer rpm-ostree
 FROM quay.io/centos/centos:stream8 as rpm-ostree
 RUN sed -i -e 's,enabled=0,enabled=1,' /etc/yum.repos.d/CentOS-Stream-PowerTools.repo
@@ -14,7 +13,7 @@ RUN env CFLAGS='-ggdb -Og' CXXFLAGS='-ggdb -Og' ./autogen.sh --prefix=/usr --lib
 RUN make
 
 ## Downloads the extensions given the extensions.yaml
-FROM registry.ci.openshift.org/rhcos-devel/rhel-coreos:${RHCOS_VERSION} as os
+FROM registry.ci.openshift.org/rhcos-devel/rhel-coreos:latest as os
 
 # Install new rpm-ostree
 COPY --from=rpm-ostree /rpm-ostree/target/debug/rpm-ostree /usr/bin/rpm-ostree


### PR DESCRIPTION
When ci-operator builds this Dockerfile, it attempts to replace
registry.ci.openshift.org/rhcos-devel/rhel-coreos:latest with a pullspec
to the RHCOS image it just built. However, since this takes a build arg,
ci-operator cannot substitute the build arg for the rhel-coreos:latest
image. This means that the extensions container could potentially be
built against the wrong RHCOS version.
