### PR TITLE
rhel9: Switch to pulling toolbox from RHEL and not OCP

### DIFF
--- a/manifest-rhel-9.0.yaml
+++ b/manifest-rhel-9.0.yaml
@@ -154,8 +154,3 @@ repo-packages:
   - repo: rhel-9-appstream
     packages:
       - nss-altfiles
-  - repo: rhel-9-server-ose
-    packages:
-      # eventually, we want the one from the container-tools module, but we're
-      # not there yet
-      - toolbox


### PR DESCRIPTION
Fix issue:
When running `cosa fetch` for rhcos based on rhel9.0, get `error:
No matches for 'toolbox' in repo 'rhel-9-server-ose'`