### PR TITLE
tests: Add `skip-console-warnings` to global kola config

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -1,6 +1,8 @@
 # This file documents currently known-to-fail kola tests. It is consumed by
 # coreos-assembler to automatically skip some tests. For more information,
 # see: https://github.com/coreos/coreos-assembler/pull/866.
+- pattern: skip-console-warnings
+  tracker: https://bugzilla.redhat.com/show_bug.cgi?id=2164765
 - pattern: fips.enable*
   tracker: https://bugzilla.redhat.com/show_bug.cgi?id=1782026
   arches:


### PR DESCRIPTION
Until https://bugzilla.redhat.com/show_bug.cgi?id=2164765 is fixed.