### PR TITLE
kola-denylist: Run kdump test on s390x again

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -33,10 +33,6 @@
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1243
   arches:
   - s390x
-- pattern: ext.config.shared.kdump.crash
-  tracker: https://bugzilla.redhat.com/show_bug.cgi?id=2080063
-  arches:
-    - s390x
 - pattern: luks.*
   tracker: https://github.com/openshift/os/issues/1149
   arches:


### PR DESCRIPTION
The fix landed in kexec-tools-2.0.20-69.el8_6

Fixes: #1050
Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>