### PR TITLE
Revert "[#1039] pin the scos kernel to 5.14.0-168.el9"

### DIFF
--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -125,8 +125,7 @@ repo-packages:
   # We always want the kernel from BaseOS
   - repo: baseos
     packages:
-      # Pin the kernel: https://github.com/openshift/os/issues/1039
-      - kernel-5.14.0-168.el9
+      - kernel
   - repo: appstream
     packages:
       # We want the one shipping in C9S, not the equivalently versioned one in RHAOS


### PR DESCRIPTION
This reverts commit 475d347ae4a143ea1ce02a6d57654625c85d8729. 
As https://bugzilla.redhat.com/show_bug.cgi?id=2138019 is fixed