### PR TITLE
Allow kernel to be sourced from the ART plashet

### DIFF
--- a/manifest-rhel-8.6.yaml
+++ b/manifest-rhel-8.6.yaml
@@ -156,10 +156,6 @@ packages:
 
 # Packages pinned to specific repos in RHCOS
 repo-packages:
-  # we always want the kernel from BaseOS
-  - repo: rhel-8.6-baseos
-    packages:
-      - kernel
   # we want the one shipping in RHEL, not the equivalently versioned one in RHAOS
   - repo: rhel-8.6-appstream
     packages:


### PR DESCRIPTION
OpenShift and RHEL have come to an agreement whereby OCP will be able to release the RHEL kernel before the normal 6 week cadence of RHEL. https://issues.redhat.com/browse/RHELPLAN-144928 tracks this agreement. https://issues.redhat.com/browse/ART-5663 discussed ART/RHCOS agreement on how this would be handled at the pipeline level. The decision was to remove the constraint requiring the kernel to be source from baseos exclusively. By doing so, it ART has a more recent kernel build in its repository, it will be preferred.