### PR TITLE
Add `hotfixes-rhel-coreos-9.yaml`

### DIFF
--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -27,9 +27,10 @@ RUN mkdir /build
 RUN go build -o /build/webserver main.go
 RUN createrepo_c /usr/share/rpm-ostree/extensions/
 
-## Final container that has the extensions and webserver
+## Final container that has the extensions, hotfixes and webserver
 FROM registry.access.redhat.com/ubi9/ubi:latest
 COPY --from=builder /build/webserver /usr/bin/webserver
 COPY --from=builder /usr/share/rpm-ostree/extensions/ /usr/share/rpm-ostree/extensions/
+COPY --from=os /os/hotfixes/ /usr/share/rpm-ostree/extensions/hotfixes/
 CMD ["./usr/bin/webserver"]
 EXPOSE 9091/tcp

--- a/hotfixes-rhel-coreos-9.yaml
+++ b/hotfixes-rhel-coreos-9.yaml
@@ -1,0 +1,5 @@
+hotfixes:
+  - osmajor: "8"
+    repo: rhel-8.6-appstream
+    packages:
+      - rpm-ostree # For https://issues.redhat.com/browse/OCPBUGS-7275


### PR DESCRIPTION
This builds on https://github.com/coreos/coreos-assembler/pull/3352 to add the latest build of RHEL8 rpm-ostree inside our extensions container so the MCD can live-apply it.

Part of https://issues.redhat.com/browse/OCPBUGS-7275