### PR TITLE
OCPBUGS-8008: manifest/9.2: Keep legacy coreos/toolbox & Revert "Ensure package come from RHEL by default"

### DIFF
--- a/manifest-rhel-9.2.yaml
+++ b/manifest-rhel-9.2.yaml
@@ -145,8 +145,6 @@ repo-packages:
     packages:
       # We want the one shipping in RHEL, not the equivalently versioned one in RHAOS
       - nss-altfiles
-      # Use the new containers/toolbox
-      - toolbox
   - repo: rhel-9.0-server-ose-4.13
     packages:
       - conmon-rs
@@ -154,3 +152,5 @@ repo-packages:
       - cri-tools
       - openshift-clients
       - openshift-hyperkube
+      # Use legacy coreos/toolbox until we're ready to use containers/toolbox
+      - toolbox

--- a/manifest-rhel-9.2.yaml
+++ b/manifest-rhel-9.2.yaml
@@ -147,15 +147,6 @@ repo-packages:
       - nss-altfiles
       # Use the new containers/toolbox
       - toolbox
-      # RHCOS packages that are now part of RHEL and that will have to be
-      # explicitely removed from this list if they have to come from the RHAOS
-      # repo again.
-      - afterburn
-      - console-login-helper-messages-issuegen console-login-helper-messages-profile
-      - coreos-installer coreos-installer-bootinfra
-      - ignition
-      - ostree
-      - rpm-ostree
   - repo: rhel-9.0-server-ose-4.13
     packages:
       - conmon-rs


### PR DESCRIPTION
Revert "manifest/9.2: Ensure package come from RHEL by default"

We already have to use coreos-installer from the RHAOS repo and it's
likely that we will have to do it again in the future for 4.14.

Remove this to avoid having to make a PR for each package.

This reverts commit 49f9824db2b6f929567d2d41cea6c97df766cf37.

---

manifest/9.2: Keep legacy coreos/toolbox

Unfortuantely, we're not yet ready to move to the new containers/toolbox
workflow. We'll attempt that for a future release.

See: https://issues.redhat.com/browse/OCPBUGS-8009
Partially reverts: https://github.com/openshift/os/commit/65776fa6e94fc25d73fd32a26f38547d55f61d44