### PR TITLE
tree: delete .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,0 @@
-/*.repo
-/content_sets.yaml


### PR DESCRIPTION
We were using it for ignoring repo files and `content_sets.yaml`. This dates back from when we had to copy yum repo files into the git checkout. Nowadays, the `--yumrepos` switch of `cosa init` makes this no longer necessary.

Delete it because we do track at least one yum repo file in this repo now (`c9s.repo`) and that confuses at least ripgrep which only respects `.gitignore` and not what files are in the tree (by design it seems: https://github.com/BurntSushi/ripgrep/issues/2329).