### PR TITLE
denylist: Add `rhcos.network.*`

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -54,3 +54,6 @@
 
 - pattern: ext.config.rpm-ostree.replace-rt-kernel
   tracker: https://github.com/openshift/os/issues/1099
+
+- pattern: rhcos.network.*
+  tracker: https://github.com/coreos/coreos-assembler/issues/3376


### PR DESCRIPTION
See https://github.com/coreos/coreos-assembler/issues/3376

I did verify that a *real* OpenShift node comes up fine.