### PR TITLE
c9s.repo: use external GPG key for extras-common

### DIFF
--- a/c9s.repo
+++ b/c9s.repo
@@ -20,7 +20,7 @@ baseurl=https://mirror.stream.centos.org/SIGs/9-stream/extras/$basearch/extras-c
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1
-gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-Extras-SHA512
+gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Extras
 
 [nfv]
 name=CentOS Stream 9 - NFV


### PR DESCRIPTION
Fixes 
```
Updating metadata for 'extras-common'...done
[0m[31merror: [0mUpdating rpm-md repo 'extras-common': Failed to download gpg key for repo 'extras-common': Status code: 404 for https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Extras-SHA512 (IP: 81.171.33.201)
error: failed to execute cmd-fetch: exit status 1
```
when building C9S build