### PR TITLE
denylist: Re-enable default-network-behavior-change

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -47,10 +47,6 @@
   tracker: https://github.com/openshift/os/issues/942
   osversion:
     - rhel-9.0
-- pattern: ext.config.shared.networking.default-network-behavior-change
-  osversion:
-    - c9s
-    - rhel-9.0
 - pattern: ext.config.shared.podman.rootless-systemd
   tracker: https://bugzilla.redhat.com/show_bug.cgi?id=2123246
   osversion:


### PR DESCRIPTION
See upstream patch https://github.com/coreos/fedora-coreos-config/pull/1963