### PR TITLE
kola-denylist: snooze `ext.config.shared.kdump.crash` on s390x

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -35,6 +35,7 @@
   tracker: https://bugzilla.redhat.com/show_bug.cgi?id=2080063
   arches:
     - s390x
+  snooze: 2023-01-25
 
 # Broken tests for EL9 under investigation
 - pattern: ext.config.shared.podman.rootless-systemd

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -36,11 +36,6 @@
   arches:
     - s390x
 
-# This test does not affect RHEL 8.6 but we're keeping it for EL9
-- pattern: ext.config.shared.networking.hostname.fallback-hostname
-  osversion:
-    - rhel-8.6
-
 # Broken tests for EL9 under investigation
 - pattern: ext.config.shared.podman.rootless-systemd
   tracker: https://bugzilla.redhat.com/show_bug.cgi?id=2123246
@@ -51,13 +46,6 @@
 # Temporary to unblock COSA CI
 - pattern: ext.config.shared.clhm.network-device-info
   tracker: https://github.com/openshift/os/issues/1041
-
-# Remove this when fixed NetworkManager-1.41.4-2 is delivered to c9s
-- pattern: ext.config.shared.networking.mtu-on-bond-ignition
-  tracker: https://github.com/openshift/os/issues/1057
-  osversion:
-    - c9s
-  snooze: 2022-11-15
 
 - pattern: ext.config.rpm-ostree.replace-rt-kernel
   tracker: https://github.com/openshift/os/issues/1099


### PR DESCRIPTION
- The backport to 8.6 bug https://bugzilla.redhat.com/show_bug.cgi?id=2150795 is fixed, snooze it until reach the release date.

- Also remove the stale deny items.