### PR TITLE
ci/prow-entrypoint: Ensure we have a qemu image for followup builds

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -111,6 +111,7 @@ kola_test_metal() {
 
 # Ensure that we can create all platform images for COSA CI
 cosa_buildextend_all() {
+    cosa build
     cosa buildextend-aliyun
     cosa buildextend-aws
     cosa buildextend-azure


### PR DESCRIPTION
This should fix https://github.com/coreos/coreos-assembler/pull/2919#issuecomment-1180824612

Fixes: c6e7dd9f99cfc9fe90ec87e041943743ab150cd6