### PR TITLE
denylist: Re-enable ext.config.shared.networking.* tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -61,12 +61,3 @@
 
 - pattern: ext.config.rpm-ostree.replace-rt-kernel
   tracker: https://github.com/openshift/os/issues/1099
-
-- pattern: ext.config.shared.networking.nameserver
-  tracker: https://github.com/openshift/os/issues/1096
-  osversion:
-    - rhel-9.0
-- pattern: ext.config.shared.networking.bridge-static-via-kargs
-  tracker: https://github.com/openshift/os/issues/1096
-  osversion:
-    - rhel-9.0


### PR DESCRIPTION
[4.13-9.2] ext.config.shared.networking failures #1096

Could not replicate failure for these two tests on rhel-coreos-9.2