### PR TITLE
kola-denylist: Snooze kdump.crash for s390x

### DIFF
--- a/kola-denylist-c9s.yaml
+++ b/kola-denylist-c9s.yaml
@@ -35,6 +35,7 @@
   tracker: https://github.com/coreos/fedora-coreos-config/issues/1500
   arches:
     - s390x
+  snooze: 2022-09-15
 
 # Broken tests under investigation
 - pattern: coreos.boot-mirror

--- a/kola-denylist-rhel-8.6.yaml
+++ b/kola-denylist-rhel-8.6.yaml
@@ -35,3 +35,4 @@
   tracker: https://github.com/coreos/fedora-coreos-config/issues/1500
   arches:
     - s390x
+  snooze: 2022-09-15

--- a/kola-denylist-rhel-9.0.yaml
+++ b/kola-denylist-rhel-9.0.yaml
@@ -35,3 +35,4 @@
   tracker: https://github.com/coreos/fedora-coreos-config/issues/1500
   arches:
     - s390x
+  snooze: 2022-09-15


### PR DESCRIPTION
As we wait for the latest kexec package(`kexec-tools-2.0.24-6.el8`) to land here with the fix, we can add a snooze to this test to make sure we remove it from denylist soon.