### PR TITLE
kola-denylist/s390x: Disable kdump test in rhcos

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -31,3 +31,7 @@
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1243
   arches:
   - s390x
+- pattern: ext.config.shared.kdump.crash
+  tracker: https://github.com/coreos/fedora-coreos-config/issues/1500
+  arches:
+    - s390x


### PR DESCRIPTION
Disable the test here for rhcos, now that we have a fix in fcos rawhide.

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>