### PR TITLE
overlay.d/07c9s: Add OKD manifests and pre-pivot.sh script 

### DIFF
--- a/overlay.d/07c9s/bootstrap/manifests/90-okd-sca-pull-disable.yaml
+++ b/overlay.d/07c9s/bootstrap/manifests/90-okd-sca-pull-disable.yaml
@@ -1,0 +1,8 @@
+kind: Secret
+apiVersion: v1
+metadata:
+  name: support
+  namespace: openshift-config
+stringData:
+  scaPullDisabled: "true"
+type: Opaque

--- a/overlay.d/07c9s/bootstrap/pre-pivot.sh
+++ b/overlay.d/07c9s/bootstrap/pre-pivot.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -euxo pipefail
+
+# This script is called by the OKD installer and runs in the
+# local context of the bootstrap node.
+# It rebases the booted operating system (e.g. Fedora CoreOS)
+# to CentOS Stream CoreOS 9
+
+# Load common functions
+. /usr/local/bin/release-image.sh
+
+# Copy manifests
+# Before rebasing the bootstrap node from FCOS to SCOS, ensure the OKD manifests are in place
+if [ ! -d /opt/openshift/openshift/ ]; then
+    mkdir -p /opt/openshift/openshift/
+fi
+cp -irvf manifests/* /opt/openshift/openshift/
+
+# Pivot to new os content
+MACHINE_OS_IMAGE=$(image_for centos-stream-coreos-9)
+rpm-ostree rebase --experimental "ostree-unverified-registry:${MACHINE_OS_IMAGE}"
+
+touch /opt/openshift/.pivot-done
+
+systemctl reboot

--- a/overlay.d/07c9s/statoverride
+++ b/overlay.d/07c9s/statoverride
@@ -1,0 +1,2 @@
+# Config file for overriding permission bits on overlay files/dirs
+# Format: =<file mode in decimal> <absolute path to a file or directory>


### PR DESCRIPTION
This commit adds manifests required for OKD, as well as the
`/bootstrap/pre-pivot.sh`script which is run by the installer [1].
The script rebases an FCOS-provisioned bootstrap node to SCOS before
continuing with the installation.
    
[1] https://github.com/openshift/installer/blob/d10d64c9843e37f500bcb8d66caf339e940b918f/data/data/bootstrap/files/usr/local/bin/bootstrap-pivot.sh#L27

/cc @vrutkovs
/cc @sherine-k 
/cc @lmzuccarelli
/cc @travier 