### PR TITLE
c9s: Add `okd-copr` repo for cri-o & cri-tools

### DIFF
--- a/c9s.repo
+++ b/c9s.repo
@@ -45,3 +45,11 @@ gpgcheck=1
 repo_gpgcheck=0
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-Virtualization
+
+[okd-copr]
+name=OKD COPR
+baseurl=https://download.copr.fedorainfracloud.org/results/@OKD/okd/centos-stream-9-$basearch/
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=https://download.copr.fedorainfracloud.org/results/@OKD/okd/pubkey.gpg

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -94,7 +94,7 @@ prepare_repos() {
         # Temporary workaround until we have all packages for SCOS
         curl -L "http://base-${ocpver_mut}-rhel90.ocp.svc.cluster.local" -o "src/config/tmp.repo"
         awk '/rhel-9-server-ose/,/^$/' "src/config/tmp.repo" > "src/config/ocp90.repo"
-        echo "includepkgs=cri-o,cri-tools,openshift-clients,openshift-hyperkube" >> "src/config/ocp90.repo"
+        echo "includepkgs=openshift-clients,openshift-hyperkube" >> "src/config/ocp90.repo"
         rm "src/config/tmp.repo"
     fi
 }

--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -25,7 +25,8 @@ repos:
   - baseos
   - appstream
   - sig-nfv
-  # Temporarily include RHCOS 9 repo for cri-o, cri-tools, oc & hyperkube
+  - okd-copr
+  # Temporarily include RHCOS 9 repo for oc & hyperkube
   - rhel-9-server-ose
 
 # We include hours/minutes to avoid version number reuse


### PR DESCRIPTION
The OKD COPR repo contains per-commit and per-release builds of cri-o, as well as release builds of cri-tools.