### PR TITLE
Revert "kola-denylist: Run kdump test on s390x again"

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -33,6 +33,10 @@
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1243
   arches:
   - s390x
+- pattern: ext.config.shared.kdump.crash
+  tracker: https://bugzilla.redhat.com/show_bug.cgi?id=2080063
+  arches:
+    - s390x
 - pattern: luks.*
   tracker: https://github.com/openshift/os/issues/1149
   arches:


### PR DESCRIPTION
This reverts commit fb1fa613245cb27aa8d47d56d50950461be525c2.

The test is is still failing on RHEL 9.2:

https://github.com/openshift/os/issues/1050#issuecomment-1423186505