### PR TITLE
kola-denylist: Add more ext.config.shared.networking tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -79,3 +79,11 @@
   tracker: https://github.com/fedora-selinux/selinux-policy/commit/c86d943538f907c2e6b20ffda0a8d2b5b5bd2e34
   osversion:
     - rhel-9.0
+- pattern: ext.config.shared.networking.nameserver
+  tracker: https://github.com/openshift/os/issues/1096
+  osversion:
+    - rhel-9.0
+- pattern: ext.config.shared.networking.bridge-static-via-kargs
+  tracker: https://github.com/openshift/os/issues/1096
+  osversion:
+    - rhel-9.0


### PR DESCRIPTION
Add two ext.config.shared.networking tests that are failing in rhel-9.0 until we can request a backport to fix the failures.

See: https://github.com/openshift/os/issues/1096 and https://github.com/openshift/os/pull/1095