### PR TITLE
manifest: Pin systemd version

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -238,6 +238,8 @@ packages:
  # Used on the bootstrap node
  - systemd-journal-remote
  # Extras
+ # Pin systemd version until we solve https://bugzilla.redhat.com/show_bug.cgi?id=2109546
+ - "'systemd <= 239-45.el8_4.10'"
  - systemd-journal-gateway
  # RHEL7 compatibility
  - compat-openssl10


### PR DESCRIPTION
- The RHCOS CI is failing due an update in systemd,
let's pin it until we can solve it

More info: https://bugzilla.redhat.com/show_bug.cgi?id=2109546