### PR TITLE
OCPBUGS-8009: Revert to legacy toolbox

### DIFF
--- a/manifest-rhel-9.2.yaml
+++ b/manifest-rhel-9.2.yaml
@@ -131,5 +131,4 @@ repo-packages:
       - openshift-clients
       - openshift-hyperkube
       # Use legacy coreos/toolbox until we're ready to use containers/toolbox
-      # See https://github.com/openshift/os/pull/1202#issuecomment-1474312602
-      # - toolbox
+      - toolbox

--- a/manifest-rhel-9.2.yaml
+++ b/manifest-rhel-9.2.yaml
@@ -20,7 +20,6 @@ repos:
   - rhel-9.2-baseos
   - rhel-9.2-appstream
   - rhel-9.2-fast-datapath
-  - rhel-9.2-server-ose-4.12  # FIXME: Drop when conmon-rs is fixed
   - rhel-9.2-server-ose-4.13
 
 # We include hours/minutes to avoid version number reuse
@@ -121,11 +120,9 @@ repo-packages:
     packages:
       # We want the one shipping in RHEL, not the equivalently versioned one in RHAOS
       - nss-altfiles
-  - repo: rhel-9.2-server-ose-4.12
-    packages:
-      - conmon-rs # FIXME drop when conmon-rs is built in 4.13
   - repo: rhel-9.2-server-ose-4.13
     packages:
+      - conmon-rs
       - cri-o
       - cri-tools
       - openshift-clients


### PR DESCRIPTION
Revert "manifest: Back to rhel toolbox"

We now have a legacy toolbox build in the correct repo.

This reverts commit 3c453e572a2c770ef42e3062d5f107951d03dcf7.

---

manifest/9/2: Get conmon-rs from rhel-9.2-server-ose-4.13 repo