### PR TITLE
tests/kola: add trust-cpu

### DIFF
--- a/tests/kola/files/data/commonlib.sh
+++ b/tests/kola/files/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../../fedora-coreos-config/tests/kola/data/commonlib.sh

--- a/tests/kola/files/trust-cpu
+++ b/tests/kola/files/trust-cpu
@@ -1,0 +1,23 @@
+#!/bin/bash
+# kola: { "exclusive": false }
+
+# This is RHCOS only.
+# This test will start failing and can be removed when RHCOS
+# gets to kernel version 6.2+
+# https://github.com/coreos/fedora-coreos-tracker/issues/1369
+# https://github.com/coreos/fedora-coreos-config/pull/2155
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+# https://bugzilla.redhat.com/show_bug.cgi?id=1830280
+case "$(arch)" in
+    x86_64)
+        config=$(grep ^CONFIG_RANDOM_TRUST_CPU /lib/modules/$(uname -r)/config)
+        if [ "$config" != "CONFIG_RANDOM_TRUST_CPU=y" ]; then
+            fatal "Error: Failed to find crng trusting CPU"
+        fi
+        ok "random trust cpu" ;;
+    *) echo "Don't know how to test hardware RNG state on arch=$(arch)" ;;
+esac


### PR DESCRIPTION
Now that trust-cpu wont be run against FCOS anymore, let's add it here so it will continue to run against RHCOS for now.

See: https://github.com/coreos/fedora-coreos-tracker/issues/1369

xref: https://github.com/coreos/fedora-coreos-config/pull/2155