### PR TITLE
extensions: Support variant for container image build

### DIFF
--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -7,8 +7,9 @@ RUN mkdir /os
 WORKDIR /os
 ADD . .
 ARG COSA
+ARG VARIANT
 RUN if [[ -z "$COSA" ]] ; then ci/get-ocp-repo.sh ; fi
-RUN rpm-ostree compose extensions --rootfs=/ --output-dir=/usr/share/rpm-ostree/extensions/ {manifest,extensions}.yaml
+RUN if [[ -n "${VARIANT}" ]]; then MANIFEST="manifest-${VARIANT}.yaml"; EXTENSIONS="extensions-${VARIANT}.yaml"; else MANIFEST="manifest.yaml"; EXTENSIONS="extensions.yaml"; fi && rpm-ostree compose extensions --rootfs=/ --output-dir=/usr/share/rpm-ostree/extensions/ "${MANIFEST}" "${EXTENSIONS}"
 
 ## Creates the repo metadata for the extensions & builds the go binary.
 ## This uses Fedora as a lowest-common-denominator because it will work on


### PR DESCRIPTION
Look for the variant's manifest.yaml and extensions.yaml when set.

Fixes: https://github.com/openshift/os/issues/1080