### PR TITLE
denylist: snooze ext.config.networking.mtu-on-bond-ignition on c9s

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -55,3 +55,10 @@
 # Temporary to unblock COSA CI
 - pattern: ext.config.shared.clhm.network-device-info
   tracker: https://github.com/openshift/os/issues/1041
+
+# Remove this when fixed NetworkManager-1.41.4-2 is delivered to c9s
+- pattern: ext.config.shared.networking.mtu-on-bond-ignition
+  tracker: https://github.com/openshift/os/issues/1057
+  osversion:
+    - c9s
+  snooze: 2022-11-15


### PR DESCRIPTION
The fixed PR is landed in https://gitlab.com/redhat/centos-stream/rpms/NetworkManager/-/commit/7d0ca70087b095a53b56da4d4fb114191c9ff2f9. Let's snooze the test until the fixed version `1.41.4-2` is delivered to c9s.

See:
- https://github.com/openshift/os/issues/1057
- https://gitlab.freedesktop.org/NetworkManager/NetworkManager/-/issues/1130