### PR TITLE
Revert "denylists: re-enable `luks.*` on `!x86_64`"

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -37,6 +37,11 @@
   tracker: https://bugzilla.redhat.com/show_bug.cgi?id=2080063
   arches:
     - s390x
+- pattern: luks.*
+  tracker: https://github.com/openshift/os/issues/1149
+  arches:
+   - ppc64le
+   - aarch64
 
 # We're using some COPR stuff intentionally
 - pattern: ext.config.shared.content-origins


### PR DESCRIPTION
This reverts commit e28b3912416493a7b7f565daa54a97ce2fa7f2b7.

This still failed on ppc64le.