### PR TITLE
[#1039] pin the scos kernel to 5.14.0-168.el9

### DIFF
--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -125,7 +125,8 @@ repo-packages:
   # We always want the kernel from BaseOS
   - repo: baseos
     packages:
-      - kernel
+      # Pin the kernel: https://github.com/openshift/os/issues/1039
+      - kernel-5.14.0-168.el9
   - repo: appstream
     packages:
       # We want the one shipping in C9S, not the equivalently versioned one in RHAOS


### PR DESCRIPTION
This PR pins the kernel for scos9 to 5.13.0-168.el9. A BZ will follow to track the issue with the secure boot.

Refers #1039 