### PR TITLE
Snooze new ext.config.shared.networking.nmstate.* tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -24,3 +24,7 @@
 
 - pattern: ext.config.shared.multipath.multipathd-service-fix
   tracker: https://github.com/openshift/os/issues/1213
+
+- pattern: ext.config.shared.networking.nmstate.*
+  tracker: https://github.com/openshift/os/issues/1228
+  snooze: 2023-04-17


### PR DESCRIPTION
The new nmstate tests are failling, snooze until we either fix the for RHCOS or disable them for RHCOS.