### PR TITLE
[4.11] Change repo names to match the RHCOS repo names

### DIFF
--- a/extensions.yaml
+++ b/extensions.yaml
@@ -3,7 +3,7 @@
 # and https://github.com/coreos/fedora-coreos-tracker/issues/401
 
 repos:
-  - rhel-8-server-ose
+  - rhel-8.6-server-ose-4.11
 
 extensions:
   # https://github.com/coreos/fedora-coreos-tracker/issues/326
@@ -57,6 +57,6 @@ extensions:
       enable:
         - virt:rhel
     repos:
-      - rhel-8-appstream
+      - rhel-8.6-appstream
     packages:
       - kata-containers

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -38,10 +38,10 @@ arch-include:
 # See README.md
 # and https://github.com/openshift/release/blob/master/core-services/release-controller/README.md#rpm-mirrors
 repos:
-  - rhel-8-baseos
-  - rhel-8-appstream
-  - rhel-8-fast-datapath
-  - rhel-8-server-ose
+  - rhel-8.6-baseos
+  - rhel-8.6-appstream
+  - rhel-8.6-fast-datapath
+  - rhel-8.6-server-ose-4.11
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1938928
 rpmdb: bdb
@@ -351,14 +351,14 @@ packages:
 
 repo-packages:
   # we always want the kernel from BaseOS
-  - repo: rhel-8-baseos
+  - repo: rhel-8.6-baseos
     packages:
       - kernel
   # we want the one shipping in RHEL, not the equivalently versioned one in RHAOS
-  - repo: rhel-8-appstream
+  - repo: rhel-8.6-appstream
     packages:
       - nss-altfiles
-  - repo: rhel-8-server-ose
+  - repo: rhel-8.6-server-ose-4.11
     packages:
       # Starting with 4.11, we are working with the Containers team to build
       # certain container-tools RPMs in the RHAOS branches for RHCOS + RHEL


### PR DESCRIPTION
 - We are changing the repo names in order to improve our internal redhat-coreos repo, to use a single branch for the RHCOS versions.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>