### PR TITLE
Pin to libsemanage-2.9-8.el8

### DIFF
--- a/manifest-rhel-8.6.yaml
+++ b/manifest-rhel-8.6.yaml
@@ -151,6 +151,8 @@ packages:
  - compat-openssl10
  # SCOS package name does not include a version number
  - openvswitch2.17
+ # https://github.com/openshift/os/issues/1036
+ - libsemanage-2.9-8.el8
 
 # Packages pinned to specific repos in RHCOS
 repo-packages:


### PR DESCRIPTION
With -9.el8, `ext.config.rebuild-selinux-policy` fails:
https://github.com/openshift/os/issues/1036

We need to debug this, but for now let's unblock CI and dev pipelines.