### PR TITLE
c9s: Switch to pulling directly from composes.stream.centos.org

### DIFF
--- a/c9s.repo
+++ b/c9s.repo
@@ -1,6 +1,6 @@
 [baseos]
 name=CentOS Stream 9 - BaseOS
-baseurl=http://mirror.stream.centos.org/9-stream/BaseOS/$basearch/os
+baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/BaseOS/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1
@@ -8,7 +8,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Officia
 
 [appstream]
 name=CentOS Stream 9 - AppStream
-baseurl=http://mirror.stream.centos.org/9-stream/AppStream/$basearch/os
+baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/AppStream/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1
@@ -24,7 +24,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-Ext
 
 [nfv]
 name=CentOS Stream 9 - NFV
-baseurl=http://mirror.stream.centos.org/9-stream/NFV/$basearch/os
+baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/NFV/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1
@@ -32,7 +32,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Officia
 
 [rt]
 name=CentOS Stream 9 - RT
-baseurl=http://mirror.stream.centos.org/9-stream/RT/$basearch/os
+baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/RT/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1


### PR DESCRIPTION
There's some lag in the mirror network apparently, and we want the newer kernel.