### PR TITLE
Bug 2133997: manifest: Lock multipath

### DIFF
--- a/manifest-rhel-9.0.yaml
+++ b/manifest-rhel-9.0.yaml
@@ -114,7 +114,8 @@ packages:
  # We include the generic release package and tweak the os-release info in a
  # post-proces script
  - redhat-release
-
+ # See https://github.com/openshift/os/issues/1110
+ - device-mapper-multipath-0.8.7-7.el9_0.1
 # Packages pinned to specific repos in RHCOS 9
 repo-packages:
   # we always want the kernel from BaseOS


### PR DESCRIPTION
 - Kola luks.tang is failing due multipath issues, using the current multipath version.
 - We have two versions of multipath in the rhel9 repo, the first version 8.7-7.el9 is causing kola to fail. Let's lock it to 8.7-7.el9_0.1 until a new version is available

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>