### PR TITLE
Allow rhel 9 kernel to be source from the ART plashet

### DIFF
--- a/manifest-rhel-9.0.yaml
+++ b/manifest-rhel-9.0.yaml
@@ -117,10 +117,6 @@ packages:
 
 # Packages pinned to specific repos in RHCOS 9
 repo-packages:
-  # We always want the kernel from BaseOS
-  - repo: rhel-9.0-baseos
-    packages:
-      - kernel
   - repo: rhel-9.0-appstream
     packages:
       # We want the one shipping in RHEL, not the equivalently versioned one in RHAOS

--- a/manifest-rhel-9.2.yaml
+++ b/manifest-rhel-9.2.yaml
@@ -136,11 +136,6 @@ packages:
 
 # Packages pinned to specific repos in RHCOS 9
 repo-packages:
-  # We always want the kernel from BaseOS
-  # - repo: rhel-9.0-baseos
-  - repo: baseos
-    packages:
-      - kernel
   # - repo: rhel-9.0-appstream
   - repo: appstream
     packages:


### PR DESCRIPTION
OpenShift and RHEL have come to an agreement whereby OCP will be able to release the RHEL kernel before the normal 6 week cadence of RHEL. https://issues.redhat.com/browse/RHELPLAN-144928 tracks this agreement. https://issues.redhat.com/browse/ART-5663 discussed ART/RHCOS agreement on how this would be handled at the pipeline level. The decision was to remove the constraint requiring the kernel to be source from baseos exclusively. By doing so, it ART has a more recent kernel build in its repository, it will be preferred.

Done for [rhel-8](https://issues.redhat.com//browse/rhel-8) in https://github.com/openshift/os/pull/1129