### PR TITLE
OCPBUGS-4653: [4.12] RHEL 9.0 related fixes

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -85,12 +85,6 @@ prepare_repos() {
         curl --fail -L "http://base-${ocpver_mut}-rhel${rhelver}.ocp.svc.cluster.local" -o "src/config/ocp.repo"
     elif [[ "${rhelver}" == "90" ]]; then
         curl --fail -L "http://base-${ocpver_mut}-rhel${rhelver}.ocp.svc.cluster.local" -o "src/config/ocp.repo"
-
-        # Temporary workaround until we have all packages for RHCOS 9
-        curl --fail -L "http://base-${ocpver_mut}-rhel86.ocp.svc.cluster.local" -o "src/config/tmp.repo"
-        awk '/rhel-8.6-server-ose-4.12/,/^$/' "src/config/tmp.repo" > "src/config/ocp86.repo"
-        echo "includepkgs=skopeo" >> "src/config/ocp86.repo"
-        rm "src/config/tmp.repo"
     else
         # Assume C9S/SCOS if the version does not match known values for RHEL
         # Temporary workaround until we have all packages for SCOS

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -247,15 +247,13 @@ main () {
             setup_user
             cosa_init "rhel-coreos-9"
             cosa_build
-            # Temporarily disabled until all tests pass
-            # kola_test_qemu
+            kola_test_qemu
             ;;
         "rhcos-90-build-test-metal" )
             setup_user
             cosa_init "rhel-coreos-9"
             cosa_build
-            # Temporarily disabled until all tests pass
-            # kola_test_metal
+            kola_test_metal
             ;;
         "scos-9-build-test-qemu")
             setup_user

--- a/common-el9.yaml
+++ b/common-el9.yaml
@@ -34,6 +34,14 @@ postprocess:
      # but we have containers that expect it to be mounted so for now let's continue
      # generating it.
      ln -sr /usr/share/zoneinfo/UTC /etc/localtime
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    # Backport https://github.com/dracutdevs/dracut/commit/25a92885a9519701cc480298c2b082e2e2bf5ebe
+    s=/usr/lib/dracut/modules.d/95nvmf/nvmf-autoconnect.sh
+    if test -f "$s"; then
+      chmod a+x "$s"
+    fi
 
 # Packages that are only for SCOS & RHCOS 9
 packages:

--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -7,8 +7,9 @@ RUN mkdir /os
 WORKDIR /os
 ADD . .
 ARG COSA
+ARG VARIANT
 RUN if [[ -z "$COSA" ]] ; then ci/get-ocp-repo.sh ; fi
-RUN rpm-ostree compose extensions --rootfs=/ --output-dir=/usr/share/rpm-ostree/extensions/ {manifest,extensions}.yaml
+RUN if [[ -n "${VARIANT}" ]]; then MANIFEST="manifest-${VARIANT}.yaml"; EXTENSIONS="extensions-${VARIANT}.yaml"; else MANIFEST="manifest.yaml"; EXTENSIONS="extensions.yaml"; fi && rpm-ostree compose extensions --rootfs=/ --output-dir=/usr/share/rpm-ostree/extensions/ "${MANIFEST}" "${EXTENSIONS}"
 
 ## Creates the repo metadata for the extensions & builds the go binary.
 ## This uses Fedora as a lowest-common-denominator because it will work on

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -55,3 +55,20 @@
 # Temporary to unblock COSA CI
 - pattern: ext.config.shared.clhm.network-device-info
   tracker: https://github.com/openshift/os/issues/1041
+
+- pattern: ext.config.shared.networking.force-persist-ip
+  tracker: https://github.com/fedora-selinux/selinux-policy/commit/c86d943538f907c2e6b20ffda0a8d2b5b5bd2e34
+  osversion:
+    - rhel-9.0
+- pattern: ext.config.shared.networking.mtu-on-bond-kargs
+  tracker: https://github.com/fedora-selinux/selinux-policy/commit/c86d943538f907c2e6b20ffda0a8d2b5b5bd2e34
+  osversion:
+    - rhel-9.0
+- pattern: ext.config.shared.networking.no-persist-ip
+  tracker: https://github.com/fedora-selinux/selinux-policy/commit/c86d943538f907c2e6b20ffda0a8d2b5b5bd2e34
+  osversion:
+    - rhel-9.0
+- pattern: ext.config.shared.networking.prefer-ignition-networking
+  tracker: https://github.com/fedora-selinux/selinux-policy/commit/c86d943538f907c2e6b20ffda0a8d2b5b5bd2e34
+  osversion:
+    - rhel-9.0

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -72,3 +72,11 @@
   tracker: https://github.com/fedora-selinux/selinux-policy/commit/c86d943538f907c2e6b20ffda0a8d2b5b5bd2e34
   osversion:
     - rhel-9.0
+- pattern: ext.config.shared.networking.nameserver
+  tracker: https://github.com/openshift/os/issues/1096
+  osversion:
+    - rhel-9.0
+- pattern: ext.config.shared.networking.bridge-static-via-kargs
+  tracker: https://github.com/openshift/os/issues/1096
+  osversion:
+    - rhel-9.0

--- a/manifest-rhel-9.0.yaml
+++ b/manifest-rhel-9.0.yaml
@@ -21,8 +21,6 @@ repos:
   - rhel-9.0-baseos
   - rhel-9.0-appstream
   - rhel-9.0-fast-datapath
-  # Temporarily include RHCOS 8 repo for skopeo
-  - rhel-8.6-server-ose-4.12
   - rhel-9.0-server-ose-4.12
 
 # We include hours/minutes to avoid version number reuse

--- a/manifest-rhel-9.0.yaml
+++ b/manifest-rhel-9.0.yaml
@@ -129,7 +129,3 @@ repo-packages:
       - nss-altfiles
       # Use the new containers/toolbox
       - toolbox
-  # TODO: Remove this when newer version of skopeo is available in RHEL9 or RHAOS9
-  - repo: rhel-8-server-ose
-    packages:
-      - skopeo

--- a/manifest-rhel-9.0.yaml
+++ b/manifest-rhel-9.0.yaml
@@ -127,3 +127,13 @@ repo-packages:
       - nss-altfiles
       # Use the new containers/toolbox
       - toolbox
+  - repo: rhel-9.0-server-ose-4.12
+    packages:
+      # Updated CoreOS packages
+      - afterburn
+      - afterburn-dracut
+      - coreos-installer
+      - coreos-installer-bootinfra
+      - ignition
+      - rpm-ostree
+      - rpm-ostree-libs


### PR DESCRIPTION
rhel9: Only use packages from rhel-9.0-server-ose-4.12 repo

---

ci: Remove rhel-8.6-server-ose-4.12 repo for RHEL 9

---

extensions: Support variant for container image build