### PR TITLE
denylist: Skip ext.config.shared.clhm.network-device-info

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -52,3 +52,7 @@
   osversion:
     - c9s
     - rhel-9.0
+
+# Temporary to unblock COSA CI
+- pattern: ext.config.shared.clhm.network-device-info
+  tracker: https://github.com/openshift/os/issues/1041


### PR DESCRIPTION
This is temporary to let us land https://github.com/coreos/coreos-assembler/pull/3137.

See https://github.com/openshift/os/issues/1041.