### PR TITLE
Backport CI fixes

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -269,7 +269,7 @@ main () {
             cosa_build
             kola_test_qemu
             ;;
-        "scos-9-build-test-metal" )
+        "scos-9-build-test-metal")
             setup_user
             cosa_init "scos"
             cosa_build

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -242,12 +242,12 @@ main () {
             prepare_repos
             ;;
         "build" | "init-and-build-default")  # TODO: change prow job to use init-and-build-default
-            cosa_init "rhel-coreos-8"
+            cosa_init "rhel-coreos-9"
             cosa_build
             ;;
         "rhcos-cosa-prow-pr-ci")
             setup_user
-            cosa_init "rhel-coreos-8"
+            cosa_init "rhel-coreos-9"
             cosa_build
             kola_test_qemu
             ;;

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -251,18 +251,6 @@ main () {
             cosa_build
             kola_test_qemu
             ;;
-        "rhcos-86-build-test-qemu")
-            setup_user
-            cosa_init "rhel-coreos-8"
-            cosa_build
-            kola_test_qemu
-            ;;
-        "rhcos-86-build-test-metal")
-            setup_user
-            cosa_init "rhel-coreos-8"
-            cosa_build
-            kola_test_metal
-            ;;
         "rhcos-92-build-test-qemu"|"rhcos-90-build-test-qemu")
             setup_user
             cosa_init "rhel-coreos-9"
@@ -286,6 +274,10 @@ main () {
             cosa_init "scos"
             cosa_build
             kola_test_metal
+            ;;
+        "rhcos-86-build-test-qemu"|"rhcos-86-build-test-metal")
+            # Disabled tests
+            exit 0
             ;;
         *)
             # This case ensures that we exhaustively list the tests that should

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -73,9 +73,9 @@ prepare_repos() {
     # Figure out which version we're building
     rhelver=$(rpm-ostree compose tree --print-only "${manifest}" | jq -r '.["automatic-version-prefix"]' | cut -f2 -d.)
 
-    # Temporary workaround until we publish builds for other versions
-    if [[ "${rhelver}" == "86" ]]; then
-        prev_build_url="${REDIRECTOR_URL}/rhcos-${ocpver}/"
+    # Temporary workaround until we publish builds in the default path
+    if [[ "${rhelver}" == "92" ]]; then
+        prev_build_url="${REDIRECTOR_URL}/rhcos-${ocpver}-9.2/"
         # Fetch the previous build
         cosa buildfetch --url="${prev_build_url}"
     fi


### PR DESCRIPTION
ci: Disable RHCOS 8 builds & tests

(cherry picked from commit a442b06ca0d100208a012506bb092ab8b3a79a24)

---

ci: Use RHCOS 9 for builds & tests by default

(cherry picked from commit 100d0d46939a4d789a505f864bad3ca187707431)

---

ci: Update fetch path for 9.2 builds

(cherry picked from commit 1c662d798e7091dfaaac307299630dab8466805e)

---

ci: Cleanup whitespace