### PR TITLE
rhel-9.2: Disable centos repos by default

### DIFF
--- a/manifest-rhel-9.2.yaml
+++ b/manifest-rhel-9.2.yaml
@@ -116,6 +116,13 @@ postprocess:
 
      ---
      EOF
+  - |
+     #!/usr/bin/env bash
+     set -xeo pipefail
+     # We need to work in disconnected environments by default, and default-enabled
+     # repos will be attempted to be fetched by rpm-ostree when doing node-local
+     # kernel overrides today for e.g. kernel-rt.
+     for x in /etc/yum.repos.d/*.repo; do sed -i -e s,enabled=1,enabled=0, $x; done
 
 # Packages that are only in RHCOS and not in SCOS or that have special
 # constraints that do not apply to SCOS


### PR DESCRIPTION
We need to work in disconnected environments by default, and default-enabled repos will be attempted to be fetched by rpm-ostree when doing node-local kernel overrides today for e.g. kernel-rt.