### PR TITLE
CI: Re-enable buildextend testing for COSA CI

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -204,6 +204,7 @@ main () {
             setup_user
             cosa_init
             cosa_build
+            cosa_buildextend_all
             kola_test_qemu
             ;;
         "rhcos-86-build-test-metal")


### PR DESCRIPTION
This should fix coreos/coreos-assembler#2919 (comment)

Fixes: c6e7dd9
Fixes: coreos/coreos-assembler#2973