### PR TITLE
scos: Make sure to pull `crio & cri-tools` from `okd-copr` repo

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -46,7 +46,6 @@
 - pattern: ext.config.shared.files.dracut-executable
   tracker: https://github.com/openshift/os/issues/942
   osversion:
-    - c9s
     - rhel-9.0
 - pattern: ext.config.shared.networking.default-network-behavior-change
   osversion:

--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -132,3 +132,7 @@ repo-packages:
       - nss-altfiles
       # Use the new containers/toolbox
       - toolbox
+  - repo: okd-copr
+    packages:
+      - cri-o
+      - cri-tools


### PR DESCRIPTION
- scos: Make sure to pull `crio & cri-tools` from `okd-copr` repo
  - Add `okd-copr` repo refer to https://github.com/openshift/os/pull/993
- denylist: Re-enable `ext.config.shared.files.dracut-executable` for scos
  - See https://github.com/openshift/os/issues/942