### PR TITLE
manifests: include FCOS `shared-el9` manifest from `common-el9`

### DIFF
--- a/common-el9.yaml
+++ b/common-el9.yaml
@@ -1,5 +1,8 @@
 # Manifest shared between CentOS Stream 9 and RHEL 9 variants
 
+include:
+  - fedora-coreos-config/manifests/shared-el9.yaml
+
 postprocess:
   # Collection of workarounds specific to EL9 variants
   - |

--- a/overlay.d/15rhcos-rhel8-workarounds/statoverride
+++ b/overlay.d/15rhcos-rhel8-workarounds/statoverride
@@ -1,0 +1,2 @@
+# Config file for overriding permission bits on overlay files/dirs
+# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/25rhcos-azure-udev-rules/statoverride
+++ b/overlay.d/25rhcos-azure-udev-rules/statoverride
@@ -1,0 +1,2 @@
+# Config file for overriding permission bits on overlay files/dirs
+# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/25rhcos-azure-udev/statoverride
+++ b/overlay.d/25rhcos-azure-udev/statoverride
@@ -1,0 +1,2 @@
+# Config file for overriding permission bits on overlay files/dirs
+# Format: =<file mode in decimal> <absolute path to a file or directory>


### PR DESCRIPTION
fedora-coreos-config is starting to separately define items it can share with EL9 but not EL8.