### PR TITLE
OKD-46: Fixes for non-x86_64 SCOS builds

### DIFF
--- a/extensions-c9s.yaml
+++ b/extensions-c9s.yaml
@@ -3,7 +3,6 @@
 # and https://github.com/coreos/fedora-coreos-tracker/issues/401
 
 repos:
-  - nfv
   - sig-virtualization
 
 extensions:
@@ -41,6 +40,8 @@ extensions:
   kernel-rt:
     architectures:
       - x86_64
+    repos:
+      - nfv
     packages:
       - kernel-rt-core
       - kernel-rt-kvm

--- a/repos/c9s.repo
+++ b/repos/c9s.repo
@@ -32,7 +32,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Officia
 
 [sig-nfv]
 name=CentOS Stream 9 - SIG NFV
-baseurl=http://mirror.stream.centos.org/SIGs/9-stream/nfv/x86_64/openvswitch-2/
+baseurl=http://mirror.stream.centos.org/SIGs/9-stream/nfv/$basearch/openvswitch-2/
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1


### PR DESCRIPTION
- Adds nfv repos only when arch is x86_64
- replaces hard-coded x86_64 with $basearch for sig-nfv packages

Closes [OKD-46](https://issues.redhat.com//browse/OKD-46)

cc @travier