### PR TITLE
Switch to https://access.redhat.com/labs/rhir for bug reporting

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -34,7 +34,7 @@ Similarly, Fedora CoreOS is an "edition" of Fedora.
 
 ## Q: Where should I report issues with OpenShift Container Platform or Red Hat CoreOS?
 
-OpenShift Container Platform (OCP) and Red Hat CoreOS (RHCOS) are products from Red Hat that customers can receive support for. If you encounter an issue with either OCP or RHCOS, you can use the [official support options](https://access.redhat.com/support) or [file a Bugzilla report](https://bugzilla.redhat.com/enter_bug.cgi?product=OpenShift%20Container%20Platform) about your issue.
+OpenShift Container Platform (OCP) and Red Hat CoreOS (RHCOS) are products from Red Hat that customers can receive support for. If you encounter an issue with either OCP or RHCOS, you can use the [official support options](https://access.redhat.com/support) or [file a bug report](https://access.redhat.com/labs/rhir/) about your issue.
 
 [OKD](https://www.okd.io/) is the community distribution of Kubernetes that powers OpenShift. If you have issues with OKD, you should report the issue on the [upstream issue tracker](https://github.com/openshift/okd).  (Please note that using RHCOS with OKD is not supported.)
 

--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -59,7 +59,7 @@ postprocess:
      CPE_NAME="${CPE_NAME}::coreos"
      HOME_URL="${HOME_URL}"
      DOCUMENTATION_URL="https://docs.okd.io/latest/welcome/index.html"
-     BUG_REPORT_URL="https://bugzilla.redhat.com/"
+     BUG_REPORT_URL="https://access.redhat.com/labs/rhir/"
      REDHAT_BUGZILLA_PRODUCT="OpenShift Container Platform"
      REDHAT_BUGZILLA_PRODUCT_VERSION="${OCP_RELEASE}"
      REDHAT_SUPPORT_PRODUCT="OpenShift Container Platform"

--- a/manifest-rhel-8.6.yaml
+++ b/manifest-rhel-8.6.yaml
@@ -59,7 +59,7 @@ postprocess:
      CPE_NAME="cpe:/o:redhat:enterprise_linux:8::coreos"
      HOME_URL="${HOME_URL}"
      DOCUMENTATION_URL="https://docs.openshift.com/container-platform/${OCP_RELEASE}/"
-     BUG_REPORT_URL="https://bugzilla.redhat.com/"
+     BUG_REPORT_URL="https://access.redhat.com/labs/rhir/"
      REDHAT_BUGZILLA_PRODUCT="OpenShift Container Platform"
      REDHAT_BUGZILLA_PRODUCT_VERSION="${OCP_RELEASE}"
      REDHAT_SUPPORT_PRODUCT="OpenShift Container Platform"


### PR DESCRIPTION
Closes: https://github.com/openshift/os/issues/950

OCP has migrated away from Bugzilla, so update the links
there.

I explicitly chose *not* to remove the
```
      REDHAT_BUGZILLA_PRODUCT="OpenShift Container Platform"
      REDHAT_BUGZILLA_PRODUCT_VERSION="${OCP_RELEASE}"
```

metadata because it's absolutely still valid to look there for
old bugs, and I am not aware of corresponding metadata keys for
JIRA - we could invent them of course, but it doesn't seem important
right now.