### PR TITLE
manifest: Add polkit for now

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -182,6 +182,8 @@ packages:
  - nfs-utils
  - dnsmasq
  - NetworkManager-ovs
+ # needed for rpm-ostree today
+ - polkit
  # Extra runtime
  - sssd
  # Common tools used by scripts and admins interactively


### PR DESCRIPTION
rpm-ostree doesn't behave fully correctly without it today, but
we'll be fixing that.

https://bugzilla.redhat.com/show_bug.cgi?id=2105405#c12

> rpm-ostree: Failed to exec /usr/bin/pkttyagent: No such file or directory