### PR TITLE
Add platform-specific console configuration metadata

### DIFF
--- a/platforms.yaml
+++ b/platforms.yaml
@@ -1,0 +1,118 @@
+# This file specifies image customizations that are specific to particular
+# architecture/platform pairs.  It is applied (indirectly, via
+# /boot/coreos/platforms.json) by create_disk.sh and gf-set-platform at
+# build time and coreos-installer at install time (if --platform is
+# specified).
+#
+# Currently this is used to configure the default console.  For any
+# arch/platform pairs not specified, GRUB and the kernel will apply their
+# own defaults.  Note that coreos-installer install --console will
+# completely override any GRUB commands specified here.
+#
+# s390x doesn't use GRUB and requires running zipl after updating kargs,
+# so it can't be added to this file without additional development work.
+#
+# All architectures, platforms, and fields are optional.
+#
+# xref https://github.com/coreos/fedora-coreos-config/pull/1781.  Once this
+# file is in FCOS testing-devel, we can replace this copy with a symlink.
+aarch64:
+  aws:
+    # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/connect-to-serial-console.html#sc-considerations
+    # It appears there's no screenshot support on ARM
+    grub_commands:
+      - serial --speed=115200 efi0
+      - terminal_input serial_efi0
+      - terminal_output serial_efi0
+    kernel_arguments:
+      - console=ttyS0,115200n8
+  azure:
+    # https://docs.microsoft.com/en-us/troubleshoot/azure/virtual-machines/serial-console-linux
+    # https://docs.microsoft.com/en-us/troubleshoot/azure/virtual-machines/boot-diagnostics
+    # Have GRUB write only to console, which gets copied to the serial port.
+    # If we use serial (serial efi0; terminal_output console serial_efi0)
+    # we get doubled output.
+    kernel_arguments:
+      - console=tty0
+      - console=ttyAMA0,115200n8
+  packet:
+    # https://metal.equinix.com/developers/docs/resilience-recovery/serial-over-ssh/#limitations
+    grub_commands:
+      - serial --speed=115200
+      - terminal_input serial
+      - terminal_output serial
+    kernel_arguments:
+      - console=ttyAMA0,115200
+  qemu:
+    # The kernel successfully autodetects a serial console, but we still
+    # want GRUB to use one
+    grub_commands:
+      - serial --speed=115200
+      - terminal_input serial console
+      - terminal_output serial console
+ppc64le:
+  qemu:
+    # petitboot doesn't understand GRUB console commands, but we need to
+    # pass console kargs
+    # https://github.com/coreos/coreos-assembler/pull/2400#discussion_r701412417
+    kernel_arguments:
+      - console=hvc0
+      - console=tty0
+x86_64:
+  aws:
+    # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/connect-to-serial-console.html#sc-considerations
+    # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetConsoleScreenshot.html
+    grub_commands:
+      - serial --speed=115200
+      - terminal_input serial console
+      - terminal_output serial console
+    kernel_arguments:
+      - console=tty0
+      - console=ttyS0,115200n8
+  azure:
+    # https://docs.microsoft.com/en-us/troubleshoot/azure/virtual-machines/serial-console-linux
+    # https://docs.microsoft.com/en-us/troubleshoot/azure/virtual-machines/boot-diagnostics
+    # Have GRUB write only to console, which gets copied to the serial port.
+    # If we use serial we get doubled output.
+    kernel_arguments:
+      - console=tty0
+      - console=ttyS0,115200n8
+  gcp:
+    # Four serial ports are available; we use the first one
+    # https://cloud.google.com/compute/docs/troubleshooting/troubleshooting-using-serial-console
+    # https://cloud.google.com/compute/docs/troubleshooting/capturing-vm-screenshots
+    grub_commands:
+      - serial --speed=115200
+      - terminal_input serial console
+      - terminal_output serial console
+    kernel_arguments:
+      - console=tty0
+      - console=ttyS0,115200n8
+  ibmcloud:
+    # Docs suggest 9600 bps, but that doesn't seem reasonable
+    # https://cloud.ibm.com/docs/vpc?topic=vpc-create-linux-custom-image#kernel-args
+    # https://cloud.ibm.com/docs/vpc?topic=vpc-vsi_is_connecting_console&interface=ui
+    grub_commands:
+      - serial --speed=115200
+      - terminal_input serial console
+      - terminal_output serial console
+    kernel_arguments:
+      - console=tty0
+      - console=ttyS0,115200n8
+  packet:
+    # https://metal.equinix.com/developers/docs/resilience-recovery/serial-over-ssh/#limitations
+    grub_commands:
+      - serial --unit=1 --speed=115200
+      - terminal_input serial
+      - terminal_output serial
+    kernel_arguments:
+      - console=ttyS1,115200n8
+  qemu:
+    # https://github.com/coreos/fedora-coreos-tracker/issues/954
+    grub_commands:
+      - serial --speed=115200
+      - terminal_input serial console
+      - terminal_output serial console
+    kernel_arguments:
+      - console=tty0
+      - console=ttyS0,115200n8


### PR DESCRIPTION
cosa `create_disk.sh` and `gf-set-platform` will read this.  `create_disk.sh` will also save a JSON version for the relevant architecture to `/boot/coreos/platforms.json` for coreos-installer.

Enable graphical console on cloud platforms that allow capturing screenshots, even if the graphical console is not interactive.

This is a copy of https://github.com/coreos/fedora-coreos-config/pull/1781. Once the config has been ratcheted into testing-devel, we'll replace this file with a symlink (#1011).