### PR TITLE
Revert "tests: Add `skip-console-warnings` to global kola config"

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -1,8 +1,6 @@
 # This file documents currently known-to-fail kola tests. It is consumed by
 # coreos-assembler to automatically skip some tests. For more information,
 # see: https://github.com/coreos/coreos-assembler/pull/866.
-- pattern: skip-console-warnings
-  tracker: https://bugzilla.redhat.com/show_bug.cgi?id=2164765
 - pattern: ext.config.shared.kdump.crash
   tracker: https://github.com/coreos/coreos-assembler/issues/2725
   arches:


### PR DESCRIPTION
Revert "tests: Add `skip-console-warnings` to global kola config"

Fixes: https://github.com/openshift/os/issues/1160
See: https://github.com/openshift/os/pull/1128
See: https://bugzilla.redhat.com/show_bug.cgi?id=2164765
    
Kept for C9S until the podman build lands there.

This reverts commit 010cb8b2ba9060c98190b0f1b700a568fb911f73.