### PR TITLE
OCPBUGS-3959: [release-4.11] Use kernel-rt from ose repo

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -17,9 +17,11 @@ REDIRECTOR_URL="https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/
 setup_user() {
     user_id="$(id -u)"
     group_id="$(id -g)"
+    # create a homedir we're sure our UID will have access to
+    homedir=$(mktemp -d -p /var/tmp)
 
-    grep -v "^builder" /etc/passwd > /tmp/passwd
-    echo "builder:x:${user_id}:${group_id}::/home/builder:/bin/bash" >> /tmp/passwd
+    grep -v "^prowbuilder" /etc/passwd > /tmp/passwd
+    echo "prowbuilder:x:${user_id}:${group_id}::${homedir}:/bin/bash" >> /tmp/passwd
     cat /tmp/passwd > /etc/passwd
     rm /tmp/passwd
 

--- a/extensions.yaml
+++ b/extensions.yaml
@@ -3,7 +3,7 @@
 # and https://github.com/coreos/fedora-coreos-tracker/issues/401
 
 repos:
-  - rhel-8-nfv
+  - rhel-8-server-ose
 
 extensions:
   # https://github.com/coreos/fedora-coreos-tracker/issues/326


### PR DESCRIPTION
There is no kernel-rt in 8.6 EUS/TUS.
We temporarily put the latest 8.6 kernel-rt into OSE repo.

Requires https://github.com/openshift/ocp-build-data/pull/2245