### PR TITLE
overlay: add 30rhcos-nvme-compat-udev

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -22,6 +22,7 @@ ostree-layers:
   - overlay/20platform-chrony
   - overlay/21dhcp-chrony
   - overlay/25azure-udev-rules
+  - overlay/30rhcos-nvme-compat-udev
 
 arch-include:
   x86_64:

--- a/overlay.d/30rhcos-nvme-compat-udev/statoverride
+++ b/overlay.d/30rhcos-nvme-compat-udev/statoverride
@@ -1,0 +1,2 @@
+# Config file for overriding permission bits on overlay files/dirs
+# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/30rhcos-nvme-compat-udev/usr/lib/dracut/modules.d/30rhcos-nvme-compat-udev/module-setup.sh
+++ b/overlay.d/30rhcos-nvme-compat-udev/usr/lib/dracut/modules.d/30rhcos-nvme-compat-udev/module-setup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# NVMe by-id/ symlinks changed wrt leading spaces from RHEL8 to RHEL9:
+# https://issues.redhat.com/browse/OCPBUGS-11375
+# https://github.com/systemd/systemd/issues/27155
+
+# This rule adds back the previous symlinks for backwards compatibility. We want
+# it in the initramfs in case there are Ignition configs which referenced the
+# old symlinks.
+
+install() {
+    inst_multiple /usr/lib/udev/rules.d/61-persistent-storage-nvme-compat.rules
+}

--- a/overlay.d/30rhcos-nvme-compat-udev/usr/lib/udev/rules.d/61-persistent-storage-nvme-compat.rules
+++ b/overlay.d/30rhcos-nvme-compat-udev/usr/lib/udev/rules.d/61-persistent-storage-nvme-compat.rules
@@ -1,0 +1,20 @@
+# NVMe by-id/ symlinks changed wrt leading spaces from RHEL8 to RHEL9:
+# https://issues.redhat.com/browse/OCPBUGS-11375
+# https://github.com/systemd/systemd/issues/27155
+
+# This rule adds back the previous symlinks for backwards compatibility.
+
+# They're the same as the regular rules in 60-persistent-storage.rules, except
+# they don't include the `OPTIONS="string_escape=replace"` directive.
+
+ACTION=="remove", GOTO="persistent_storage_nvme_compat_end"
+ENV{UDEV_DISABLE_PERSISTENT_STORAGE_RULES_FLAG}=="1", GOTO="persistent_storage_nvme_compat_end"
+SUBSYSTEM!="block", GOTO="persistent_storage_nvme_compat_end"
+
+KERNEL=="nvme*[0-9]n*[0-9]", ENV{DEVTYPE}=="disk", ENV{ID_MODEL}=="?*", ENV{ID_SERIAL_SHORT}=="?*", \
+  ENV{ID_SERIAL}="$env{ID_MODEL}_$env{ID_SERIAL_SHORT}", SYMLINK+="disk/by-id/nvme-$env{ID_SERIAL}"
+
+KERNEL=="nvme*[0-9]n*[0-9]p*[0-9]", ENV{DEVTYPE}=="partition", ENV{ID_MODEL}=="?*", ENV{ID_SERIAL_SHORT}=="?*", \
+  ENV{ID_SERIAL}="$env{ID_MODEL}_$env{ID_SERIAL_SHORT}", SYMLINK+="disk/by-id/nvme-$env{ID_SERIAL}-part%n"
+
+LABEL="persistent_storage_nvme_compat_end"

--- a/overlay.d/README.md
+++ b/overlay.d/README.md
@@ -39,9 +39,23 @@ lands in downstream packages. See upstream thread:
 https://listengine.tuxfamily.org/chrony.tuxfamily.org/chrony-dev/2020/05/msg00022.html
 
 25rhcos-azure-udev
--------------
+------------------
 
 We want to provide Azure udev rules as part of the initrd, so that Ignition
 is able to detect disks and act on them. The WALinuxAgent-udev has been
 changed to install udev rules into the initramfs, but that change isn't
 in el8 yet. This can be dropped when moving to el9.
+
+30rhcos-nvme-compat-udev
+------------------------
+
+NVMe by-id/ symlinks changed wrt leading spaces from RHEL8 to RHEL9:
+https://issues.redhat.com/browse/OCPBUGS-11375
+https://github.com/systemd/systemd/issues/27155
+
+This overlay ships a rule that adds back the previous symlinks for backwards
+compatibility. TBD when we can drop this, e.g. by having layered software use
+the `eui` links instead or pivoting to GPT partition UUIDs. Customers may have
+also manually typed the old symlink in their Ignition configs and other k8s
+resources though. Those would require some communication before we can rip this
+out.

--- a/tests/kola/disk/nvme-compat-symlink
+++ b/tests/kola/disk/nvme-compat-symlink
@@ -1,0 +1,27 @@
+#!/bin/bash
+## kola:
+##   exclusive: true
+##   additionalDisks: ["1G:channel=nvme,serial=    foobar"]
+##   platforms: qemu
+#
+# By default coreos-generate-iscsi-initiatorname.service is active on RHCOS,
+# inactive on FCOS
+# https://github.com/openshift/os/pull/453
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+# the canonical symlink
+s=/dev/disk/by-id/nvme-QEMU_NVMe_Ctrl_____foobar
+if ! test -L "${s}"; then
+    fatal "missing canonical symlink ${s}"
+fi
+
+# the compat symlink
+s=/dev/disk/by-id/nvme-QEMU_NVMe_Ctrl__foobar
+if ! test -L "${s}"; then
+    fatal "missing compat symlink ${s}"
+fi
+
+ok "nvme compat symlink"


### PR DESCRIPTION
The systemd in RHEL 9.2 now ships this commit:
https://github.com/systemd/systemd/commit/5118e8e71d

This changes how symlinks created from device serials with leading spaces are interpreted, from e.g.

```
nvme-QEMU_NVMe_Ctrl__foobar -> ../../nvme0n1
```

to

```
nvme-QEMU_NVMe_Ctrl_______foobar -> ../../nvme0n1
```

This in turn breaks anything/anyone that relied on the previous symlinks. Things in the storage stack for example that auto-discover block devices, or simply just customers customizing their storage.

Add back a rule similar to the previous version so that we keep creating the previous symlink. Also ship this in the initramfs in case Ignition configs referenced them.

The motivating factor for the systemd change was to fix incorrect behaviour when e.g. the model name contained a `/`; udevd would create a literal directory as a result:

https://github.com/systemd/systemd/issues/19309

This rule we're adding back is still susceptible to this issue, though we haven't seen it in the wild for RHCOS. We could deviate from the old rule and have something custom to handle this but it's probably not worth the effort. The new rule is still there creating the fixed symlink, so users could still use that one if such a case arises.

Fixes: https://issues.redhat.com/browse/OCPBUGS-11375
See also: https://github.com/systemd/systemd/issues/27155