### PR TITLE
extensions: Workaround for CentOS GPG key paths

### DIFF
--- a/c9s.repo
+++ b/c9s.repo
@@ -14,6 +14,14 @@ repo_gpgcheck=0
 enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 
+[extras-common]
+name=CentOS Stream 9 - Extras packages
+baseurl=https://mirror.stream.centos.org/SIGs/9-stream/extras/$basearch/extras-common
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-Extras-SHA512
+
 [nfv]
 name=CentOS Stream 9 - NFV
 baseurl=http://mirror.stream.centos.org/9-stream/NFV/$basearch/os

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -90,7 +90,6 @@ prepare_repos() {
         # Temporary workaround until we have all packages for SCOS
         curl --fail -L "http://base-${ocpver_mut}-rhel90.ocp.svc.cluster.local" -o "src/config/tmp.repo"
         awk '/rhel-9.0-server-ose-4.13/,/^$/' "src/config/tmp.repo" > "src/config/ocp90.repo"
-        echo "includepkgs=openshift-clients,openshift-hyperkube" >> "src/config/ocp90.repo"
         rm "src/config/tmp.repo"
     fi
 }

--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -9,6 +9,11 @@ ADD . .
 ARG COSA
 ARG VARIANT
 RUN if [[ -z "$COSA" ]] ; then ci/get-ocp-repo.sh ; fi
+RUN mkdir -p /usr/share/distribution-gpg-keys/centos
+RUN ln -s /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial /usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+RUN ln -s {/etc/pki/rpm-gpg,/usr/share/distribution-gpg-keys/centos}/RPM-GPG-KEY-CentOS-SIG-Extras-SHA512
+RUN ln -s {/etc/pki/rpm-gpg,/usr/share/distribution-gpg-keys/centos}/RPM-GPG-KEY-CentOS-SIG-NFV
+RUN ln -s {/etc/pki/rpm-gpg,/usr/share/distribution-gpg-keys/centos}/RPM-GPG-KEY-CentOS-SIG-Virtualization
 RUN if [[ -n "${VARIANT}" ]]; then MANIFEST="manifest-${VARIANT}.yaml"; EXTENSIONS="extensions-${VARIANT}.yaml"; else MANIFEST="manifest.yaml"; EXTENSIONS="extensions.yaml"; fi && rpm-ostree compose extensions --rootfs=/ --output-dir=/usr/share/rpm-ostree/extensions/ ./"${MANIFEST}" ./"${EXTENSIONS}"
 
 ## Creates the repo metadata for the extensions & builds the go binary.

--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -25,9 +25,10 @@ repos:
   - baseos
   - appstream
   - sig-nfv
-  - okd-copr
-  # Temporarily include RHCOS 9 repo for oc & hyperkube
+  # Include RHCOS 9 repo for oc, hyperkube, cri-o, conmon-rs
   - rhel-9.0-server-ose-4.13
+  # Use this repo to build SCOS with OKD SCOS packages
+  # - okd-copr
 
 # We include hours/minutes to avoid version number reuse
 automatic-version-prefix: "413.9.<date:%Y%m%d%H%M>"
@@ -132,7 +133,14 @@ repo-packages:
       - nss-altfiles
       # Use the new containers/toolbox
       - toolbox
-  - repo: okd-copr
+  - repo: rhel-9.0-server-ose-4.13
     packages:
+      - conmon-rs
       - cri-o
       - cri-tools
+      - openshift-clients
+      - openshift-hyperkube
+  # - repo: okd-copr
+  #   packages:
+  #     - cri-o
+  #     - cri-tools

--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -24,6 +24,8 @@ ostree-layers:
 repos:
   - baseos
   - appstream
+  # For NFV & Virtualization SIG GPG keys
+  - extras-common
   - sig-nfv
   # Include RHCOS 9 repo for oc, hyperkube, cri-o, conmon-rs
   - rhel-9.0-server-ose-4.13
@@ -120,6 +122,9 @@ packages:
  # We include the generic release package and tweak the os-release info in a
  # post-proces script
  - centos-release
+ # GPG keys for NFV & Virtualization SIGs
+ - centos-release-virt-common
+ - centos-release-nfv-common
 
 # Packages pinned to specific repos in SCOS 9
 repo-packages:


### PR DESCRIPTION
scos: Only pull packages from RHCOS repos by default

Public builds and the OKD SCOS pipeline should use other repos.

---

scos: Include NFV & Virtualization SIGs GPG keys

---

extensions: Workaround for CentOS GPG key paths

The repo configuration file for C9S packages uses `gpgkey` option with
paths adapted for COSA which is Fedora based.

This workaround around that to let the rpm-ostree command pick the key
when run inside an SCOS container.