### PR TITLE
ci/prow-entrypoint: Add an `update-variant` command

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -229,6 +229,10 @@ main () {
             cosa_init "rhel-coreos-8"
             cosa_build
             ;;
+        "update-variant")
+            cosa update-variant default "$2"
+            prepare_repos
+            ;;
         "rhcos-cosa-prow-pr-ci")
             setup_user
             cosa_init "rhel-coreos-8"


### PR DESCRIPTION
So...basically we're in a state where we have this nice `cosa update-variant` command except there's a lot of heavy lifting around the repositories and even some changes to the repo configs that happen in *this* entrypoint.  The latter of which is a bigger problem because changes like that won't
happen for production builds.

Anyways back to the original problem I was looking at: All the entrypoints here really only support a toplevel thing that does it all like `/src/ci/prow-entrypoint.sh rhcos-90-build-test-qemu` but what I want to do is *just* build the oscontainer.

Add an `update-variant` wrapper that does the same thing as the cosa command but also runs the heavily load-bearing `prepare_repos` function.