### PR TITLE
Add image-c9s.yaml

### DIFF
--- a/image-c9s.yaml
+++ b/image-c9s.yaml
@@ -1,1 +1,20 @@
-image-rhel-9.0.yaml
+# See https://github.com/coreos/coreos-assembler/pull/298
+size: 16
+
+# Disable networking by default on firstboot. We can drop this once cosa stops
+# defaulting to `ip=dhcp,dhcp6 rd.neednet=1` when it doesn't see this key.
+ignition-network-kcmdline: []
+
+# In OKD, keep OpenShift metadata on our container image, but xref https://github.com/openshift/os/issues/1047
+ostree-container-inject-openshift-cvo-labels: true
+
+# vmware-secure-boot changes the EFI secure boot option.
+# set false here due to https://bugzilla.redhat.com/show_bug.cgi?id=2106055
+vmware-secure-boot: false
+
+# rhel9_64Guest requires hardware version 18 and vSphere 7.0U3
+# https://kb.vmware.com/s/article/88157
+vmware-os-type: rhel8_64Guest
+# VMware hardware versions: https://kb.vmware.com/s/article/1003746
+# Supported VMware versions: https://lifecycle.vmware.com/
+vmware-hw-version: 15


### PR DESCRIPTION
Adds a dedicated image config for CentOS Stream 9.

`oc adm release new` and the CVO require the `machine-os` label to be present on one of the payload images.
For c9s, we let COSA add the required labels to the ostree container image.

In OKD/SCOS, this image is aliased as both `machine-os-content` and `centos-stream-coreos-9` in the payload.