### PR TITLE
denylist: Drop coreos.ignition.journald-log from denylist

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -3,8 +3,6 @@
 # see: https://github.com/coreos/coreos-assembler/pull/866.
 - pattern: skip-console-warnings
   tracker: https://bugzilla.redhat.com/show_bug.cgi?id=2164765
-- pattern: coreos.ignition.journald-log
-  tracker: https://github.com/coreos/coreos-assembler/issues/1173
 - pattern: ext.config.shared.ignition.stable-boot
   tracker: https://bugzilla.redhat.com/show_bug.cgi?id=2075085
   osversion:


### PR DESCRIPTION
Enabling `ignition.journald-log` as the test now runs and passes for RHCOS.