### PR TITLE
kola-denylist: Add a few ext.config.shared.networking

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -62,3 +62,20 @@
   osversion:
     - c9s
   snooze: 2022-11-15
+
+- pattern: ext.config.shared.networking.force-persist-ip
+  tracker: https://github.com/fedora-selinux/selinux-policy/commit/c86d943538f907c2e6b20ffda0a8d2b5b5bd2e34
+  osversion:
+    - rhel-9.0
+- pattern: ext.config.shared.networking.mtu-on-bond-kargs
+  tracker: https://github.com/fedora-selinux/selinux-policy/commit/c86d943538f907c2e6b20ffda0a8d2b5b5bd2e34
+  osversion:
+    - rhel-9.0
+- pattern: ext.config.shared.networking.no-persist-ip
+  tracker: https://github.com/fedora-selinux/selinux-policy/commit/c86d943538f907c2e6b20ffda0a8d2b5b5bd2e34
+  osversion:
+    - rhel-9.0
+- pattern: ext.config.shared.networking.prefer-ignition-networking
+  tracker: https://github.com/fedora-selinux/selinux-policy/commit/c86d943538f907c2e6b20ffda0a8d2b5b5bd2e34
+  osversion:
+    - rhel-9.0


### PR DESCRIPTION
These are all root caused to injecting networking-related kargs triggers a selinux denial in `systemd-network-generator`:

```
[    4.171674] audit: type=1400 audit(1670858949.421:4): avc:  denied  { add_name } for  pid=1214 comm="systemd-network" name="90-eth1.network" scontext=system_u:system_r:init_t:s0 tcontext=system_u:object_r:net_conf_t:s0 tclass=dir permissive=0
```

This is fixed in c9s, and I think the fix is
https://github.com/fedora-selinux/selinux-policy/commit/c86d943538f907c2e6b20ffda0a8d2b5b5bd2e34

I don't think the denial here is fatal though for our use case, it's only about writing networkd files which we don't use.