### PR TITLE
c9s: Get conmon-rs from rhcontainerbot COPR

### DIFF
--- a/c9s.repo
+++ b/c9s.repo
@@ -61,3 +61,11 @@ gpgcheck=1
 repo_gpgcheck=0
 enabled=1
 gpgkey=https://download.copr.fedorainfracloud.org/results/@OKD/okd/pubkey.gpg
+
+[podman-next-copr]
+name=Copr repo for podman-next owned by rhcontainerbot
+baseurl=https://download.copr.fedorainfracloud.org/results/rhcontainerbot/podman-next/centos-stream+epel-next-9-$basearch/
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=https://download.copr.fedorainfracloud.org/results/rhcontainerbot/podman-next/pubkey.gpg

--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -23,8 +23,9 @@ repos:
   # For NFV & Virtualization SIG GPG keys
   - extras-common
   - sig-nfv
-  # OKD SCOS builds of cri-o & cri-tools
+  # OKD SCOS builds of cri-o, cri-tools and conmon-rs
   - okd-copr
+  - podman-next-copr
   # Include RHCOS 9 repo for oc, hyperkube and conmon-rs
   - rhel-9.0-server-ose-4.13
 
@@ -134,7 +135,17 @@ repo-packages:
       - nss-altfiles
       # Use the new containers/toolbox
       - toolbox
+      # We want the ones shipping in C9S, not the integrations builds from COPR
+      - aardvark-dns
+      - containers-common
+      - crun
+      - netavark
+      - podman
+      - skopeo
   - repo: okd-copr
     packages:
       - cri-o
       - cri-tools
+  - repo: podman-next-copr
+    packages:
+      - conmon-rs


### PR DESCRIPTION
Until there are official C9S appstream or SIG builds of conmon-rs available, get it from the integration builds maintained by upstream. This ensures a current version of conmon-rs is consumed during builds outside of Prow, i.e. OKD/SCOS release builds.