### PR TITLE
kola-denylist: drop ext.config.shared.content-origins and ext.config.version.rhel-matches-rhcos-build

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -16,10 +16,6 @@
   arches:
   - ppc64le
 
-# Temporary while we're using C9S
-- pattern: ext.config.version.rhel-matches-rhcos-build
-  tracker: ''
-
 - pattern: ext.config.rpm-ostree.replace-rt-kernel
   tracker: https://github.com/openshift/os/issues/1099
 

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -16,10 +16,6 @@
   arches:
   - ppc64le
 
-# We're using some COPR stuff intentionally
-- pattern: ext.config.shared.content-origins
-  tracker: ''
-
 # Temporary while we're using C9S
 - pattern: ext.config.version.rhel-matches-rhcos-build
   tracker: ''

--- a/tests/kola/version/rhel-matches-rhcos-build
+++ b/tests/kola/version/rhel-matches-rhcos-build
@@ -2,7 +2,7 @@
 ## kola:
 ##   exclusive: false
 #
-# Check that the OS version (C9S, RHEL 9.0) matches the version stored in
+# Check that the OS version (C9S, RHEL 9.x) matches the version stored in
 # /etc/os-release
 
 set -xeuo pipefail
@@ -13,9 +13,11 @@ ocp_version="$(source /etc/os-release; echo "${VERSION}")"
 variant="$(source /etc/os-release; echo "${ID}")"
 case "${variant}" in
     "scos")
+        # on SCOS, this is just "9"
         osver="$(source /usr/lib/os-release.stream; echo "${VERSION_ID}")"
         ;;
     "rhcos")
+        # on RHCOS, this is e.g. "9.2"; we convert to "92"
         osver="$(source /usr/lib/os-release.rhel; echo "${VERSION_ID}" | sed 's/\.//')"
         ;;
     "*")


### PR DESCRIPTION
See individual commits.