### PR TITLE
Bug 2108320: Greatly raise `StartLimitBurst` for `rpm-ostreed.service`

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -16,6 +16,7 @@ ostree-layers:
   - overlay/05rhcos
   - overlay/06gcp-routes
   - overlay/15rhcos-tuned-bits
+  - overlay/15rhcos-rhel8-workarounds  # TODO conditionalize on rhel8
   - overlay/20platform-chrony
   - overlay/21dhcp-chrony
 

--- a/overlay.d/15rhcos-rhel8-workarounds/usr/lib/systemd/system/rpm-ostreed.service.d/startlimit.conf
+++ b/overlay.d/15rhcos-rhel8-workarounds/usr/lib/systemd/system/rpm-ostreed.service.d/startlimit.conf
@@ -1,0 +1,4 @@
+[Unit]
+# Work around for lack of https://github.com/coreos/rpm-ostree/pull/3523/commits/0556152adb14a8e1cdf6c5d6f234aacbe8dd4e3f
+# on older RHEL
+StartLimitBurst=1000

--- a/tests/kola/rpm-ostree/startlimit
+++ b/tests/kola/rpm-ostree/startlimit
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail
+# https://github.com/coreos/rpm-ostree/pull/3523/commits/0556152adb14a8e1cdf6c5d6f234aacbe8dd4e3f
+for x in $(seq 10); do rpm-ostree status >/dev/null; done
+echo ok


### PR DESCRIPTION
This is a hack to work around the lack of
https://github.com/coreos/rpm-ostree/pull/3523/commits/0556152adb14a8e1cdf6c5d6f234aacbe8dd4e3f
for RHEL 8.6 and below.

A recent PR in the MCO https://github.com/openshift/machine-config-operator/pull/3243
tipped things over the edge and we now see failures a lot more often.