### PR TITLE
[4.9] Change repo names to match the RHCOS repo names

### DIFF
--- a/extensions.yaml
+++ b/extensions.yaml
@@ -3,7 +3,7 @@
 # and https://github.com/coreos/fedora-coreos-tracker/issues/401
 
 repos:
-  - rhel-8-nfv
+  - rhel-8.4-nfv
 
 extensions:
   # https://github.com/coreos/fedora-coreos-tracker/issues/326
@@ -55,6 +55,6 @@ extensions:
         # for qemu-kiwi
         - virt:av
     repos:
-      - rhel-8-advanced-virt
+      - rhel-8.4-advanced-virt
     packages:
       - kata-containers

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -25,10 +25,10 @@ arch-include:
 # See README.md
 # and https://github.com/openshift/release/blob/master/core-services/release-controller/README.md#rpm-mirrors
 repos:
-  - rhel-8-baseos
-  - rhel-8-appstream
-  - rhel-8-fast-datapath
-  - rhel-8-server-ose
+  - rhel-8.4-baseos
+  - rhel-8.4-appstream
+  - rhel-8.4-fast-datapath
+  - rhel-8.4-server-ose-4.9
 
 # https://bugzilla.redhat.com/show_bug.cgi?id=1938928
 rpmdb: bdb
@@ -262,14 +262,14 @@ packages:
 
 repo-packages:
   # we always want the kernel from BaseOS
-  - repo: rhel-8-baseos
+  - repo: rhel-8.4-baseos
     packages:
       - kernel
   # we want the one shipping in RHEL, not the equivalently versioned one in RHAOS
-  - repo: rhel-8-appstream
+  - repo: rhel-8.4-appstream
     packages:
       - nss-altfiles
-  - repo: rhel-8-server-ose
+  - repo: rhel-8.4-server-ose-4.9
     packages:
       # eventually, we want the one from the container-tools module, but we're
       # not there yet


### PR DESCRIPTION
 - We are changing the repo names in order to improve our internal redhat-coreos repo, to use a single branch for the RHCOS versions.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>