### PR TITLE
[4.10] manifest: Pull podman & skopeo from RHAOS repo

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -300,6 +300,8 @@ repo-packages:
       - runc
       # newer than what is included in RHEL 8.4.Z EUS, needed to match cri-o changes
       - conmon
+      # newer then what is included in RHEL 8.4.Z EUS
+      - podman skopeo
 
 modules:
   enable:


### PR DESCRIPTION
We will push new versions of those packages into this repo as we need it in 4.10 but they won't be released for RHEL 8.4.