### PR TITLE
rhel9: Use default `ostree-format`

### DIFF
--- a/image-rhel-9.0.yaml
+++ b/image-rhel-9.0.yaml
@@ -5,8 +5,6 @@ size: 16
 # defaulting to `ip=dhcp,dhcp6 rd.neednet=1` when it doesn't see this key.
 ignition-network-kcmdline: []
 
-ostree-format: "oci"
-
 # vmware-secure-boot changes the EFI secure boot option.
 # set false here due to https://bugzilla.redhat.com/show_bug.cgi?id=2106055
 vmware-secure-boot: false


### PR DESCRIPTION
When I did the previous PR to change the `image.yaml` for rhel8
I forgot we'd forked it for rhel9.  Drop the override so
we pick up the new default from
https://github.com/coreos/coreos-assembler/commit/61b68b437d489da8d899bf5788732c329e49c9a9