### PR TITLE
Bump to OVS 3.1 on RHEL9

### DIFF
--- a/common-el9.yaml
+++ b/common-el9.yaml
@@ -49,4 +49,4 @@ postprocess:
 
 # Packages that are only for SCOS & RHCOS 9
 packages:
- - openvswitch2.17
+ - openvswitch3.1

--- a/manifest-rhel-9.2.yaml
+++ b/manifest-rhel-9.2.yaml
@@ -154,6 +154,3 @@ repo-packages:
       - cri-tools
       - openshift-clients
       - openshift-hyperkube
-  - repo: rhel-9.0-fast-datapath
-    packages:
-      - openvswitch2.17


### PR DESCRIPTION
Container side bumps to 3.1 in https://github.com/openshift/ovn-kubernetes/pull/1544 and we should to keep the host OS side in sync.