### PR TITLE
OCPBUGS-595: overlay: Add `rhcos-selinux-policy-upgrade.service`

### DIFF
--- a/overlay.d/05rhcos/usr/lib/systemd/system-preset/43-manifest-rhcos.preset
+++ b/overlay.d/05rhcos/usr/lib/systemd/system-preset/43-manifest-rhcos.preset
@@ -3,6 +3,7 @@
 
 # Upgrade fixes
 enable rhcos-usrlocal-selinux-fixup.service
+enable rhcos-selinux-policy-upgrade.service
 # Enable the iscsi workaround
 enable coreos-generate-iscsi-initiatorname.service
 # Enable auditd. See https://jira.coreos.com/browse/RHCOS-536

--- a/overlay.d/05rhcos/usr/lib/systemd/system/rhcos-selinux-policy-upgrade.service
+++ b/overlay.d/05rhcos/usr/lib/systemd/system/rhcos-selinux-policy-upgrade.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=RHEL CoreOS Rebuild SELinux Policy If Necessary
+Documentation=https://bugzilla.redhat.com/2057497
+DefaultDependencies=false
+After=systemd-tmpfiles-setup.service local-fs.target
+Before=sysinit.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/libexec/rhcos-rebuild-selinux-policy
+
+[Install]
+WantedBy=sysinit.target

--- a/overlay.d/05rhcos/usr/libexec/rhcos-rebuild-selinux-policy
+++ b/overlay.d/05rhcos/usr/libexec/rhcos-rebuild-selinux-policy
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Executed by rhcos-selinux-policy-upgrade.service
+set -euo pipefail
+
+RHEL_VERSION=$(. /usr/lib/os-release && echo ${RHEL_VERSION:-})
+echo -n "RHEL_VERSION=${RHEL_VERSION:-}"
+case "${RHEL_VERSION:-}" in
+  8.[0-6]) echo "Checking for policy recompilation";;
+  *) echo "Assuming we have new enough ostree"; exit 0;;
+esac
+
+ls -al /{usr/,}etc/selinux/targeted/policy/policy.31
+if ! cmp --quiet /{usr/,}etc/selinux/targeted/policy/policy.31; then
+    echo "Recompiling policy due to local modifications as workaround for https://bugzilla.redhat.com/2057497"
+    semodule -B
+fi

--- a/tests/kola/rebuild-selinux-policy/data/commonlib.sh
+++ b/tests/kola/rebuild-selinux-policy/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../../fedora-coreos-config/tests/kola/data/commonlib.sh

--- a/tests/kola/rebuild-selinux-policy/test.sh
+++ b/tests/kola/rebuild-selinux-policy/test.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# Test for https://issues.redhat.com/browse/OCPBUGS-595
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+cd $(mktemp -d)
+journalctl -b -u rhcos-selinux-policy-upgrade > logs.txt
+RHEL_VERSION=$(. /usr/lib/os-release && echo ${RHEL_VERSION:-})
+echo "RHEL_VERSION=${RHEL_VERSION:-}"
+service_should_start=0
+case "${RHEL_VERSION:-}" in
+  8.[0-6]) service_should_start=1;;
+  *) ;;
+esac
+
+case "${AUTOPKGTEST_REBOOT_MARK:-}" in
+    "")
+    if grep -qFe 'Recompiling policy' logs.txt; then
+        cat logs.txt
+        fatal "Recompiled policy on first boot"
+    fi
+    setsebool -P container_manage_cgroup on
+    /tmp/autopkgtest-reboot changed-policy
+    ;;
+    "changed-policy") 
+    if test "${service_should_start}" = "1" && ! grep -qFe 'Recompiling policy' logs.txt; then
+        cat logs.txt
+        fatal "Failed to recompile policy on first boot"
+    fi
+    ;;
+esac
+echo ok


### PR DESCRIPTION
This will auto rebuild the policy if we detect local modifications;
it is only needed before RHEL 8.7 when we'll pick up the
combined underlying work from
https://bugzilla.redhat.com/show_bug.cgi?id=2057497