### PR TITLE
scos: enable some networking cases

### DIFF
--- a/kola-denylist-c9s.yaml
+++ b/kola-denylist-c9s.yaml
@@ -42,9 +42,6 @@
 - pattern: ext.config.shared.files.dracut-executable
   tracker: https://github.com/openshift/os/issues/942
 - pattern: ext.config.shared.networking.default-network-behavior-change
-- pattern: ext.config.shared.networking.force-persist-ip
-- pattern: ext.config.shared.networking.mtu-on-bond-kargs
-- pattern: ext.config.shared.networking.prefer-ignition-networking
 - pattern: ext.config.shared.podman.dns
 - pattern: ext.config.version.rhel-major-version
 - pattern: ext.config.version.rhel-matches-rhcos-build


### PR DESCRIPTION
Fixed `selinux-policy-34.1.39-1.el9.noarch` is included in scos,
should enable related cases.
See:
- https://bugzilla.redhat.com/show_bug.cgi?id=2111069

Fix https://github.com/openshift/os/issues/909