### PR TITLE
Get containers stack from highest NEVRA

### DIFF
--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -143,11 +143,6 @@ repo-packages:
       - toolbox
       # We want the ones shipping in C9S, not the integrations builds from COPR
       - aardvark-dns
-      - containers-common
-      - crun
-      - netavark
-      - podman
-      - skopeo
   - repo: okd-copr
     packages:
       - cri-o


### PR DESCRIPTION
We've oscillated on whether to get podman from RHEL or OCP channels.  Current decision is to just float with highest version.

In particular this ensures we get a `containers-common` that we want from the OCP channels.