### PR TITLE
[release-4.10] denylist: add `ext.config.shared.chrony.dhcp-propagation`

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -14,3 +14,5 @@
 - pattern: rhcos.upgrade.from-ocp-rhcos
   tracker: https://github.com/openshift/os/issues/857
   snooze: 2022-06-27
+- pattern: ext.config.shared.chrony.dhcp-propagation
+  tracker: https://github.com/openshift/os/issues/1233


### PR DESCRIPTION
This is failing now due to stale Fedora content. Denylist for now at least to unblock builds.

See: https://github.com/openshift/os/issues/1233