### PR TITLE
denylist: Drop snooze on `ext.config.kdump.crash` on s390x

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -37,7 +37,6 @@
   tracker: https://bugzilla.redhat.com/show_bug.cgi?id=2080063
   arches:
     - s390x
-  snooze: 2023-01-25
 
 # Broken tests for EL9 under investigation
 - pattern: ext.config.shared.podman.rootless-systemd


### PR DESCRIPTION
We're not going to block on this.