### PR TITLE
[release-4.12] kola-denylist: Deny upgrade tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -80,6 +80,7 @@
   tracker: https://github.com/openshift/os/issues/1096
   osversion:
     - rhel-9.0
-- pattern: rhcos.upgrade.from-ocp-rhcos/verify-no-pkg-downgrades
+- pattern: rhcos.upgrade.from-ocp-rhcos*
+  tracker: "Deny upgrades until we have a RHEL9 build for 4.12"
   osversion:
     - rhel-9.0


### PR DESCRIPTION
 - The verify-no-pkg-downgrades test is a subtest, we can't deny a subtest only, need to deny all upgrade tests instead.
 - RHCOS 4.12-9.0 will only be a preview so we don't need to be strict on it.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>