### PR TITLE
ci: Neuter `rhcos-92-build-test-*` for now

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -253,12 +253,16 @@ main () {
             kola_test_qemu
             ;;
         "rhcos-92-build-test-qemu"|"rhcos-90-build-test-qemu")
+            echo "FIXME skipped until we have updated mirrors in Prow"
+            exit 0
             setup_user
             cosa_init "rhel-coreos-9"
             cosa_build
             kola_test_qemu
             ;;
         "rhcos-92-build-test-metal"|"rhcos-90-build-test-metal")
+            echo "FIXME skipped until we have updated mirrors in Prow"
+            exit 0
             setup_user
             cosa_init "rhel-coreos-9"
             cosa_build


### PR DESCRIPTION
FIXME skipped until we have updated mirrors in Prow