### PR TITLE
Bug 2114964: denylist: Skip ext.config.chrony.dhcp-propagation

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -5,6 +5,8 @@
   tracker: https://bugzilla.redhat.com/show_bug.cgi?id=1782026
   arches:
    - s390x
+- pattern: ext.config.chrony.dhcp-propagation
+  tracker: https://github.com/coreos/fedora-coreos-config/commit/3dee27d4487ee0a484858fe60e3c5b1a792d48b9
 - pattern: coreos.ignition.journald-log
   tracker: https://github.com/coreos/coreos-assembler/issues/1173
 - pattern: coreos.ignition.mount.*


### PR DESCRIPTION
The test needs adjustment, the OS content is fine.  Fix this
after 4.11 is out.