### PR TITLE
Revert "image*.yaml: Enable injection of OCP `machine-os` metadata by…

### DIFF
--- a/image-rhel-8.6.yaml
+++ b/image-rhel-8.6.yaml
@@ -8,9 +8,6 @@ squashfs-compression: gzip
 # defaulting to `ip=dhcp,dhcp6 rd.neednet=1` when it doesn't see this key.
 ignition-network-kcmdline: []
 
-# Keep OCP metadata on our container image, but xref https://github.com/openshift/os/issues/1047
-ostree-container-inject-openshift-cvo-labels: true
-
 # vmware-secure-boot changes the EFI secure boot option.
 # set false here due to https://bugzilla.redhat.com/show_bug.cgi?id=2106055
 vmware-secure-boot: false

--- a/image-rhel-9.0.yaml
+++ b/image-rhel-9.0.yaml
@@ -5,9 +5,6 @@ size: 16
 # defaulting to `ip=dhcp,dhcp6 rd.neednet=1` when it doesn't see this key.
 ignition-network-kcmdline: []
 
-# Keep OCP metadata on our container image, but xref https://github.com/openshift/os/issues/1047
-ostree-container-inject-openshift-cvo-labels: true
-
 # vmware-secure-boot changes the EFI secure boot option.
 # set false here due to https://bugzilla.redhat.com/show_bug.cgi?id=2106055
 vmware-secure-boot: false


### PR DESCRIPTION
… default"

This reverts commit f4646dc2d5a83f9101f3b40e3235cebd1ee5c58a.

We're seeing failures here because as of right now the `machine-os-content` and `rhel-coreos-8` are not aliases; and even if they were it appears that `oc` would need work to handle this.