### PR TITLE
extensions: use Fedora as a builder

### DIFF
--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -10,8 +10,10 @@ ARG COSA
 RUN if [[ -z "$COSA" ]] ; then ci/get-ocp-repo.sh ; fi
 RUN rpm-ostree compose extensions --rootfs=/ --output-dir=/usr/share/rpm-ostree/extensions/ {manifest,extensions}.yaml
 
-## Creates the repo metadata for the extensions & builds the go binary
-FROM quay.io/centos/centos:stream9 as builder
+## Creates the repo metadata for the extensions & builds the go binary.
+## This uses Fedora as a lowest-common-denominator because it will work on
+## current p8/s390x.  See https://github.com/openshift/os/issues/1000
+FROM quay.io/fedora/fedora:36 as builder
 COPY --from=os /usr/share/rpm-ostree/extensions/ /usr/share/rpm-ostree/extensions/
 RUN dnf install -y createrepo_c golang
 ADD extensions/repo-server/main.go .


### PR DESCRIPTION
Closes: https://github.com/openshift/os/issues/1000

RHEL doesn't ship `createrepo_c`, so we were using CentOS Stream 8 for that.

Then we hit on the fact that C8S doesn't exist for s390x, so switched to C9S.

But RHEL9 made a push to require newer hardware baselines.  This is problematic for parts of the RHCOS pipeline which are deployed on Power8 hardware.

So...Fedora hasn't made the hardware baseline switches, so for now let's just use that as a lowest common denominator.  The base image and packages exist on all architectures we care about.