### PR TITLE
Switch to RHEL 9.0 by default

### DIFF
--- a/extensions.yaml
+++ b/extensions.yaml
@@ -1,1 +1,1 @@
-extensions-rhel-coreos-8.yaml
+extensions-rhel-coreos-9.yaml

--- a/image.yaml
+++ b/image.yaml
@@ -1,1 +1,1 @@
-image-rhel-coreos-8.yaml
+image-rhel-coreos-9.yaml

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,1 +1,1 @@
-manifest-rhel-coreos-8.yaml
+manifest-rhel-coreos-9.yaml


### PR DESCRIPTION
Done via:
```
$ cosa update-variant default rhel-coreos-9
```

Revert this commit to move RHCOS back to RHEL 8.6 by default.