### PR TITLE
denylist: re-enable `bond-with-dhcp` and `bond-with-restart` for EL9

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -57,11 +57,3 @@
   osversion:
     - c9s
     - rhel-9.0
-- pattern: rhcos.network.bond-with-dhcp
-  osversion:
-    - c9s
-    - rhel-9.0
-- pattern: rhcos.network.bond-with-restart
-  osversion:
-    - c9s
-    - rhel-9.0


### PR DESCRIPTION
The change with scripts refer to https://github.com/coreos/coreos-assembler/pull/3079