### PR TITLE
OCPBUGS-4762: [release-4.10] manifest: bump to openvswitch2.17

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -223,7 +223,7 @@ packages:
  - cri-o cri-tools
  # Networking
  - nfs-utils
- - openvswitch2.16
+ - openvswitch2.17
  - dnsmasq
  - NetworkManager-ovs
  # Extra runtime


### PR DESCRIPTION
We need to consolidate OVS streams and move off OVS 2.16. Bump host OS OVS to 2.17 which has a good track record the past 10 months in 4.11+.