### PR TITLE
c9s: Add `c9s-` to repo names, use public OCP ART repo

### DIFF
--- a/c9s.repo
+++ b/c9s.repo
@@ -1,4 +1,4 @@
-[baseos]
+[c9s-baseos]
 name=CentOS Stream 9 - BaseOS
 baseurl=http://mirror.stream.centos.org/9-stream/BaseOS/$basearch/os
 gpgcheck=1
@@ -6,7 +6,7 @@ repo_gpgcheck=0
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
-[appstream]
+[c9s-appstream]
 name=CentOS Stream 9 - AppStream
 baseurl=http://mirror.stream.centos.org/9-stream/AppStream/$basearch/os
 gpgcheck=1
@@ -14,7 +14,7 @@ repo_gpgcheck=0
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
-[nfv]
+[c9s-nfv]
 name=CentOS Stream 9 - NFV
 baseurl=http://mirror.stream.centos.org/9-stream/NFV/$basearch/os
 gpgcheck=1
@@ -22,7 +22,7 @@ repo_gpgcheck=0
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
-[rt]
+[c9s-rt]
 name=CentOS Stream 9 - RT
 baseurl=http://mirror.stream.centos.org/9-stream/RT/$basearch/os
 gpgcheck=1
@@ -30,7 +30,7 @@ repo_gpgcheck=0
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
-[sig-nfv]
+[c9s-sig-nfv]
 name=CentOS Stream 9 - SIG NFV
 baseurl=http://mirror.stream.centos.org/SIGs/9-stream/nfv/$basearch/openvswitch-2/
 gpgcheck=1
@@ -38,18 +38,10 @@ repo_gpgcheck=0
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-NFV
 
-[sig-virtualization]
+[c9s-sig-virtualization]
 name=CentOS Stream 9 - SIG Virtualization
 baseurl=http://mirror.stream.centos.org/SIGs/9-stream/virt/x86_64/kata-containers/
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-Virtualization
-
-[okd-copr]
-name=OKD COPR
-baseurl=https://download.copr.fedorainfracloud.org/results/@OKD/okd/centos-stream-9-$basearch/
-gpgcheck=1
-repo_gpgcheck=0
-enabled=1
-gpgkey=https://download.copr.fedorainfracloud.org/results/@OKD/okd/pubkey.gpg

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -84,17 +84,10 @@ prepare_repos() {
     elif [[ "${rhelver}" == "90" ]]; then
         curl --fail -L "http://base-${ocpver_mut}-rhel${rhelver}.ocp.svc.cluster.local" -o "src/config/ocp.repo"
 
-        # Temporary workaround until we have all packages for RHCOS 9
+        # Temporary workaround until we have all packages for RHCOS 9 (dot zero?)
         curl --fail -L "http://base-${ocpver_mut}-rhel86.ocp.svc.cluster.local" -o "src/config/tmp.repo"
         awk '/rhel-8-server-ose/,/^$/' "src/config/tmp.repo" > "src/config/ocp86.repo"
         echo "includepkgs=skopeo" >> "src/config/ocp86.repo"
-        rm "src/config/tmp.repo"
-    else
-        # Assume C9S/SCOS if the version does not match known values for RHEL
-        # Temporary workaround until we have all packages for SCOS
-        curl --fail -L "http://base-${ocpver_mut}-rhel90.ocp.svc.cluster.local" -o "src/config/tmp.repo"
-        awk '/rhel-9-server-ose/,/^$/' "src/config/tmp.repo" > "src/config/ocp90.repo"
-        echo "includepkgs=openshift-clients,openshift-hyperkube" >> "src/config/ocp90.repo"
         rm "src/config/tmp.repo"
     fi
 }

--- a/extensions-c9s.yaml
+++ b/extensions-c9s.yaml
@@ -3,7 +3,7 @@
 # and https://github.com/coreos/fedora-coreos-tracker/issues/401
 
 repos:
-  - sig-virtualization
+  - c9s-sig-virtualization
 
 extensions:
   # https://github.com/coreos/fedora-coreos-tracker/issues/326
@@ -56,6 +56,6 @@ extensions:
     architectures:
       - x86_64
     repos:
-      - sig-virtualization
+      - c9s-sig-virtualization
     packages:
       - kata-containers

--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -20,14 +20,12 @@ include:
 ostree-layers:
   - overlay/07c9s
 
-# CentOS Stream 9 repos + internal repos for now
+# CentOS Stream 9 repos + OCP public repos
 repos:
-  - baseos
-  - appstream
-  - sig-nfv
-  - okd-copr
-  # Temporarily include RHCOS 9 repo for oc & hyperkube
-  - rhel-9-server-ose
+  - c9s-baseos
+  - c9s-appstream
+  - c9s-sig-nfv
+  - ocp-412-el8-beta-public
 
 # We include hours/minutes to avoid version number reuse
 automatic-version-prefix: "412.9.<date:%Y%m%d%H%M>"
@@ -123,16 +121,13 @@ packages:
 # Packages pinned to specific repos in SCOS 9
 repo-packages:
   # We always want the kernel from BaseOS
-  - repo: baseos
+  - repo: c9s-baseos
     packages:
       - kernel
-  - repo: appstream
+  - repo: c9s-appstream
     packages:
       # We want the one shipping in C9S, not the equivalently versioned one in RHAOS
       - nss-altfiles
       # Use the new containers/toolbox
       - toolbox
-  - repo: okd-copr
-    packages:
-      - cri-o
-      - cri-tools
+

--- a/ocp-public.repo
+++ b/ocp-public.repo
@@ -1,0 +1,10 @@
+[ocp-412-el8-beta-public]
+name=OpenShift 4.12 RHEL8 RPMs
+baseurl=https://mirror.openshift.com/pub/openshift-v4/$basearch/dependencies/rpms/4.12-el8-beta/
+# For some sad reason, the OCP RPMs aren't GPG signed?  Anyways we should stop caring about RPM GPG
+# and move to pulling RPMs from OCI artifacts
+gpgcheck=0
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/redhat/RPM-GPG-KEY-redhat8-release
+


### PR DESCRIPTION
In the future, we may want to mix in *some* C9S packages into an otherwise "RHCOS9" build.  We hence need the ability to enable both repositories at the same time.

Also, it's just generally more obvious (i.e. debuggable) to have the stream included in the repository name.

Next, add the public OCP RPM dependency repo, and use it instead of the private one.  The downside is we aren't getting continually refreshed content.  But, I don't understand why we don't just fix that and publish these RPMs continuously.

Finally, it seems that `conmon-rs` is not yet in that repo, so we keep the OKD COPR for now to get that.  But I think we should fix this and publish that in the OCP RPM repo too.