### PR TITLE
OCPBUGS-2980: [release-4.11] Pin to libsemanage-2.9-8.el8

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -346,6 +346,8 @@ packages:
  - conntrack-tools
  # Upstream PR https://github.com/coreos/fedora-coreos-config/pull/786
  - WALinuxAgent-udev
+ # https://github.com/openshift/os/issues/1036
+ - libsemanage-2.9-8.el8
 
 repo-packages:
   # we always want the kernel from BaseOS


### PR DESCRIPTION
```
[jlebon]
  With -9.el8, ext.config.rebuild-selinux-policy fails:
  https://github.com/openshift/os/issues/1036

  We need to debug this, but for now let's unblock CI and dev pipelines.
```
cherry-pick https://github.com/openshift/os/commit/247e64abe9d8225ea852222da689bfb5c99adf65