### PR TITLE
docs: Add rhaos-overrides.yaml

### DIFF
--- a/docs/rhaos-overrides.yaml
+++ b/docs/rhaos-overrides.yaml
@@ -1,0 +1,16 @@
+# This file currently is just written (and read) by humans, but
+# it intends to define in a future machine-readable way the
+# desirhttps://github.com/ostreedev/ostree/pull/2569#issuecomment-1238416156ed RHEL packages we want to ship in OCP/RHCOS before
+# they're released by errata.
+# What we want in the future is related to https://issues.redhat.com/browse/GRPA-1358
+# Basically:
+# - Make multiple versions of packages *available* in RHAOS repos
+# - A pull request to this repo becomes the *source of truth*
+#
+# But for now, we just use this as a public reference for which packages
+# we intend to ship
+
+rhel-8:
+  # Ship https://github.com/coreos/rpm-ostree/pull/3961/commits/6f3370e3b45d855afc37947e255ef25bae3985e3
+  # for https://issues.redhat.com/browse/MCO-356
+  - rpm-ostree-2022.10.94.g89f58028-2.el8

--- a/docs/rhaos-overrides.yaml
+++ b/docs/rhaos-overrides.yaml
@@ -2,7 +2,7 @@
 # it intends to define in a future machine-readable way the
 # desired RHEL packages we want to ship in OCP/RHCOS before
 # they're released by errata.
-# What we want in the future is related to https://issues.redhat.com/browse/GRPA-1358
+# What we want in the future is to implement https://issues.redhat.com/browse/COS-808
 # Basically:
 # - Make multiple versions of packages *available* in RHAOS repos
 # - A pull request to this repo becomes the *source of truth*

--- a/docs/rhaos-overrides.yaml
+++ b/docs/rhaos-overrides.yaml
@@ -1,6 +1,6 @@
 # This file currently is just written (and read) by humans, but
 # it intends to define in a future machine-readable way the
-# desirhttps://github.com/ostreedev/ostree/pull/2569#issuecomment-1238416156ed RHEL packages we want to ship in OCP/RHCOS before
+# desired RHEL packages we want to ship in OCP/RHCOS before
 # they're released by errata.
 # What we want in the future is related to https://issues.redhat.com/browse/GRPA-1358
 # Basically:


### PR DESCRIPTION
I think the source of truth for what we ship should be defined
via git and changes that are tested via pull requests; not humans
manually invoking a Koji tag command.

We don't yet live in that world and may never for RHEL-8, though
we have the opportunity with C9S to do better.

For now, this file defines what we intend to ship in a public
human (and in theory machine) readable way.