### PR TITLE
tests: Remove duplicated toolbox test

### DIFF
--- a/tests/kola/toolbox
+++ b/tests/kola/toolbox
@@ -1,1 +1,0 @@
-../../fedora-coreos-config/tests/kola/toolbox


### PR DESCRIPTION
The new toolbox test is already available through the shared symlink. It was however marked FCOS only and was thus never run. It will thus be picked up here once we update it in f-c-c.

Fixes: ebaeae8 tests: Use new toolbox test