### PR TITLE
[release-4.12] kola-denylist: 9.0: Skip package downgrade test

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -80,3 +80,6 @@
   tracker: https://github.com/openshift/os/issues/1096
   osversion:
     - rhel-9.0
+- pattern: rhcos.upgrade.from-ocp-rhcos/verify-no-pkg-downgrades
+  osversion:
+    - rhel-9.0


### PR DESCRIPTION
RHCOS 4.12-9.0 will only be a preview so we don't need to be strict on package downgrades.