### PR TITLE
[release-4.13] Use kernel-rt from ose repo

### DIFF
--- a/extensions-rhel-8.6.yaml
+++ b/extensions-rhel-8.6.yaml
@@ -3,7 +3,7 @@
 # and https://github.com/coreos/fedora-coreos-tracker/issues/401
 
 repos:
-  - rhel-8-nfv
+  - rhel-8-server-ose
 
 extensions:
   # https://github.com/coreos/fedora-coreos-tracker/issues/326


### PR DESCRIPTION
There is no kernel-rt in 8.6 EUS/TUS.
We temporarily put the latest 8.6 kernel-rt into OSE repo.