### PR TITLE
Fix crio service failed issue and re-enable crio.base for EL9

### DIFF
--- a/common-el9.yaml
+++ b/common-el9.yaml
@@ -20,13 +20,6 @@ postprocess:
      mkdir -p /usr/libexec/crio
      ln -sr /usr/bin/conmon /usr/libexec/crio/conmon
 
-     # Use crun by default
-     sed -i '/\[crio.runtime\]/a default_runtime="crun"' /etc/crio/crio.conf
-     cat >> /etc/crio/crio.conf <<EOF
-     [crio.runtime.runtimes.crun]
-     runtime_path="/usr/bin/crun"
-     EOF
-
      # Enable tmp-on-tmpfs by default because we don't want to have things leak
      # across reboots, it increases alignment with FCOS, and also fixes the
      # Live ISO. First, verify that RHEL is still disabling.

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -43,10 +43,6 @@
     - rhel-8.6
 
 # Broken tests for EL9 under investigation
-- pattern: crio.base
-  osversion:
-    - c9s
-    - rhel-9.0
 - pattern: ext.config.shared.files.dracut-executable
   tracker: https://github.com/openshift/os/issues/942
   osversion:

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -43,10 +43,6 @@
     - rhel-8.6
 
 # Broken tests for EL9 under investigation
-- pattern: coreos.boot-mirror
-  osversion:
-    - c9s
-    - rhel-9.0
 - pattern: crio.base
   osversion:
     - c9s


### PR DESCRIPTION
- Fix crio service failed issue
- Re-enable crio.base for EL9
- Re-enable coreos.boot-mirror for EL9