### PR TITLE
Add `--fail` to all invocations of `curl`

### DIFF
--- a/ci/get-ocp-repo.sh
+++ b/ci/get-ocp-repo.sh
@@ -4,4 +4,4 @@ ocpver=$(rpm-ostree compose tree --print-only manifest.yaml | jq -r '.["mutate-o
 ocpver_mut=$(rpm-ostree compose tree --print-only manifest.yaml | jq -r '.["mutate-os-release"]' | sed 's|\.|-|')
 rhelver=$(rpm-ostree compose tree --print-only manifest.yaml | jq -r '.["automatic-version-prefix"]' | cut -f2 -d.)
 
-curl -L "http://base-${ocpver_mut}-rhel${rhelver}.ocp.svc.cluster.local" -o "ocp.repo"
+curl --fail -L "http://base-${ocpver_mut}-rhel${rhelver}.ocp.svc.cluster.local" -o "ocp.repo"

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -80,19 +80,19 @@ prepare_repos() {
 
     # Fetch the repos corresponding to the release we are building
     if [[ "${rhelver}" == "86" ]]; then
-        curl -L "http://base-${ocpver_mut}-rhel${rhelver}.ocp.svc.cluster.local" -o "src/config/ocp.repo"
+        curl --fail -L "http://base-${ocpver_mut}-rhel${rhelver}.ocp.svc.cluster.local" -o "src/config/ocp.repo"
     elif [[ "${rhelver}" == "90" ]]; then
-        curl -L "http://base-${ocpver_mut}-rhel${rhelver}.ocp.svc.cluster.local" -o "src/config/ocp.repo"
+        curl --fail -L "http://base-${ocpver_mut}-rhel${rhelver}.ocp.svc.cluster.local" -o "src/config/ocp.repo"
 
         # Temporary workaround until we have all packages for RHCOS 9
-        curl -L "http://base-${ocpver_mut}-rhel86.ocp.svc.cluster.local" -o "src/config/tmp.repo"
+        curl --fail -L "http://base-${ocpver_mut}-rhel86.ocp.svc.cluster.local" -o "src/config/tmp.repo"
         awk '/rhel-8-server-ose/,/^$/' "src/config/tmp.repo" > "src/config/ocp86.repo"
         echo "includepkgs=skopeo" >> "src/config/ocp86.repo"
         rm "src/config/tmp.repo"
     else
         # Assume C9S/SCOS if the version does not match known values for RHEL
         # Temporary workaround until we have all packages for SCOS
-        curl -L "http://base-${ocpver_mut}-rhel90.ocp.svc.cluster.local" -o "src/config/tmp.repo"
+        curl --fail -L "http://base-${ocpver_mut}-rhel90.ocp.svc.cluster.local" -o "src/config/tmp.repo"
         awk '/rhel-9-server-ose/,/^$/' "src/config/tmp.repo" > "src/config/ocp90.repo"
         echo "includepkgs=openshift-clients,openshift-hyperkube" >> "src/config/ocp90.repo"
         rm "src/config/tmp.repo"

--- a/docs/development.md
+++ b/docs/development.md
@@ -112,6 +112,6 @@ the portion of the test that uses `curl` to populate the `ocp.repo` (see <https:
 
 For example:
 
-`$ curl -Ls http://base-4-11-rhel8.ocp.svc.cluster.local > src/config/ocp.repo`
+`$ curl --fail -Ls http://base-4-11-rhel8.ocp.svc.cluster.local > src/config/ocp.repo`
 
 1. Build and test normally


### PR DESCRIPTION
See https://github.com/openshift/machine-config-operator/pull/3317#issuecomment-1248765511 where it looks like release-controller failed and we got a corrupted repo file.  It would have been a bit easier to debug if we printed the error.