### PR TITLE
gitmodules: track rhcos-4.13 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "fedora-coreos-config"]
 	path = fedora-coreos-config
 	url = https://github.com/coreos/fedora-coreos-config
-	branch = testing-devel
+	branch = rhcos-4.13


### PR DESCRIPTION
Have the submodule track the rhcos-4.13 branch on the fedora-coreos-config repo as a part of the 4.13 branching.