### PR TITLE
OCPBUGS-5569: [release-4.12] common.yaml: include the 25azure-udev-rules overlay from FCOS

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -18,6 +18,7 @@ ostree-layers:
   - overlay/15rhcos-tuned-bits
   - overlay/20platform-chrony
   - overlay/21dhcp-chrony
+  - overlay/25azure-udev-rules
 
 arch-include:
   x86_64:

--- a/overlay.d/25azure-udev-rules
+++ b/overlay.d/25azure-udev-rules
@@ -1,0 +1,1 @@
+../fedora-coreos-config/overlay.d/25azure-udev-rules


### PR DESCRIPTION
This was originally introduced in https://github.com/coreos/fedora-coreos-config/pull/2176.
Let's pick it up here in RHCOS too.

(cherry picked from commit 42fc881cce10202734e933055643b9f7b091798d)
