### PR TITLE
c9s: Add distribution-gpg-keys rpm from EPEL

### DIFF
--- a/c9s.repo
+++ b/c9s.repo
@@ -53,3 +53,11 @@ gpgcheck=1
 repo_gpgcheck=0
 enabled=1
 gpgkey=https://download.copr.fedorainfracloud.org/results/@OKD/okd/pubkey.gpg
+
+[epel-9]
+name=Extra Packages for Enterprise Linux 9
+baseurl=https://dl.fedoraproject.org/pub/epel/9/Everything/$basearch
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/epel/RPM-GPG-KEY-EPEL-9

--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -26,6 +26,7 @@ repos:
   - appstream
   - sig-nfv
   - okd-copr
+  - epel-9
   # Temporarily include RHCOS 9 repo for oc & hyperkube
   - rhel-9-server-ose
 
@@ -119,6 +120,9 @@ packages:
  # We include the generic release package and tweak the os-release info in a
  # post-proces script
  - centos-release
+ # Include distribution-gpg-keys for having the GPG keys available
+ # when building the extensions image within the base container via COSA
+ - distribution-gpg-keys
 
 # Packages pinned to specific repos in SCOS 9
 repo-packages:
@@ -136,3 +140,6 @@ repo-packages:
     packages:
       - cri-o
       - cri-tools
+  - repo: epel-9
+    packages:
+      - distribution-gpg-keys


### PR DESCRIPTION
This is required for the extensions build running inside the base OS container via COSA as otherwise the GPG key files are not available there.