### PR TITLE
[release-4.12] Revert "manifest-rhel-8.6: Update repo for kernel package"

### DIFF
--- a/manifest-rhel-8.6.yaml
+++ b/manifest-rhel-8.6.yaml
@@ -157,7 +157,7 @@ packages:
 # Packages pinned to specific repos in RHCOS
 repo-packages:
   # we always want the kernel from BaseOS
-  - repo: rhel-8.6-server-ose-4.12
+  - repo: rhel-8.6-baseos
     packages:
       - kernel
   # we want the one shipping in RHEL, not the equivalently versioned one in RHAOS


### PR DESCRIPTION
This reverts commit 9affaa85f4ce8e0d151846830133ad65fcf8fb66.

We fast tracked the kernel through the ose repo but now that the fixes have landed in the baseos, start using the kernel from the baseos again.