### PR TITLE
kola-denylist: re-enable `luks.*` test on `!x86_64`

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -31,12 +31,6 @@
   tracker: https://bugzilla.redhat.com/show_bug.cgi?id=2080063
   arches:
     - s390x
-- pattern: luks.*
-  tracker: https://github.com/openshift/os/issues/1149
-  arches:
-   - ppc64le
-   - aarch64
-   - s390x
 
 # We're using some COPR stuff intentionally
 - pattern: ext.config.shared.content-origins


### PR DESCRIPTION
See https://github.com/openshift/os/pull/1185

(cherry picked from commit 4c3c5d86c145c51657d8b7c08707adea70216590)