### PR TITLE
extensions-c9s: use `match-base-evr: kernel` for kernel-rt

### DIFF
--- a/extensions-c9s.yaml
+++ b/extensions-c9s.yaml
@@ -48,6 +48,7 @@ extensions:
       - kernel-rt-modules
       - kernel-rt-modules-extra
       - kernel-rt-devel
+    match-base-evr: kernel
   # https://github.com/openshift/machine-config-operator/pull/2456
   # https://github.com/openshift/enhancements/blob/master/enhancements/sandboxed-containers/sandboxed-containers-tech-preview.md
   # GRPA-3123


### PR DESCRIPTION
The kernel-rt merge has already happened in CentOS Stream 9. So using `match-base-evr` now works there. This means that rpm-ostree will guarantee that the kernel-rt package matches the version of the base kernel.

We don't build SCOS in the CoreOS pipelines today but let's exercise this knob as preparation for when the change propagates to RHEL.