### PR TITLE
common.yaml: remove the workaround to add exec for `nvmf-autoconnect.sh`

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -195,14 +195,6 @@ postprocess:
      # but we have containers that expect it to be mounted so for now let's continue
      # generating it.
      ln -sr /usr/share/zoneinfo/UTC /etc/localtime
-  - |
-    #!/usr/bin/env bash
-    set -xeuo pipefail
-    # Backport https://github.com/dracutdevs/dracut/commit/25a92885a9519701cc480298c2b082e2e2bf5ebe
-    s=/usr/lib/dracut/modules.d/95nvmf/nvmf-autoconnect.sh
-    if test -f "$s"; then
-      chmod a+x "$s"
-    fi
 
 remove-files:
   # We don't ship man(1) or info(1)


### PR DESCRIPTION
As we are using RHEL 9.2, and the issue is gone.
```
$ cat /etc/os-release
...
REDHAT_SUPPORT_PRODUCT_VERSION="9.2 Beta"

$ ll /usr/lib/dracut/modules.d/95nvmf/nvmf-autoconnect.sh
-rwxr-xr-x. 1 root root 140 Jun 19  2022 /usr/lib/dracut/modules.d/95nvmf/nvmf-autoconnect.sh
$ rpm -qf /usr/lib/dracut/modules.d/95nvmf/nvmf-autoconnect.sh
dracut-057-21.git20230214.el9.x86_64
```