### PR TITLE
OCPBUGS-8008: Revert "manifest: Back to rhel toolbox"

### DIFF
--- a/manifest-rhel-9.2.yaml
+++ b/manifest-rhel-9.2.yaml
@@ -129,5 +129,4 @@ repo-packages:
       - openshift-clients
       - openshift-hyperkube
       # Use legacy coreos/toolbox until we're ready to use containers/toolbox
-      # See https://github.com/openshift/os/pull/1202#issuecomment-1474312602
-      # - toolbox
+      - toolbox


### PR DESCRIPTION
Revert "manifest: Back to rhel toolbox"

We now have a build of the legacy toolbox in the RHAOS repo.

This reverts commit cdeb2523df43add1b7713c109c2273d8aa7cc6d0.