### PR TITLE
tests/rhel-major-version: Also ignore shim-aa64

### DIFF
--- a/tests/kola/version/rhel-major-version
+++ b/tests/kola/version/rhel-major-version
@@ -23,8 +23,10 @@ esac
 for pkg in $(rpm -qa); do
     name="$(rpm -q --queryformat='%{NAME}' "${pkg}")"
     # See https://bugzilla.redhat.com/show_bug.cgi?id=2115815
-    if [[ "${variant}" == "scos" ]] && [[ "${name}" == "shim-x64" ]]; then
-        continue
+    if [[ "${variant}" == "scos" ]]; then
+        if [[ "${name}" == "shim-x64" ]] || [[ "${name}" == "shim-aa64" ]]; then
+            continue
+        fi
     fi
     # Weirdly, querying the libgcc package on RHEL 8 returns the result twice
     # so let's read only the first answer


### PR DESCRIPTION
The shim packages are still from RHEL 8 in C9S. e81936c ignored the x86 package but missed the aarch64 one.

Fixes: e81936c tests: Add EL9 support for version checks