### PR TITLE
 image*.yaml: Enable injection of OCP `machine-os` metadata by default

### DIFF
--- a/image-rhel-8.6.yaml
+++ b/image-rhel-8.6.yaml
@@ -8,6 +8,9 @@ squashfs-compression: gzip
 # defaulting to `ip=dhcp,dhcp6 rd.neednet=1` when it doesn't see this key.
 ignition-network-kcmdline: []
 
+# Keep OCP metadata on our container image, but xref https://github.com/openshift/os/issues/1047
+ostree-container-inject-openshift-cvo-labels: true
+
 # vmware-secure-boot changes the EFI secure boot option.
 # set false here due to https://bugzilla.redhat.com/show_bug.cgi?id=2106055
 vmware-secure-boot: false

--- a/image-rhel-8.6.yaml
+++ b/image-rhel-8.6.yaml
@@ -8,10 +8,6 @@ squashfs-compression: gzip
 # defaulting to `ip=dhcp,dhcp6 rd.neednet=1` when it doesn't see this key.
 ignition-network-kcmdline: []
 
-# See https://github.com/coreos/coreos-assembler/pull/3014 - this
-# will hopefully be the default soon, but trying to enable it here first.
-ostree-format: "oci-chunked-v1"
-
 # vmware-secure-boot changes the EFI secure boot option.
 # set false here due to https://bugzilla.redhat.com/show_bug.cgi?id=2106055
 vmware-secure-boot: false

--- a/image-rhel-9.0.yaml
+++ b/image-rhel-9.0.yaml
@@ -5,6 +5,9 @@ size: 16
 # defaulting to `ip=dhcp,dhcp6 rd.neednet=1` when it doesn't see this key.
 ignition-network-kcmdline: []
 
+# Keep OCP metadata on our container image, but xref https://github.com/openshift/os/issues/1047
+ostree-container-inject-openshift-cvo-labels: true
+
 # vmware-secure-boot changes the EFI secure boot option.
 # set false here due to https://bugzilla.redhat.com/show_bug.cgi?id=2106055
 vmware-secure-boot: false


### PR DESCRIPTION
NOTE: This will actually break things unless we *also* in the same transaction implement the `machine-os-content` :arrow_right: `rhel-coreos-8` alias when building the release image.

Which actually implies that this configuration should be part of *this* repository, and not part of the pipeline config (legacy: jobspec, new: pipeline config.yaml).

Hmm.  Perhaps I can for now change the legacy pipeline to grep `image.yaml` itself...
*edit* done in https://url.corp.redhat.com/a107a47

---

image: Drop unused `oci-format`

It's the default now.

---

image*.yaml: Enable injection of OCP `machine-os` metadata by default

This is implemented by https://github.com/coreos/coreos-assembler/pull/3153

We had these in the legacy oscontainer for RHCOS, and OKD today hacks them in via a Dockerfile:
https://github.com/openshift/okd-machine-os/blob/0e9fbabbd3363bfc46d9d657bc173666e83e5d18/Dockerfile#L34

We need to carry support for this forward into the new format image, as it's what is used to display the OS version as part of the release image.

Also xref https://issues.redhat.com/browse/TRT-647

---

