### PR TITLE
denylists: Re-enable tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -51,10 +51,6 @@
 - pattern: ext.config.version.rhel-matches-rhcos-build
   tracker: ''
 
-# This test is broken
-- pattern: ext.config.shared.networking.default-network-behavior-change
-  tracker: ''
-
 # Temporary to unblock COSA CI
 - pattern: ext.config.shared.clhm.network-device-info
   tracker: https://github.com/openshift/os/issues/1041

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -37,11 +37,6 @@
   tracker: https://bugzilla.redhat.com/show_bug.cgi?id=2080063
   arches:
     - s390x
-- pattern: luks.*
-  tracker: https://github.com/openshift/os/issues/1149
-  arches:
-   - ppc64le
-   - aarch64
 
 # We're using some COPR stuff intentionally
 - pattern: ext.config.shared.content-origins


### PR DESCRIPTION
denylists: re-enable `ext.config.shared.networking.default-network-behavior-change`

- Sync in https://github.com/openshift/os/pull/1165

---

denylists: re-enable `luks.*` on `!x86_64`
- Sync in https://github.com/openshift/os/pull/1174