### PR TITLE
extensions: Use COSA vendored GPG keys for SCOS builds

### DIFF
--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -9,6 +9,7 @@ ADD . .
 ARG COSA
 ARG VARIANT
 RUN if [[ -z "$COSA" ]] ; then ci/get-ocp-repo.sh ; fi
+RUN cp -aLT distribution-gpg-keys /usr/share/
 RUN if [[ -n "${VARIANT}" ]]; then MANIFEST="manifest-${VARIANT}.yaml"; EXTENSIONS="extensions-${VARIANT}.yaml"; else MANIFEST="manifest.yaml"; EXTENSIONS="extensions.yaml"; fi && rpm-ostree compose extensions --rootfs=/ --output-dir=/usr/share/rpm-ostree/extensions/ ./"${MANIFEST}" ./"${EXTENSIONS}"
 
 ## Creates the repo metadata for the extensions & builds the go binary.

--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -25,9 +25,10 @@ repos:
   - baseos
   - appstream
   - sig-nfv
-  - okd-copr
-  # Temporarily include RHCOS 9 repo for oc & hyperkube
+  # Include RHCOS 9 repo for oc, hyperkube, cri-o, conmon-rs
   - rhel-9.0-server-ose-4.13
+  # Use this repo to build SCOS with OKD SCOS packages
+  # - okd-copr
 
 # We include hours/minutes to avoid version number reuse
 automatic-version-prefix: "413.9.<date:%Y%m%d%H%M>"


### PR DESCRIPTION
scos: Only pull packages from RHCOS repos by default

Public builds and the OKD SCOS pipeline should use other repos.

---

extensions: Use COSA vendored GPG keys for SCOS builds