### PR TITLE
kola-denylist: Remove RHEL 8.6 entries

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -3,12 +3,6 @@
 # see: https://github.com/coreos/coreos-assembler/pull/866.
 - pattern: skip-console-warnings
   tracker: https://bugzilla.redhat.com/show_bug.cgi?id=2164765
-- pattern: ext.config.shared.ignition.stable-boot
-  tracker: https://bugzilla.redhat.com/show_bug.cgi?id=2075085
-  osversion:
-   - rhel-8.6
-  arches:
-  - s390x
 - pattern: ext.config.shared.kdump.crash
   tracker: https://github.com/coreos/coreos-assembler/issues/2725
   arches:
@@ -38,19 +32,8 @@
 - pattern: ext.config.version.rhel-matches-rhcos-build
   tracker: ''
 
-# Temporary to unblock COSA CI
-- pattern: ext.config.shared.clhm.network-device-info
-  tracker: https://github.com/openshift/os/issues/1041
-  osversion:
-   - rhel-8.6
-
 - pattern: ext.config.rpm-ostree.replace-rt-kernel
   tracker: https://github.com/openshift/os/issues/1099
 
 - pattern: rhcos.network.*
   tracker: https://github.com/coreos/coreos-assembler/issues/3376
-
-- pattern: ext.config.shared.ignition.resource.remote
-  tracker: https://github.com/openshift/os/issues/1190
-  osversion:
-   - rhel-8.6


### PR DESCRIPTION
Since we are now no longer building RHEL 8,6 content, remove tests that are only disabled for RHEL 8.6