### PR TITLE
[release-4.11] ci: set up separate homedir for Prow builder

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -17,9 +17,11 @@ REDIRECTOR_URL="https://rhcos-redirector.apps.art.xq1c.p1.openshiftapps.com/art/
 setup_user() {
     user_id="$(id -u)"
     group_id="$(id -g)"
+    # create a homedir we're sure our UID will have access to
+    homedir=$(mktemp -d -p /var/tmp)
 
-    grep -v "^builder" /etc/passwd > /tmp/passwd
-    echo "builder:x:${user_id}:${group_id}::/home/builder:/bin/bash" >> /tmp/passwd
+    grep -v "^prowbuilder" /etc/passwd > /tmp/passwd
+    echo "prowbuilder:x:${user_id}:${group_id}::${homedir}:/bin/bash" >> /tmp/passwd
     cat /tmp/passwd > /etc/passwd
     rm /tmp/passwd
 


### PR DESCRIPTION
This is a backport of the CI fix in the main branch.  The 4.11 PR's are failing with the same error.

> Currently, we try to fake that the OpenShift-allocated uid is a valid user by adding it to `/etc/passwd` and using a home dir of `/home/builder`. But that doesn't work because anything that wants to write to the home dir will get `EACCES`.
> 
> The exact error was:
> 
> ```
> + cosa buildextend-extensions
> Extracting a84ad9e41b55dae5dcdbad814604adc8973fcfb2681d27ab2908193ea54b4cd4
> error: Permission denied (os error 13)
> ```
> 
> Using strace, the files it failed on were:
> 
> ```
> [pid  1498] mkdir("/home/builder/.cache", 0700 <unfinished ...>
> [pid  1498] <... mkdir resumed>)        = -1 EACCES (Permission denied)
> [pid  1498] openat(AT_FDCWD, "/home/builder/.cache/ostree/auth.json", O_RDONLY|O_CLOEXEC <unfinished ...>
> [pid  1498] <... openat resumed>)       = -1 EACCES (Permission denied)
> ```
> 
> Probably something to do with the container stack when invoked by rpm-ostree?
> 
> Anyway, there might be something to fix there, but for now hack around this by instead allocating a temporary separate homedir.