### PR TITLE
Bug 2116456: Revert "manifest: Pin systemd version"

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -223,8 +223,6 @@ packages:
  # Used on the bootstrap node
  - systemd-journal-remote
  # Extras
- # Pin systemd version until we solve https://bugzilla.redhat.com/show_bug.cgi?id=2109546
- - "'systemd <= 239-45.el8_4.10'"
  - systemd-journal-gateway
  # RHEL7 compatibility
  - compat-openssl10


### PR DESCRIPTION
The console-login-helper-messages package was patched to workaround the
updated systemd[0]. This should allow RHCOS to retrack the systemd in 8.4 and get updates.

This reverts commit 7abac3cb64e3eaff02f8c5b0f4d6a62c69a46958.

[0] https://github.com/coreos/console-login-helper-messages/commit/4815dc446cd161049b2716e33374e6afae171c50