### PR TITLE
Bug 2106058: vSphere defaults to SecureBoot on; breaks installation of out-of-tree drivers

### DIFF
--- a/image.yaml
+++ b/image.yaml
@@ -14,6 +14,10 @@ ignition-network-kcmdline: []
 
 ostree-format: "oci"
 
+# vmware-secure-boot changes the EFI secure boot option.
+# set false here due to https://bugzilla.redhat.com/show_bug.cgi?id=2106055
+vmware-secure-boot: false
+
 vmware-os-type: rhel8_64Guest
 # VMware hardware versions: https://kb.vmware.com/s/article/1003746
 # Supported VMware versions: https://lifecycle.vmware.com/


### PR DESCRIPTION
Secure boot enabled by default causes issues with unsigned kernel
modules.

ref: https://bugzilla.redhat.com/show_bug.cgi?id=2106055
(cherry picked from commit fde312556a7f1c6a87bbb4ea0d4b14f26ab84cef)
(cherry picked from commit 98daddb09ee439d12d1684f92af46e6d4c197b1c)

requires https://github.com/coreos/coreos-assembler/pull/2983