### PR TITLE
CI: Partially enable RHCOS 9 & SCOS testing

### DIFF
--- a/common-el9.yaml
+++ b/common-el9.yaml
@@ -1,0 +1,32 @@
+# Manifest shared between CentOS Stream 9 and RHEL 9 variants
+
+postprocess:
+  # Collection of workarounds specific to EL9 variants
+  - |
+     #!/usr/bin/env bash
+     set -xeo pipefail
+
+     # FIXME: Force enable dbus-broker to get the dbus.service → dbus-broker.service
+     systemctl enable dbus-broker
+
+     # FIXME: Why is this only broken here?  NM isn't removing the link?
+     sed -i '/etc.resolv/d' /usr/lib/tmpfiles.d/etc.conf
+
+     # crio should stop hardcoding things in their config file!
+     # We are apparently somehow pulling in a conmon override in RHCOS
+     # that contains /usr/libexec/crio/conmon - WHY?
+     # sed -i '/conmon.*=/d' /etc/crio/crio.conf
+     # Oh right but the MCO overrides that too so...
+     mkdir -p /usr/libexec/crio
+     ln -sr /usr/bin/conmon /usr/libexec/crio/conmon
+
+     # Use crun by default
+     sed -i '/\[crio.runtime\]/a default_runtime="crun"' /etc/crio/crio.conf
+     cat >> /etc/crio/crio.conf <<EOF
+     [crio.runtime.runtimes.crun]
+     runtime_path="/usr/bin/crun"
+     EOF
+
+# Packages that are only for SCOS & RHCOS 9
+packages:
+ - openvswitch2.17

--- a/extensions-rhel-9.0.yaml
+++ b/extensions-rhel-9.0.yaml
@@ -4,6 +4,8 @@
 
 repos:
   - rhel-9-nfv
+  # Temporarily included for kata-containers
+  - rhel-8-server-ose
 
 extensions:
   # https://github.com/coreos/fedora-coreos-tracker/issues/326

--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -22,8 +22,8 @@ repos:
   - baseos
   - appstream
   - sig-nfv
-  # Temporarily include RHCOS 8 repo for cri-o, oc & hyperkube
-  - rhel-8-server-ose
+  # Temporarily include RHCOS 9 repo for cri-o, cri-tools, oc & hyperkube
+  - rhel-9-server-ose
 
 # We include hours/minutes to avoid version number reuse
 automatic-version-prefix: "412.91.<date:%Y%m%d%H%M>"

--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -9,9 +9,11 @@ variables:
   distro: "scos"
   version: "9"
 
-# Include manifests common to all RHEL and CentOS Stream versions
+# Include manifests common to all RHEL and CentOS Stream versions and manifest
+# common to RHEL 9 & C9S variants
 include:
   - common.yaml
+  - common-el9.yaml
 
 # Starting from here, everything should be specific to SCOS
 
@@ -106,31 +108,6 @@ postprocess:
 
      ---
      EOF
-  # Collection of workarounds specific to SCOS
-  - |
-     #!/usr/bin/env bash
-     set -xeo pipefail
-
-     # FIXME: Force enable dbus-broker to get the dbus.service → dbus-broker.service
-     systemctl enable dbus-broker
-
-     # FIXME: Why is this only broken here?  NM isn't removing the link?
-     sed -i '/etc.resolv/d' /usr/lib/tmpfiles.d/etc.conf
-
-     # crio should stop hardcoding things in their config file!
-     # We are apparently somehow pulling in a conmon override in RHCOS
-     # that contains /usr/libexec/crio/conmon - WHY?
-     # sed -i '/conmon.*=/d' /etc/crio/crio.conf
-     # Oh right but the MCO overrides that too so...
-     mkdir -p /usr/libexec/crio
-     ln -sr /usr/bin/conmon /usr/libexec/crio/conmon
-
-     # Use crun by default
-     sed -i '/\[crio.runtime\]/a default_runtime="crun"' /etc/crio/crio.conf
-     cat >> /etc/crio/crio.conf <<EOF
-     [crio.runtime.runtimes.crun]
-     runtime_path="/usr/bin/crun"
-     EOF
 
 # Packages that are only in SCOS and not in RHCOS or that have special
 # constraints that do not apply to RHCOS
@@ -138,5 +115,3 @@ packages:
  # We include the generic release package and tweak the os-release info in a
  # post-proces script
  - centos-release
- # Keep the version in sync with RHCOS
- - openvswitch2.17

--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -21,7 +21,7 @@ include:
 repos:
   - baseos
   - appstream
-  - openvswitch
+  - sig-nfv
   # Temporarily include RHCOS 8 repo for cri-o, oc & hyperkube
   - rhel-8-server-ose
 

--- a/manifest-rhel-9.0.yaml
+++ b/manifest-rhel-9.0.yaml
@@ -9,9 +9,11 @@ variables:
   distro: "rhel"
   version: "9.0"
 
-# Include manifests common to all RHEL and CentOS Stream versions
+# Include manifests common to all RHEL and CentOS Stream versions and manifest
+# common to RHEL 9 & C9S variants
 include:
   - common.yaml
+  - common-el9.yaml
 
 # Starting from here, everything should be specific to RHCOS based on RHEL 9.0
 
@@ -108,31 +110,6 @@ postprocess:
 
      ---
      EOF
-  # Collection of workarounds specific to RHEL 9.0 based RHCOS
-  - |
-     #!/usr/bin/env bash
-     set -xeo pipefail
-
-     # FIXME: Force enable dbus-broker to get the dbus.service → dbus-broker.service
-     systemctl enable dbus-broker
-
-     # FIXME: Why is this only broken here?  NM isn't removing the link?
-     sed -i '/etc.resolv/d' /usr/lib/tmpfiles.d/etc.conf
-
-     # crio should stop hardcoding things in their config file!
-     # We are apparently somehow pulling in a conmon override in RHCOS
-     # that contains /usr/libexec/crio/conmon - WHY?
-     # sed -i '/conmon.*=/d' /etc/crio/crio.conf
-     # Oh right but the MCO overrides that too so...
-     mkdir -p /usr/libexec/crio
-     ln -sr /usr/bin/conmon /usr/libexec/crio/conmon
-
-     # Use crun by default
-     sed -i '/\[crio.runtime\]/a default_runtime="crun"' /etc/crio/crio.conf
-     cat >> /etc/crio/crio.conf <<EOF
-     [crio.runtime.runtimes.crun]
-     runtime_path="/usr/bin/crun"
-     EOF
 
 # Packages that are only in RHCOS and not in SCOS or that have special
 # constraints that do not apply to SCOS
@@ -140,8 +117,6 @@ packages:
  # We include the generic release package and tweak the os-release info in a
  # post-proces script
  - redhat-release
- # Keep the version in sync with SCOS
- - openvswitch2.17
 
 # Packages pinned to specific repos in RHCOS
 repo-packages:

--- a/manifest-rhel-9.0.yaml
+++ b/manifest-rhel-9.0.yaml
@@ -22,9 +22,9 @@ repos:
   - rhel-9-baseos
   - rhel-9-appstream
   - rhel-9-fast-datapath
-  # Temporarily disabled until available
-  # - rhel-9-server-ose
+  # Temporarily include RHCOS 8 repo for skopeo
   - rhel-8-server-ose
+  - rhel-9-server-ose
 
 # We include hours/minutes to avoid version number reuse
 automatic-version-prefix: "412.90.<date:%Y%m%d%H%M>"

--- a/repos/c9s.repo
+++ b/repos/c9s.repo
@@ -30,8 +30,8 @@ repo_gpgcheck=0
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
-[openvswitch]
-name=CentOS Stream 9 OpenvSwitch
+[sig-nfv]
+name=CentOS Stream 9 - SIG NFV
 baseurl=http://mirror.stream.centos.org/SIGs/9-stream/nfv/x86_64/openvswitch-2/
 gpgcheck=1
 repo_gpgcheck=0


### PR DESCRIPTION
Let's enable some CI that works right now so that at least we don't regress.

---

manifests: Add shared manifest for EL9 variants

---

repos: Update C9S SIG NFV repo name

---

ci: Partially enable RHCOS 9 & SCOS testing

- Only build RHCOS9, only run basic tests for SCOS
- Includes temporary workaround for variant selection for non default
  variants. Will be removed once COSA support for variants is completed.