### PR TITLE
ci: Make COSA test job like QEMU

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -189,7 +189,6 @@ main () {
             setup_user
             cosa_init
             cosa_build
-            cosa_buildextend_all
             kola_test_qemu
             ;;
         "rhcos-86-build-test-qemu")


### PR DESCRIPTION
Temporary workaround until we figure out CI failures during buildextend
for all platform images.