### PR TITLE
[4.13] Backports from 4.14

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "fedora-coreos-config"]
 	path = fedora-coreos-config
 	url = https://github.com/coreos/fedora-coreos-config
-	branch = testing-devel
+	branch = rhcos-4.13

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -3,18 +3,12 @@
 # see: https://github.com/coreos/coreos-assembler/pull/866.
 - pattern: skip-console-warnings
   tracker: https://bugzilla.redhat.com/show_bug.cgi?id=2164765
-- pattern: fips.enable*
-  tracker: https://bugzilla.redhat.com/show_bug.cgi?id=1782026
-  arches:
-   - s390x
 - pattern: coreos.ignition.journald-log
   tracker: https://github.com/coreos/coreos-assembler/issues/1173
-- pattern: coreos.ignition.mount.*
-  tracker: https://bugzilla.redhat.com/show_bug.cgi?id=1899990
-  arches:
-  - s390x
 - pattern: ext.config.shared.ignition.stable-boot
   tracker: https://bugzilla.redhat.com/show_bug.cgi?id=2075085
+  osversion:
+   - rhel-8.6
   arches:
   - s390x
 - pattern: ext.config.shared.kdump.crash

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -60,5 +60,3 @@
 
 - pattern: ext.config.shared.ignition.resource.remote
   tracker: https://github.com/openshift/os/issues/1190
-  osversion:
-   - rhel-8.6

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -63,3 +63,8 @@
 
 - pattern: rhcos.network.*
   tracker: https://github.com/coreos/coreos-assembler/issues/3376
+
+- pattern: ext.config.shared.ignition.resource.remote
+  tracker: https://github.com/openshift/os/issues/1190
+  osversion:
+   - rhel-8.6

--- a/manifest-rhel-9.2.yaml
+++ b/manifest-rhel-9.2.yaml
@@ -147,6 +147,15 @@ repo-packages:
       - nss-altfiles
       # Use the new containers/toolbox
       - toolbox
+      # RHCOS packages that are now part of RHEL and that will have to be
+      # explicitely removed from this list if they have to come from the RHAOS
+      # repo again.
+      - afterburn
+      - console-login-helper-messages-issuegen console-login-helper-messages-profile
+      - coreos-installer coreos-installer-bootinfra
+      - ignition
+      - ostree
+      - rpm-ostree
   - repo: rhel-9.0-server-ose-4.13
     packages:
       - conmon-rs

--- a/overlay.d/25rhcos-azure-udev-rules/statoverride
+++ b/overlay.d/25rhcos-azure-udev-rules/statoverride
@@ -1,2 +1,0 @@
-# Config file for overriding permission bits on overlay files/dirs
-# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/25rhcos-azure-udev-rules/usr/lib/udev/rules.d/50-azure-ptp.rules
+++ b/overlay.d/25rhcos-azure-udev-rules/usr/lib/udev/rules.d/50-azure-ptp.rules
@@ -1,5 +1,0 @@
-# Manual backport of:
-# https://github.com/systemd/systemd/commit/32e868f058da8b90add00b2958c516241c532b70
-# Can drop once we get to RHEL 8.6:
-# https://bugzilla.redhat.com/show_bug.cgi?id=1991834
-SUBSYSTEM=="ptp", ATTR{clock_name}=="hyperv", SYMLINK += "ptp_hyperv"


### PR DESCRIPTION
manifest/9.2: Ensure package come from RHEL by default

Make sure that we use RHEL (and not RHAOS) packages by default.

(cherry picked from commit 49f9824db2b6f929567d2d41cea6c97df766cf37)

---

overlay: Remove unused 25rhcos-azure-udev-rules

Not needed (and not actually used right now) in RHEL 8.6+ anymore.

(cherry picked from commit 5d5d0c583023a2cd9c301f2bad810098a9e8e565)

---

Bump fedora-coreos-config

Adam Piasecki (1):
      tests/kola/selinux/enforcing: Enhance SELinux mode test

Adam0Brien (1):
      F38 Changes: Kola test for shorter shutdown timer

Benjamin Gilbert (2):
      tests/kola: add test for custom SSH host key with mode 640
      denylist: drop snoozes for Ignition spec bump

Dusty Mabe (6):
      tests/kola: add version comparison functions to commonlib.sh
      tests/kola: mark systemd.default-unit-timeouts as platform-independent
      tests/kola: break up long line in systemd.default-unit-timeouts
      denylist: bump snooze for files.file-directory-permissions
      platforms.yaml: Add serial console information for KubeVirt platform.
      denylist: drop snooze for ext.config.platforms.aws.nvme

Huijing Hei (1):
      transposefs: add new workaround using try in loop

Jonathan Lebon (1):
      ci: update for new kolaTestIso()

gursewak1997 (4):
      Move chrony config from generator to systemd service
      platform-chrony: Make /run/coreos dir so we can create platform-chrony.conf
      denylist: bump snooze for kdump.crash
      denylist: drop extensions.module from denylist Ref: https://github.com/coreos/fedora-coreos-tracker/issues/1420#issuecomment-1460646570

(cherry picked from commit 3b0d0c76a094977ab91fd7529978a768f58a3719)

---

denylist: Skip ext.config.shared.ignition.resource.remote

See #1190

(cherry picked from commit d47155ab9aea4ad9a75e49189928482e504892b3)

---

s390x/kola-denylist: Re-enable working tests

fips.enable* is working on newest s390x. Remove the test from denylist.
For more details see #546

coreos.ignition.mount.* is fixed with gdisk-1.0.3-9.el8. Remove the test from
denylist.

ext.config.shared.ignition.stable-boot is fixed in RHEL 9. Only disable for
RHEL 8 builds.

Signed-off-by: Jan Schintag <jan.schintag@de.ibm.com>
(cherry picked from commit 36729d18411c5e9ef3d21effa7896ee84f1518b9)

---

Revert "tests: Add `skip-console-warnings` to global kola config"

Fixes: https://github.com/openshift/os/issues/1160
See: https://github.com/openshift/os/pull/1128
See: https://bugzilla.redhat.com/show_bug.cgi?id=2164765

This reverts commit 010cb8b2ba9060c98190b0f1b700a568fb911f73.

(cherry picked from commit 2419a93859ba5b159c9ccf4b41d61efbfdd2ec6a)