### PR TITLE
s390x/kola-denylist: Re-enable working tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -3,18 +3,12 @@
 # see: https://github.com/coreos/coreos-assembler/pull/866.
 - pattern: skip-console-warnings
   tracker: https://bugzilla.redhat.com/show_bug.cgi?id=2164765
-- pattern: fips.enable*
-  tracker: https://bugzilla.redhat.com/show_bug.cgi?id=1782026
-  arches:
-   - s390x
 - pattern: coreos.ignition.journald-log
   tracker: https://github.com/coreos/coreos-assembler/issues/1173
-- pattern: coreos.ignition.mount.*
-  tracker: https://bugzilla.redhat.com/show_bug.cgi?id=1899990
-  arches:
-  - s390x
 - pattern: ext.config.shared.ignition.stable-boot
   tracker: https://bugzilla.redhat.com/show_bug.cgi?id=2075085
+  osversion:
+   - rhel-8.6
   arches:
   - s390x
 - pattern: ext.config.shared.kdump.crash


### PR DESCRIPTION
fips.enable* is working on newest s390x. Remove the test from denylist. For more details see #546

coreos.ignition.mount.* is fixed with gdisk-1.0.3-9.el8. Remove the test from denylist.

ext.config.shared.ignition.stable-boot is fixed in RHEL 9. Only disable for RHEL 8 builds.