### PR TITLE
manifest: Pull skopeo from RHAOS repo for rhel9

### DIFF
--- a/manifest-rhel-9.0.yaml
+++ b/manifest-rhel-9.0.yaml
@@ -154,3 +154,7 @@ repo-packages:
   - repo: rhel-9-appstream
     packages:
       - nss-altfiles
+  # remove this when newer version in rhel9
+  - repo: rhel-8-server-ose
+    packages:
+      - skopeo


### PR DESCRIPTION
Fix `rhcos-90-build-test` CI error in https://github.com/openshift/os/pull/905 : `error: Packages not found: skopeo >= 2:1.7.0`