### PR TITLE
Pull conmon-rs from 4.12 for now

### DIFF
--- a/manifest-rhel-9.2.yaml
+++ b/manifest-rhel-9.2.yaml
@@ -20,6 +20,7 @@ repos:
   - rhel-9.2-baseos
   - rhel-9.2-appstream
   - rhel-9.2-fast-datapath
+  - rhel-9.2-server-ose-4.12  # FIXME: Drop when conmon-rs is fixed
   - rhel-9.2-server-ose-4.13
 
 # We include hours/minutes to avoid version number reuse
@@ -120,9 +121,11 @@ repo-packages:
     packages:
       # We want the one shipping in RHEL, not the equivalently versioned one in RHAOS
       - nss-altfiles
+  - repo: rhel-9.2-server-ose-4.12
+    packages:
+      - conmon-rs # FIXME drop when conmon-rs is built in 4.13
   - repo: rhel-9.2-server-ose-4.13
     packages:
-      - conmon-rs
       - cri-o
       - cri-tools
       - openshift-clients


### PR DESCRIPTION
Because 4.13 builds broke, but ART's tooling started preferring 4.12 and skipping the 4.13 build.