### PR TITLE
OCPBUGS-2926: platforms: add secondary serial console on OpenStack/VirtualBox/VMware

### DIFF
--- a/platforms.yaml
+++ b/platforms.yaml
@@ -35,6 +35,17 @@ aarch64:
     kernel_arguments:
       - console=tty0
       - console=ttyAMA0,115200n8
+  openstack:
+    # Graphical console primary, serial console available for logging
+    # https://docs.openstack.org/diskimage-builder/latest/elements/bootloader/README.html
+    # https://issues.redhat.com/browse/OCPBUGS-2926
+    grub_commands:
+      - serial --speed=115200
+      - terminal_input serial console
+      - terminal_output serial console
+    kernel_arguments:
+      - console=ttyAMA0,115200n8
+      - console=tty0
   packet:
     # https://metal.equinix.com/developers/docs/resilience-recovery/serial-over-ssh/#limitations
     grub_commands:
@@ -51,6 +62,14 @@ aarch64:
       - terminal_input serial console
       - terminal_output serial console
 ppc64le:
+  openstack:
+    # Graphical console primary, serial console available for logging
+    # petitboot doesn't understand GRUB console commands
+    # https://docs.openstack.org/diskimage-builder/latest/elements/bootloader/README.html
+    # https://issues.redhat.com/browse/OCPBUGS-2926
+    kernel_arguments:
+      - console=hvc0
+      - console=tty0
   qemu:
     # petitboot doesn't understand GRUB console commands, but we need to
     # pass console kargs
@@ -99,6 +118,17 @@ x86_64:
     kernel_arguments:
       - console=tty0
       - console=ttyS0,115200n8
+  openstack:
+    # Graphical console primary, serial console available for logging
+    # https://docs.openstack.org/diskimage-builder/latest/elements/bootloader/README.html
+    # https://issues.redhat.com/browse/OCPBUGS-2926
+    grub_commands:
+      - serial --speed=115200
+      - terminal_input serial console
+      - terminal_output serial console
+    kernel_arguments:
+      - console=ttyS0,115200n8
+      - console=tty0
   packet:
     # https://metal.equinix.com/developers/docs/resilience-recovery/serial-over-ssh/#limitations
     grub_commands:
@@ -116,3 +146,23 @@ x86_64:
     kernel_arguments:
       - console=tty0
       - console=ttyS0,115200n8
+  virtualbox:
+    # Graphical console primary, serial console available for logging
+    # https://docs.fedoraproject.org/en-US/fedora-coreos/provisioning-virtualbox/#_troubleshooting_first_boot_problems
+    grub_commands:
+      - serial --speed=115200
+      - terminal_input serial console
+      - terminal_output serial console
+    kernel_arguments:
+      - console=ttyS0,115200n8
+      - console=tty0
+  vmware:
+    # Graphical console primary, serial console available for logging
+    # https://docs.fedoraproject.org/en-US/fedora-coreos/provisioning-vmware/#_troubleshooting_first_boot_problems
+    grub_commands:
+      - serial --speed=115200
+      - terminal_input serial console
+      - terminal_output serial console
+    kernel_arguments:
+      - console=ttyS0,115200n8
+      - console=tty0


### PR DESCRIPTION
Previously, `openstack console log <server>` was useful for collecting console logs from OpenStack VMs, and the serial console was similarly useful in VMware, but we disabled serial console output on both platforms.  Re-enable it as a secondary console so it gets as much information as possible without interfering with the graphical console. Do the same on VirtualBox to stay in sync with FCOS.

Untested on OpenStack.

Fixes: https://issues.redhat.com/browse/OCPBUGS-2926
xref: https://github.com/coreos/fedora-coreos-config/pull/2038