### PR TITLE
[rhcos-4.8/s390x] Disable luks.tang test

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -17,3 +17,8 @@
    - s390x
 - pattern: coreos.ignition.journald-log
   tracker: https://github.com/coreos/coreos-assembler/issues/1173
+# New s390x cluster is to slow to run this test
+- pattern: luks.tang
+  tracker: https://github.com/openshift/os/issues/1093
+  arches:
+    - s390x


### PR DESCRIPTION
The new cluster is running nested virtualization, making it to slow to properly run this test.

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>