### PR TITLE
overlay: Remove unused 25rhcos-azure-udev-rules

### DIFF
--- a/overlay.d/25rhcos-azure-udev-rules/statoverride
+++ b/overlay.d/25rhcos-azure-udev-rules/statoverride
@@ -1,2 +1,0 @@
-# Config file for overriding permission bits on overlay files/dirs
-# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/25rhcos-azure-udev-rules/usr/lib/udev/rules.d/50-azure-ptp.rules
+++ b/overlay.d/25rhcos-azure-udev-rules/usr/lib/udev/rules.d/50-azure-ptp.rules
@@ -1,5 +1,0 @@
-# Manual backport of:
-# https://github.com/systemd/systemd/commit/32e868f058da8b90add00b2958c516241c532b70
-# Can drop once we get to RHEL 8.6:
-# https://bugzilla.redhat.com/show_bug.cgi?id=1991834
-SUBSYSTEM=="ptp", ATTR{clock_name}=="hyperv", SYMLINK += "ptp_hyperv"


### PR DESCRIPTION
Not needed (and not actually used right now) in RHEL 8.6+ anymore.