### PR TITLE
common.yaml: add `crypto-policies-scripts` which provides `fips-mode-setup`

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -222,6 +222,8 @@ packages:
  - conntrack-tools
  # Upstream PR https://github.com/coreos/fedora-coreos-config/pull/786
  - WALinuxAgent-udev
+ # Provide fips-mode-setup which is needed by rhcos-fips.sh
+ - crypto-policies-scripts
 
 packages-x86_64:
   # Temporary add of open-vm-tools. Should be removed when containerized


### PR DESCRIPTION
`crypto-policies-scripts` includes `fips-mode-setup` tool, which
is needed by rhcos-fips.sh. The package is missing when building
SCOS image, we need to add it