### PR TITLE
OCPBUGS-7174: [release-4.11] manifest.yaml: include the 25azure-udev-rules overlay from FCOS

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -24,6 +24,7 @@ ostree-layers:
   - overlay/15rhcos-rhel8-workarounds  # TODO conditionalize on rhel8
   - overlay/20platform-chrony
   - overlay/21dhcp-chrony
+  - overlay/25azure-udev-rules
   - overlay/25rhcos-azure-udev
 
 arch-include:

--- a/overlay.d/25azure-udev-rules
+++ b/overlay.d/25azure-udev-rules
@@ -1,0 +1,1 @@
+../fedora-coreos-config/overlay.d/25azure-udev-rules


### PR DESCRIPTION
This was originally introduced in https://github.com/coreos/fedora-coreos-config/pull/2176.
Let's pick it up here in RHCOS too.
