### PR TITLE
Collection of SCOS & RHCOS 9 fixes

### DIFF
--- a/extensions-c9s.yaml
+++ b/extensions-c9s.yaml
@@ -49,14 +49,11 @@ extensions:
   # https://github.com/openshift/machine-config-operator/pull/2456
   # https://github.com/openshift/enhancements/blob/master/enhancements/sandboxed-containers/sandboxed-containers-tech-preview.md
   # GRPA-3123
-  # - kata-containers (RHAOS)
-  sandboxed-containers:
-    architectures:
-      - x86_64
-    modules:
-      enable:
-        - virt:rhel
-    repos:
-      - appstream
-    packages:
-      - kata-containers
+  # - kata-containers
+  # sandboxed-containers:
+  #   architectures:
+  #     - x86_64
+  #   repos:
+  #     - appstream
+  #   packages:
+  #     - kata-containers

--- a/extensions-rhel-9.0.yaml
+++ b/extensions-rhel-9.0.yaml
@@ -53,9 +53,6 @@ extensions:
   sandboxed-containers:
     architectures:
       - x86_64
-    modules:
-      enable:
-        - virt:rhel
     repos:
       - rhel-9-appstream
     packages:

--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -138,5 +138,5 @@ packages:
  # We include the generic release package and tweak the os-release info in a
  # post-proces script
  - centos-release
- # RHCOS package name includes a version number
- - openvswitch2.16
+ # Keep the version in sync with RHCOS
+ - openvswitch2.17

--- a/manifest-rhel-9.0.yaml
+++ b/manifest-rhel-9.0.yaml
@@ -140,7 +140,7 @@ packages:
  # We include the generic release package and tweak the os-release info in a
  # post-proces script
  - redhat-release
- # SCOS package name does not include a version number
+ # Keep the version in sync with SCOS
  - openvswitch2.17
 
 # Packages pinned to specific repos in RHCOS

--- a/manifest-rhel-9.0.yaml
+++ b/manifest-rhel-9.0.yaml
@@ -153,3 +153,7 @@ repo-packages:
   - repo: rhel-9-appstream
     packages:
       - nss-altfiles
+  # TODO: Remove this when newer version of skopeo is available in RHEL9 or RHAOS9
+  - repo: rhel-8-server-ose
+    packages:
+      - skopeo

--- a/overlay.d/05rhcos/usr/libexec/coreos-cryptfs
+++ b/overlay.d/05rhcos/usr/libexec/coreos-cryptfs
@@ -104,7 +104,7 @@ try_open() {
     local clevis_id="$(cryptsetup luksDump ${dev} | sed -rn 's|^\s+([0-9]+): clevis|\1|p')"
     if [ -n "${clevis_id}" ]; then
         load_kmods
-        local pin=$(cryptsetup token export --token-id "${cleivs_id}" "${dev}" \
+        local pin=$(cryptsetup token export --token-id "${clevis_id}" "${dev}" \
             | jq -rM '.jwe.protected' | base64 -d | jq -rM '.clevis.pin')
         msg "${dev} is configured for Clevis pin '${pin}'"
         [ "${pin}" == "tpm2" ] || net_waiter

--- a/repos/c9s.repo
+++ b/repos/c9s.repo
@@ -33,7 +33,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Officia
 [openvswitch]
 name=CentOS Stream 9 OpenvSwitch
 baseurl=http://mirror.stream.centos.org/SIGs/9-stream/nfv/x86_64/openvswitch-2/
-gpgcheck=0
+gpgcheck=1
 repo_gpgcheck=0
 enabled=1
-# gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-NFV


### PR DESCRIPTION
Fixes extracted from https://github.com/openshift/os/pull/905 (where they passed CI). Merging those independently so that we don't accumulate too much changes in the backlog as we can not fully enable CI yet.

---

extensions: Remove now unneeded module directive (RHEL9)

libvirt & qemu-kvm are not in a module anymore in RHEL 9.

---

extensions: Disable kata-containers (SCOS)

Temporarily disable kata-containers extension for SCOS.

---

manifests: Fix openvswitch for SCOS/RHCOS9

- Update versions now that C9S ones are available
- Use the correct GPG key for the NFV CentOS SIG

---

manifest: Pull skopeo from RHAOS repo for rhel9

---

overlay/05rhcos: Fix typo in coreos-cryptfs