### PR TITLE
tests: Unify format and update kola config to YAML

### DIFF
--- a/tests/kola/afterburn/data/commonlib.sh
+++ b/tests/kola/afterburn/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../../fedora-coreos-config/tests/kola/data/commonlib.sh

--- a/tests/kola/afterburn/sshkey-service
+++ b/tests/kola/afterburn/sshkey-service
@@ -7,10 +7,7 @@
 
 set -xeuo pipefail
 
-fatal() {
-    echo "$@" >&2
-    exit 1
-}
+. $KOLA_EXT_DATA/commonlib.sh
 
 if [ "$(systemctl is-enabled afterburn-sshkeys@.service)" = enabled ]; then
     fatal "Error: afterburn-sshkeys@ is enabled"

--- a/tests/kola/afterburn/sshkey-service
+++ b/tests/kola/afterburn/sshkey-service
@@ -1,9 +1,9 @@
 #!/bin/bash
-
+## kola:
+##   exclusive: false
+#
 # By default afterburn-sshkeys@core is disabled on RHCOS, enabled on FCOS
 # https://github.com/coreos/afterburn/issues/405
-
-# kola: { "exclusive": false }
 
 set -xeuo pipefail
 

--- a/tests/kola/console/console-login-helper-service
+++ b/tests/kola/console/console-login-helper-service
@@ -5,14 +5,7 @@
 # kola: { "exclusive": false }
 set -xeuo pipefail
 
-ok() {
-    echo "ok" "$@"
-}
-
-fatal() {
-    echo "$@" >&2
-    exit 1
-}
+. $KOLA_EXT_DATA/commonlib.sh
 
 # Check that we have the proper presets for console-login-helper-messages in RHCOS.
 # Versions of CLHM prior to v0.21 have `issuegen`-related systemd units.

--- a/tests/kola/console/console-login-helper-service
+++ b/tests/kola/console/console-login-helper-service
@@ -1,8 +1,9 @@
 #!/bin/bash
-
+## kola:
+##   exclusive: false
+#
 # This is RHCOS only
 
-# kola: { "exclusive": false }
 set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh

--- a/tests/kola/console/data/commonlib.sh
+++ b/tests/kola/console/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../../fedora-coreos-config/tests/kola/data/commonlib.sh

--- a/tests/kola/disk/data/commonlib.sh
+++ b/tests/kola/disk/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../../fedora-coreos-config/tests/kola/data/commonlib.sh

--- a/tests/kola/disk/iscsi-initiatorname-service
+++ b/tests/kola/disk/iscsi-initiatorname-service
@@ -7,14 +7,7 @@
 # kola: { "exclusive": false }
 set -xeuo pipefail
 
-ok() {
-    echo "ok" "$@"
-}
-
-fatal() {
-    echo "$@" >&2
-    exit 1
-}
+. $KOLA_EXT_DATA/commonlib.sh
 
 if ! systemctl show -p ActiveState coreos-generate-iscsi-initiatorname.service | grep -q ActiveState=active; then
     fatal "Error: coreos-generate-iscsi-initiatorname.service not active"

--- a/tests/kola/disk/iscsi-initiatorname-service
+++ b/tests/kola/disk/iscsi-initiatorname-service
@@ -1,10 +1,11 @@
 #!/bin/bash
-
+## kola:
+##   exclusive: false
+#
 # By default coreos-generate-iscsi-initiatorname.service is active on RHCOS,
 # inactive on FCOS
 # https://github.com/openshift/os/pull/453
 
-# kola: { "exclusive": false }
 set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh

--- a/tests/kola/files/check-qemu-ga
+++ b/tests/kola/files/check-qemu-ga
@@ -1,5 +1,7 @@
 #!/bin/bash
-# kola: { "exclusive": false }
+## kola:
+##   exclusive: false
+
 set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh

--- a/tests/kola/files/check-qemu-ga
+++ b/tests/kola/files/check-qemu-ga
@@ -2,10 +2,7 @@
 # kola: { "exclusive": false }
 set -xeuo pipefail
 
-fatal() {
-    echo "$@" >&2
-    exit 1
-}
+. $KOLA_EXT_DATA/commonlib.sh
 
 if ! test -f /usr/bin/qemu-ga; then
   fatal "Error: missing qemu guest agent"

--- a/tests/kola/files/conntrack-tools
+++ b/tests/kola/files/conntrack-tools
@@ -1,8 +1,9 @@
 #!/bin/bash
-
+## kola:
+##   exclusive: false
+#
 # This is RHCOS only, by default conntrack-tools is not installed on FCOS
 
-# kola: { "exclusive": false }
 set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh

--- a/tests/kola/files/conntrack-tools
+++ b/tests/kola/files/conntrack-tools
@@ -5,10 +5,7 @@
 # kola: { "exclusive": false }
 set -xeuo pipefail
 
-fatal() {
-    echo "$@" >&2
-    exit 1
-}
+. $KOLA_EXT_DATA/commonlib.sh
 
 if ! rpm --quiet -q conntrack-tools; then
     fatal "Error: conntrack-tools is not installed"

--- a/tests/kola/files/env-godebug
+++ b/tests/kola/files/env-godebug
@@ -7,10 +7,7 @@
 
 set -xeuo pipefail
 
-fatal() {
-    echo "$@" >&2
-    exit 1
-}
+. $KOLA_EXT_DATA/commonlib.sh
 
 source /etc/os-release
 ostree_conf="/boot/loader.1/entries/ostree-1-${ID}.conf"

--- a/tests/kola/files/env-godebug
+++ b/tests/kola/files/env-godebug
@@ -1,6 +1,8 @@
 #!/bin/bash
-# kola: { "exclusive": false }
-# verify environment variable `GODEBUG=x509ignoreCN=0` in initrd
+## kola:
+##   exclusive: false
+#
+# Verify environment variable `GODEBUG=x509ignoreCN=0` in initrd
 # See:
 # - https://bugzilla.redhat.com/show_bug.cgi?id=1886134
 # - https://github.com/openshift/os/pull/441

--- a/tests/kola/files/kata-osbuilder
+++ b/tests/kola/files/kata-osbuilder
@@ -8,10 +8,7 @@
 
 set -xeuo pipefail
 
-fatal() {
-    echo "$@" >&2
-    exit 1
-}
+. $KOLA_EXT_DATA/commonlib.sh
 
 config="/usr/lib/systemd/system-preset/45-rhcos-extensions.preset"
 

--- a/tests/kola/files/kata-osbuilder
+++ b/tests/kola/files/kata-osbuilder
@@ -1,7 +1,10 @@
 #!/bin/bash
-# kola: { "exclusive": false }
-# check that `kata-osbuilder-generate.service` as part of the default presets
+## kola:
+##   exclusive: false
+#
+# Check that `kata-osbuilder-generate.service` as part of the default presets
 # - defined in /usr/lib/systemd/system-preset/45-rhcos-extensions.preset
+#
 # See:
 # - https://bugzilla.redhat.com/show_bug.cgi?id=1941342
 # - https://github.com/openshift/os/pull/524

--- a/tests/kola/files/localtime
+++ b/tests/kola/files/localtime
@@ -4,5 +4,7 @@
 ##  exclusive: false
 set -xeuo pipefail
 
+. $KOLA_EXT_DATA/commonlib.sh
+
 # See https://issues.redhat.com/browse/LOG-3117
 test -L /etc/localtime

--- a/tests/kola/files/localtime
+++ b/tests/kola/files/localtime
@@ -1,7 +1,7 @@
 #!/bin/bash
 ## kola:
-##  # readonly test
-##  exclusive: false
+##   exclusive: false
+
 set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh

--- a/tests/kola/files/trust-cpu
+++ b/tests/kola/files/trust-cpu
@@ -1,6 +1,7 @@
 #!/bin/bash
-# kola: { "exclusive": false }
-
+## kola:
+##   exclusive: false
+#
 # This is RHCOS only.
 # This test will start failing and can be removed when RHCOS
 # gets to kernel version 6.2+

--- a/tests/kola/files/usrlocal-fixup
+++ b/tests/kola/files/usrlocal-fixup
@@ -6,10 +6,7 @@
 # kola: { "exclusive": false }
 set -xeuo pipefail
 
-fatal() {
-    echo "$@" >&2
-    exit 1
-}
+. $KOLA_EXT_DATA/commonlib.sh
 
 if ! test -f /var/lib/.coreos-usrlocal-fixup.stamp; then
     fatal "Error: missing /var/lib/.coreos-usrlocal-fixup.stamp"

--- a/tests/kola/files/usrlocal-fixup
+++ b/tests/kola/files/usrlocal-fixup
@@ -1,9 +1,10 @@
 #!/bin/bash
-
+## kola:
+##   exclusive: false
+#
 # This is RHCOS only
 # https://github.com/openshift/os/pull/672
 
-# kola: { "exclusive": false }
 set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh

--- a/tests/kola/rpm-ostree/replace-rt-kernel
+++ b/tests/kola/rpm-ostree/replace-rt-kernel
@@ -1,12 +1,15 @@
 #!/bin/bash
+## kola:
+##   tags: "needs-internet"
+##   timeoutMin: 30
+#
 # Verify that replacing with an older centos kernel works, and that
 # replacing with kernel-rt works.
-## kola:
-##  tags: "needs-internet"
-##  timeoutMin: 30
+
 set -euo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
+
 # Execute a command verbosely, i.e. echoing its arguments to stderr
 runv () {
     ( set -x ; "${@}" )

--- a/tests/kola/version/data/commonlib.sh
+++ b/tests/kola/version/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../../fedora-coreos-config/tests/kola/data/commonlib.sh

--- a/tests/kola/version/drop-azure-ptp
+++ b/tests/kola/version/drop-azure-ptp
@@ -1,5 +1,7 @@
 #!/bin/bash
-# kola: { "exclusive": false }
+## kola:
+##   exclusive: false
+
 set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh

--- a/tests/kola/version/drop-azure-ptp
+++ b/tests/kola/version/drop-azure-ptp
@@ -2,10 +2,7 @@
 # kola: { "exclusive": false }
 set -xeuo pipefail
 
-fatal() {
-    echo "$@" >&2
-    exit 1
-}
+. $KOLA_EXT_DATA/commonlib.sh
 
 if [ -e /usr/lib/udev/rules.d/50-azure-ptp.rules ] && \
     grep ptp_hyperv /usr/lib/udev/rules.d/50-udev-default.rules; then

--- a/tests/kola/version/rhaos-pkgs-match-openshift
+++ b/tests/kola/version/rhaos-pkgs-match-openshift
@@ -5,10 +5,7 @@
 # kola: { "exclusive": false }
 set -xeuo pipefail
 
-fatal() {
-    echo "$@" >&2
-    exit 1
-}
+. $KOLA_EXT_DATA/commonlib.sh
 
 # Check that rhaos packages do not match the OpenShift version
 if [[ $(rpm -qa | grep rhaos | grep -v $OPENSHIFT_VERSION) ]]; then

--- a/tests/kola/version/rhaos-pkgs-match-openshift
+++ b/tests/kola/version/rhaos-pkgs-match-openshift
@@ -1,8 +1,9 @@
 #!/bin/bash
-
+## kola:
+##   exclusive: false
+#
 # This is RHCOS only
 
-# kola: { "exclusive": false }
 set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh

--- a/tests/kola/version/rhel-major-version
+++ b/tests/kola/version/rhel-major-version
@@ -1,6 +1,9 @@
 #!/bin/bash
-# kola: { "exclusive": false }
+## kola:
+##   exclusive: false
+#
 # Ensure that only packages from the RHEL major version are included
+
 set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh

--- a/tests/kola/version/rhel-major-version
+++ b/tests/kola/version/rhel-major-version
@@ -3,10 +3,7 @@
 # Ensure that only packages from the RHEL major version are included
 set -xeuo pipefail
 
-fatal() {
-    echo "$@" >&2
-    exit 1
-}
+. $KOLA_EXT_DATA/commonlib.sh
 
 variant="$(source /etc/os-release; echo "${ID}")"
 case "${variant}" in

--- a/tests/kola/version/rhel-matches-rhcos-build
+++ b/tests/kola/version/rhel-matches-rhcos-build
@@ -1,7 +1,10 @@
 #!/bin/bash
-# kola: { "exclusive": false }
+## kola:
+##   exclusive: false
+#
 # Check that the OS version (C9S, RHEL 9.0) matches the version stored in
 # /etc/os-release
+
 set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh

--- a/tests/kola/version/rhel-matches-rhcos-build
+++ b/tests/kola/version/rhel-matches-rhcos-build
@@ -4,10 +4,7 @@
 # /etc/os-release
 set -xeuo pipefail
 
-fatal() {
-    echo "$@" >&2
-    exit 1
-}
+. $KOLA_EXT_DATA/commonlib.sh
 
 ocp_version="$(source /etc/os-release; echo "${VERSION}")"
 variant="$(source /etc/os-release; echo "${ID}")"


### PR DESCRIPTION
tests: Use KOLA_EXT_DATA/commonlib.sh

Use common shared bash library and functions instead of copy/pasted
definitions.

---

tests: Unify layout with YAML'ed kola config

Unify test layout and format and use YAML based config for kola.