### PR TITLE
kola-denylist: skip rhcos.upgrade.from-ocp-rhcos for now

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -1,6 +1,8 @@
 # This file documents currently known-to-fail kola tests. It is consumed by
 # coreos-assembler to automatically skip some tests. For more information,
 # see: https://github.com/coreos/coreos-assembler/pull/866.
+- pattern: rhcos.upgrade.from-ocp-rhcos
+  tracker: https://github.com/coreos/coreos-assembler/issues/3270
 - pattern: fips.enable*
   tracker: https://bugzilla.redhat.com/show_bug.cgi?id=1782026
   arches:


### PR DESCRIPTION
There are a few issues with that test we need to fix first. Let's skip it for now to not block on this. We also have upgrade tests in OpenShift CI.