### PR TITLE
scos: make ext.config.files.env-godebug compatable for scos

### DIFF
--- a/tests/kola/files/env-godebug
+++ b/tests/kola/files/env-godebug
@@ -12,7 +12,8 @@ fatal() {
     exit 1
 }
 
-ostree_conf="/boot/loader.1/entries/ostree-1-rhcos.conf"
+source /etc/os-release
+ostree_conf="/boot/loader.1/entries/ostree-1-${ID}.conf"
 initramfs=/boot$(grep initrd ${ostree_conf} | sed 's/initrd //g')
 conf="etc/systemd/system.conf.d/10-default-env-godebug.conf"
 tempd=$(mktemp -d)


### PR DESCRIPTION
Fix failed case `ext.config.files.env-godebug`