### PR TITLE
Revert "extensions: Enable SCOS extension builds with COSA"

### DIFF
--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -7,14 +7,8 @@ RUN mkdir /os
 WORKDIR /os
 ADD . .
 ARG COSA
-RUN variant="" \
-    && if [[ -f 'src/config.json' ]]; then \
-        variant="-"+$(jq --raw-output '."coreos-assembler.config-variant"' 'src/config.json'); \
-    fi \
-    && if [[ -z "$COSA" ]] && [ "$variant" != "scos" ] && [ "$variant" != "c9s" ]; then \
-        ci/get-ocp-repo.sh; \
-    fi \
-    && rpm-ostree compose extensions --rootfs=/ --output-dir=/usr/share/rpm-ostree/extensions/ {manifest,extensions}${variant}.yaml
+RUN if [[ -z "$COSA" ]] ; then ci/get-ocp-repo.sh ; fi
+RUN rpm-ostree compose extensions --rootfs=/ --output-dir=/usr/share/rpm-ostree/extensions/ {manifest,extensions}.yaml
 
 ## Creates the repo metadata for the extensions & builds the go binary.
 ## This uses Fedora as a lowest-common-denominator because it will work on


### PR DESCRIPTION
This reverts commit 7bcca86eb807f27e4b0899f7c4443ae9c0d153d2.

When running `cosa build-extensions-container`, the `src/config.json` file is not present, so the condition for setting a non-empty variant will never be true.

This can be mitigated by running `cosa update-variant default scos` beforehand, pointing the symlinks for `{manifest,extensions}.yaml` to the desired variant.

/cc @jmarrero 
/cc @travier 

I think it might be best to have COSA pass the variant to the Dockerfile as an arg, but for now this can be worked around per the above.