### PR TITLE
scripts/install-openshift: Use registry.ci.openshift.org

### DIFF
--- a/scripts/install-openshift
+++ b/scripts/install-openshift
@@ -10,7 +10,7 @@ import textwrap
 import sys
 import uuid
 
-RELEASE_IMAGE_TEMPLATE = "registry.svc.ci.openshift.org/ocp/release"
+RELEASE_IMAGE_TEMPLATE = "registry.ci.openshift.org/ocp/release"
 
 
 def install_oc():


### PR DESCRIPTION
registry.svc.ci.openshift.org has been decommissioned.

See: https://docs.ci.openshift.org/docs/how-tos/use-registries-in-build-farm/#summary-of-available-registries