### PR TITLE
05rhcos: add `Before=` to `rhcos-afterburn-checkin.service`

### DIFF
--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/30rhcos-afterburn-checkin/rhcos-afterburn-checkin.service
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/30rhcos-afterburn-checkin/rhcos-afterburn-checkin.service
@@ -30,6 +30,9 @@ After=ignition-fetch.service
 # across reboots, so defer it until after the kargs reboot.
 After=coreos-kargs-reboot.service
 
+# Run before switching root.
+Before=initrd.target
+
 [Service]
 Environment=AFTERBURN_OPT_PROVIDER=--cmdline
 ExecStart=/usr/bin/afterburn ${AFTERBURN_OPT_PROVIDER} --check-in


### PR DESCRIPTION
Dracut services must sequence themselves `Before` something, to prevent races where the service doesn't run before it's killed by `initrd-cleanup.service`.

xref https://github.com/coreos/fedora-coreos-config/pull/1884