### PR TITLE
rhel9: Add `/etc/localtime` pointing to `UTC` by default

### DIFF
--- a/common-el9.yaml
+++ b/common-el9.yaml
@@ -26,6 +26,14 @@ postprocess:
      grep -q '# RHEL-only: Disable /tmp on tmpfs' /usr/lib/systemd/system/basic.target
      echo '# RHCOS-only: we follow the Fedora/upstream default' >> /usr/lib/systemd/system/basic.target
      echo 'Wants=tmp.mount' >> /usr/lib/systemd/system/basic.target
+  - |
+     #!/usr/bin/env bash
+     set -xeo pipefail
+     # See https://issues.redhat.com/browse/LOG-3117
+     # Something changed between rhel8 and rhel9 to not generate this by default
+     # but we have containers that expect it to be mounted so for now let's continue
+     # generating it.
+     ln -sr /usr/share/zoneinfo/UTC /etc/localtime
 
 # Packages that are only for SCOS & RHCOS 9
 packages:

--- a/tests/kola/files/localtime
+++ b/tests/kola/files/localtime
@@ -1,0 +1,8 @@
+#!/bin/bash
+## kola:
+##  # readonly test
+##  exclusive: false
+set -xeuo pipefail
+
+# See https://issues.redhat.com/browse/LOG-3117
+test -L /etc/localtime


### PR DESCRIPTION
See https://issues.redhat.com/browse/LOG-3117

Something is creating it for RHCOS8, but seemingly not in the RHCOS9 build.  (I bet Anaconda does this by default, so it will be on most Anaconda-based systems though)

This ensures that containers can mount it from the host; though we should also chase down and fix those containers to do this in a better way (one approach is to mount all of `/etc`).