### PR TITLE
Bug 2117353: [release-4.11] bump fedora-coreos-config submodule

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -5,8 +5,6 @@
   tracker: https://bugzilla.redhat.com/show_bug.cgi?id=1782026
   arches:
    - s390x
-- pattern: ext.config.chrony.dhcp-propagation
-  tracker: https://github.com/coreos/fedora-coreos-config/commit/3dee27d4487ee0a484858fe60e3c5b1a792d48b9
 - pattern: coreos.ignition.journald-log
   tracker: https://github.com/coreos/coreos-assembler/issues/1173
 - pattern: coreos.ignition.mount.*


### PR DESCRIPTION
git shortlog --no-merges f99e2b78224c3c4fbc64da9a03e27665d4487f09..539f342b78478360c1939c2547a343107bb79849
Benjamin Gilbert (1):
      05core: fix coreos-boot-edit.service race with switch-root

Dusty Mabe (1):
      tests: bump memory for tests because of DNF issue