### PR TITLE
OCPBUGS-4652: RHEL9: Collection of small fixes

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -85,12 +85,6 @@ prepare_repos() {
         curl --fail -L "http://base-${ocpver_mut}-rhel${rhelver}.ocp.svc.cluster.local" -o "src/config/ocp.repo"
     elif [[ "${rhelver}" == "90" ]]; then
         curl --fail -L "http://base-${ocpver_mut}-rhel${rhelver}.ocp.svc.cluster.local" -o "src/config/ocp.repo"
-
-        # Temporary workaround until we have all packages for RHCOS 9
-        curl --fail -L "http://base-${ocpver_mut}-rhel86.ocp.svc.cluster.local" -o "src/config/tmp.repo"
-        awk '/rhel-8.6-server-ose-4.13/,/^$/' "src/config/tmp.repo" > "src/config/ocp86.repo"
-        echo "includepkgs=skopeo" >> "src/config/ocp86.repo"
-        rm "src/config/tmp.repo"
     else
         # Assume C9S/SCOS if the version does not match known values for RHEL
         # Temporary workaround until we have all packages for SCOS

--- a/manifest-rhel-9.0.yaml
+++ b/manifest-rhel-9.0.yaml
@@ -117,7 +117,7 @@ packages:
 
 # Packages pinned to specific repos in RHCOS 9
 repo-packages:
-  # we always want the kernel from BaseOS
+  # We always want the kernel from BaseOS
   - repo: rhel-9.0-baseos
     packages:
       - kernel
@@ -127,3 +127,13 @@ repo-packages:
       - nss-altfiles
       # Use the new containers/toolbox
       - toolbox
+  - repo: rhel-9.0-server-ose-4.13
+    packages:
+      # Updated CoreOS packages
+      - afterburn
+      - afterburn-dracut
+      - coreos-installer
+      - coreos-installer-bootinfra
+      - ignition
+      - rpm-ostree
+      - rpm-ostree-libs

--- a/manifest-rhel-9.0.yaml
+++ b/manifest-rhel-9.0.yaml
@@ -129,7 +129,3 @@ repo-packages:
       - nss-altfiles
       # Use the new containers/toolbox
       - toolbox
-  # TODO: Remove this when newer version of skopeo is available in RHEL9 or RHAOS9
-  - repo: rhel-8.6-server-ose-4.13
-    packages:
-      - skopeo

--- a/manifest-rhel-9.0.yaml
+++ b/manifest-rhel-9.0.yaml
@@ -21,8 +21,6 @@ repos:
   - rhel-9.0-baseos
   - rhel-9.0-appstream
   - rhel-9.0-fast-datapath
-  # Temporarily include RHCOS 8 repo for skopeo
-  - rhel-8.6-server-ose-4.13
   - rhel-9.0-server-ose-4.13
 
 # We include hours/minutes to avoid version number reuse


### PR DESCRIPTION
Revert "manifest: Pull skopeo from RHAOS repo for rhel9"

This reverts commit 042d43f3ff9a378403f59c08ccaef76d896253aa.

---

RHEL9: Remove rhel-8.6-server-ose-4.13 repo

---

RHEL9: Pull updated CoreOS packages from RHAOS repo

---

ci: Remove rhel-8.6-server-ose-4.13 repo for 9.0

---

Closes: https://github.com/openshift/os/issues/979