### PR TITLE
[rhcos-4.12] kola-denylist: Run kdump test on s390x again

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -31,10 +31,6 @@
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1243
   arches:
   - s390x
-- pattern: ext.config.shared.kdump.crash
-  tracker: https://bugzilla.redhat.com/show_bug.cgi?id=2080063
-  arches:
-    - s390x
 
 # This test does not affect RHEL 8.6 but we're keeping it for EL9
 - pattern: ext.config.shared.networking.hostname.fallback-hostname


### PR DESCRIPTION
The fix landed in kexec-tools-2.0.20-69.el8_6

Fixes: #1050
Backport of #1154

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>