### PR TITLE
[4.12] Change repo names to match the RHCOS repo names

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -88,14 +88,14 @@ prepare_repos() {
 
         # Temporary workaround until we have all packages for RHCOS 9
         curl --fail -L "http://base-${ocpver_mut}-rhel86.ocp.svc.cluster.local" -o "src/config/tmp.repo"
-        awk '/rhel-8-server-ose/,/^$/' "src/config/tmp.repo" > "src/config/ocp86.repo"
+        awk '/rhel-8.6-server-ose-4.12/,/^$/' "src/config/tmp.repo" > "src/config/ocp86.repo"
         echo "includepkgs=skopeo" >> "src/config/ocp86.repo"
         rm "src/config/tmp.repo"
     else
         # Assume C9S/SCOS if the version does not match known values for RHEL
         # Temporary workaround until we have all packages for SCOS
         curl --fail -L "http://base-${ocpver_mut}-rhel90.ocp.svc.cluster.local" -o "src/config/tmp.repo"
-        awk '/rhel-9-server-ose/,/^$/' "src/config/tmp.repo" > "src/config/ocp90.repo"
+        awk '/rhel-9.0-server-ose-4.12/,/^$/' "src/config/tmp.repo" > "src/config/ocp90.repo"
         echo "includepkgs=openshift-clients,openshift-hyperkube" >> "src/config/ocp90.repo"
         rm "src/config/tmp.repo"
     fi

--- a/extensions-rhel-8.6.yaml
+++ b/extensions-rhel-8.6.yaml
@@ -3,7 +3,7 @@
 # and https://github.com/coreos/fedora-coreos-tracker/issues/401
 
 repos:
-  - rhel-8-server-ose
+  - rhel-8.6-server-ose-4.12
 
 extensions:
   # https://github.com/coreos/fedora-coreos-tracker/issues/326
@@ -57,6 +57,6 @@ extensions:
       enable:
         - virt:rhel
     repos:
-      - rhel-8-appstream
+      - rhel-8.6-appstream
     packages:
       - kata-containers

--- a/extensions-rhel-9.0.yaml
+++ b/extensions-rhel-9.0.yaml
@@ -3,7 +3,7 @@
 # and https://github.com/coreos/fedora-coreos-tracker/issues/401
 
 repos:
-  - rhel-9-nfv
+  - rhel-9.0-nfv
 
 extensions:
   # https://github.com/coreos/fedora-coreos-tracker/issues/326
@@ -54,6 +54,6 @@ extensions:
     architectures:
       - x86_64
     repos:
-      - rhel-9-appstream
+      - rhel-9.0-appstream
     packages:
       - kata-containers

--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -27,7 +27,7 @@ repos:
   - sig-nfv
   - okd-copr
   # Temporarily include RHCOS 9 repo for oc & hyperkube
-  - rhel-9-server-ose
+  - rhel-9.0-server-ose-4.12
 
 # We include hours/minutes to avoid version number reuse
 automatic-version-prefix: "412.9.<date:%Y%m%d%H%M>"

--- a/manifest-rhel-8.6.yaml
+++ b/manifest-rhel-8.6.yaml
@@ -22,10 +22,10 @@ ostree-layers:
 
 # See "Notes about repositories" in `docs/development.md`
 repos:
-  - rhel-8-baseos
-  - rhel-8-appstream
-  - rhel-8-fast-datapath
-  - rhel-8-server-ose
+  - rhel-8.6-baseos
+  - rhel-8.6-appstream
+  - rhel-8.6-fast-datapath
+  - rhel-8.6-server-ose-4.12
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1938928
 rpmdb: bdb
@@ -157,14 +157,14 @@ packages:
 # Packages pinned to specific repos in RHCOS
 repo-packages:
   # we always want the kernel from BaseOS
-  - repo: rhel-8-baseos
+  - repo: rhel-8.6-baseos
     packages:
       - kernel
   # we want the one shipping in RHEL, not the equivalently versioned one in RHAOS
-  - repo: rhel-8-appstream
+  - repo: rhel-8.6-appstream
     packages:
       - nss-altfiles
-  - repo: rhel-8-server-ose
+  - repo: rhel-8.6-server-ose-4.12
     packages:
       # Starting with 4.11, we are working with the Containers team to build
       # certain container-tools RPMs in the RHAOS branches for RHCOS + RHEL

--- a/manifest-rhel-9.0.yaml
+++ b/manifest-rhel-9.0.yaml
@@ -18,12 +18,12 @@ include:
 
 # See "Notes about repositories" in `docs/development.md`
 repos:
-  - rhel-9-baseos
-  - rhel-9-appstream
-  - rhel-9-fast-datapath
+  - rhel-9.0-baseos
+  - rhel-9.0-appstream
+  - rhel-9.0-fast-datapath
   # Temporarily include RHCOS 8 repo for skopeo
-  - rhel-8-server-ose
-  - rhel-9-server-ose
+  - rhel-8.6-server-ose-4.12
+  - rhel-9.0-server-ose-4.12
 
 # We include hours/minutes to avoid version number reuse
 automatic-version-prefix: "412.90.<date:%Y%m%d%H%M>"
@@ -120,10 +120,10 @@ packages:
 # Packages pinned to specific repos in RHCOS 9
 repo-packages:
   # we always want the kernel from BaseOS
-  - repo: rhel-9-baseos
+  - repo: rhel-9.0-baseos
     packages:
       - kernel
-  - repo: rhel-9-appstream
+  - repo: rhel-9.0-appstream
     packages:
       # We want the one shipping in RHEL, not the equivalently versioned one in RHAOS
       - nss-altfiles


### PR DESCRIPTION
 - We are changing the repo names in order to improve our internal redhat-coreos repo, to use a single branch for the RHCOS versions.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>