### PR TITLE
Add tmpfiles.d config to restore dispatcher scripts labels

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -15,6 +15,7 @@ ostree-layers:
   - overlay/02fcos-nouveau
   - overlay/05rhcos
   - overlay/06gcp-routes
+  - overlay/15rhcos-networkmanager-dispatcher
   - overlay/15rhcos-tuned-bits
   - overlay/20platform-chrony
   - overlay/21dhcp-chrony

--- a/overlay.d/15rhcos-networkmanager-dispatcher/statoverride
+++ b/overlay.d/15rhcos-networkmanager-dispatcher/statoverride
@@ -1,0 +1,2 @@
+# Config file for overriding permission bits on overlay files/dirs
+# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/15rhcos-networkmanager-dispatcher/usr/lib/tmpfiles.d/rhcos-networkmanager-dispatcher.conf
+++ b/overlay.d/15rhcos-networkmanager-dispatcher/usr/lib/tmpfiles.d/rhcos-networkmanager-dispatcher.conf
@@ -1,0 +1,2 @@
+# Restore SELinux labels for dispatcher script for NetworkManager
+Z /etc/NetworkManager/dispatcher.d/ - - - - -


### PR DESCRIPTION
Files outside of ostree commits are not relabeled by ostree after SELinux policy updates. Let's always relabel them on boot for now.

See: https://issues.redhat.com/browse/OCPBUGS-7707
See: https://issues.redhat.com/browse/OCPBUGS-7293