### PR TITLE
denylist: re-enable 'network-device-info' test

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -58,6 +58,8 @@
 # Temporary to unblock COSA CI
 - pattern: ext.config.shared.clhm.network-device-info
   tracker: https://github.com/openshift/os/issues/1041
+  osversion:
+   - rhel-8.6
 
 - pattern: ext.config.rpm-ostree.replace-rt-kernel
   tracker: https://github.com/openshift/os/issues/1099


### PR DESCRIPTION
Tested on RHCOS-413.92:
```
--- PASS: non-exclusive-test-bucket-0 (25.83s)
    --- PASS: non-exclusive-test-bucket-0/ext.config.shared.clhm.network-device-info (0.45s)
PASS, output in tmp/kola
+ rc=0

```

https://github.com/openshift/os/issues/1041