### PR TITLE
extensions-rhel-9.2: Don't enable `sig-virtualization` globally

### DIFF
--- a/extensions-rhel-9.2.yaml
+++ b/extensions-rhel-9.2.yaml
@@ -2,10 +2,6 @@
 # https://github.com/openshift/enhancements/blob/master/enhancements/rhcos/extensions.md
 # and https://github.com/coreos/fedora-coreos-tracker/issues/401
 
-repos:
-  # - rhel-9.0-nfv
-  - sig-virtualization
-
 extensions:
   # https://github.com/coreos/fedora-coreos-tracker/issues/326
   usbguard:


### PR DESCRIPTION
We already have conditional repositories enabled; having this enabled globally breaks the build on s390x where the repo doesn't exist.