### PR TITLE
rhel-9.2: Add `centos-release-virt-common` on !s390x

### DIFF
--- a/centos-virt.yaml
+++ b/centos-virt.yaml
@@ -1,0 +1,7 @@
+# In RHEL, there is only one production key.
+# In CentOS, we need a separate package for the separate keys.
+# Now, we can't just include this *unconditionally* since it
+# doesn't exist for s390x.
+packages:
+ # GPG keys for NFV & Virtualization SIGs
+ - centos-release-virt-common

--- a/manifest-rhel-9.2.yaml
+++ b/manifest-rhel-9.2.yaml
@@ -126,6 +126,11 @@ packages:
  # TODO: Uncomment when ready
  # - redhat-release
 
+arch-include:
+  x86_64: centos-virt.yaml
+  aarch64: centos-virt.yaml
+  ppc64le: centos-virt.yaml
+
 # Packages pinned to specific repos in RHCOS 9
 repo-packages:
   # - repo: rhel-9.0-appstream


### PR DESCRIPTION
In the previous change, I re-broke the s390x virt-common issue. I had actually (tried to) test things locally, but right now we don't correctly cache-bust `cosa build-extensions-container` when the base image is modified because cosa doesn't really understand containers.

To recap, two problems intersect here:

- In RHEL, there is only one production release GPG key, but in CentOS for some reason there are multiple, one for base OS and one for SIGs etc.  And those SIG keys are in separate packages.
- Compounding the above, the Virt SIG isn't built for s390x, so we have to make this architecture conditional