### PR TITLE
denylist: Remove multipath.multipathd-service-fix

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -22,9 +22,6 @@
 - pattern: rhcos.network.*
   tracker: https://github.com/coreos/coreos-assembler/issues/3376
 
-- pattern: ext.config.shared.multipath.multipathd-service-fix
-  tracker: https://github.com/openshift/os/issues/1213
-
 - pattern: ext.config.shared.networking.nmstate.*
   tracker: https://github.com/openshift/os/issues/1228
   snooze: 2023-04-17


### PR DESCRIPTION
Dropping `multipath.multipathd-service-fix` from denylist since the https://github.com/openshift/os/issues/1213 is fixed.

Closes:  https://github.com/openshift/os/issues/1213