### PR TITLE
tests: Add EL9 support for version checks

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -57,14 +57,6 @@
   osversion:
     - c9s
     - rhel-9.0
-- pattern: ext.config.version.rhel-major-version
-  osversion:
-    - c9s
-    - rhel-9.0
-- pattern: ext.config.version.rhel-matches-rhcos-build
-  osversion:
-    - c9s
-    - rhel-9.0
 - pattern: rhcos.network.bond-with-dhcp
   osversion:
     - c9s

--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -29,7 +29,7 @@ repos:
   - rhel-9-server-ose
 
 # We include hours/minutes to avoid version number reuse
-automatic-version-prefix: "412.91.<date:%Y%m%d%H%M>"
+automatic-version-prefix: "412.9.<date:%Y%m%d%H%M>"
 # This ensures we're semver-compatible which OpenShift wants
 automatic-version-suffix: "-"
 # Keep this is sync with the version in postprocess

--- a/tests/kola/version/rhel-major-version
+++ b/tests/kola/version/rhel-major-version
@@ -1,5 +1,6 @@
 #!/bin/bash
 # kola: { "exclusive": false }
+# Ensure that only packages from the RHEL major version are included
 set -xeuo pipefail
 
 fatal() {
@@ -7,12 +8,28 @@ fatal() {
     exit 1
 }
 
-# checks to ensure that the only packages from the RHEL major version are included
+variant="$(source /etc/os-release; echo "${ID}")"
+case "${variant}" in
+    "scos")
+        osver="$(source /usr/lib/os-release.stream; echo "${VERSION}")"
+        ;;
+    "rhcos")
+        osver="$(source /usr/lib/os-release.rhel; echo "${VERSION}" | cut -d. -f1 )"
+        ;;
+    "*")
+        fatal "Unknown variant"
+esac
 
-source /etc/os-release
-var=$(echo "${RHEL_VERSION}" | cut -d. -f1)
-for x in $(rpm -qa --queryformat='%{RELEASE}\n' | grep -oP 'el\s*\K\d+'); do
-    if [[ "$var" -ne $((x)) ]]; then
-        fatal "Error RHEL packages do not match current version"
+for pkg in $(rpm -qa); do
+    name="$(rpm -q --queryformat='%{NAME}' "${pkg}")"
+    # See https://bugzilla.redhat.com/show_bug.cgi?id=2115815
+    if [[ "${variant}" == "scos" ]] && [[ "${name}" == "shim-x64" ]]; then
+        continue
+    fi
+    # Weirdly, querying the libgcc package on RHEL 8 returns the result twice
+    # so let's read only the first answer
+    release="$(rpm -q --queryformat='%{RELEASE}' "${pkg}" | grep -oP 'el\s*\K\d+' | head -1)"
+    if [[ "${release}" != "${osver}" ]]; then
+        fatal "Found packages '${name}' with release version '${release}' that does not match the OS current version '${osver}'"
     fi
 done

--- a/tests/kola/version/rhel-matches-rhcos-build
+++ b/tests/kola/version/rhel-matches-rhcos-build
@@ -1,5 +1,7 @@
 #!/bin/bash
 # kola: { "exclusive": false }
+# Check that the OS version (C9S, RHEL 9.0) matches the version stored in
+# /etc/os-release
 set -xeuo pipefail
 
 fatal() {
@@ -7,8 +9,18 @@ fatal() {
     exit 1
 }
 
-# check if RHEL version encoded in RHCOS build version matches /etc/os-release
-source /etc/os-release
-if [ "${RHEL_VERSION//.}" != "$(echo "${VERSION}" | awk -F "." '{print $2}')" ]; then
-  fatal "Error: RHEL version does not match"
+ocp_version="$(source /etc/os-release; echo "${VERSION}")"
+variant="$(source /etc/os-release; echo "${ID}")"
+case "${variant}" in
+    "scos")
+        osver="$(source /usr/lib/os-release.stream; echo "${VERSION_ID}")"
+        ;;
+    "rhcos")
+        osver="$(source /usr/lib/os-release.rhel; echo "${VERSION_ID}" | sed 's/\.//')"
+        ;;
+    "*")
+        fatal "Unknown variant"
+esac
+if [[ "${osver}" != "$(echo "${ocp_version}" | awk -F "." '{print $2}')" ]]; then
+  fatal "Error: OS version and /etc/os-release version do not match"
 fi


### PR DESCRIPTION
- Use `/etc/os-release.<osver>` to check versions
- Use single number versioning for SCOS as C9S does not have minor
  releases
- Skip shim from RHEL 8 in C9S
- Add a workaround to only read the first answer for package RELEASE as
  weirdly, querying the libgcc package on RHEL 8 returns the result
  twice.