### PR TITLE
OCPBUGS-11589: overlay: Inject `SYSTEMD_JOURNAL_{COMPACT,KEYED_HASH}=0`

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -19,6 +19,7 @@ ostree-layers:
   - overlay/06gcp-routes
   - overlay/15rhcos-networkmanager-dispatcher
   - overlay/15rhcos-tuned-bits
+  - overlay/15rhcos-journald-backcompat
   - overlay/20platform-chrony
   - overlay/21dhcp-chrony
   - overlay/25azure-udev-rules

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -57,3 +57,9 @@
 
 - pattern: ext.config.shared.multipath.multipathd-service-fix
   tracker: https://github.com/openshift/os/issues/1213
+
+# lift when systemd in c9s has the compat patch
+- pattern: ext.config.systemd.journal-compat
+  tracker: https://github.com/openshift/os/pull/1230
+  osversion:
+  - c9s

--- a/overlay.d/15rhcos-journald-backcompat/statoverride
+++ b/overlay.d/15rhcos-journald-backcompat/statoverride
@@ -1,0 +1,2 @@
+# Config file for overriding permission bits on overlay files/dirs
+# Format: =<file mode in decimal> <absolute path to a file or directory>

--- a/overlay.d/15rhcos-journald-backcompat/usr/lib/systemd/system/systemd-journald.service.d/rhel8-compat.conf
+++ b/overlay.d/15rhcos-journald-backcompat/usr/lib/systemd/system/systemd-journald.service.d/rhel8-compat.conf
@@ -1,0 +1,5 @@
+# See https://issues.redhat.com/browse/LOG-3832
+# This allows containers running rhel8 to read our journal
+[Service]
+Environment=SYSTEMD_JOURNAL_COMPACT=0
+Environment=SYSTEMD_JOURNAL_KEYED_HASH=0

--- a/tests/kola/systemd/data/commonlib.sh
+++ b/tests/kola/systemd/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../../fedora-coreos-config/tests/kola/data/commonlib.sh

--- a/tests/kola/systemd/journal-compat
+++ b/tests/kola/systemd/journal-compat
@@ -1,0 +1,22 @@
+#!/bin/bash
+## kola:
+##   # Since we pull a container image
+##   tags: "needs-internet" 
+##   timeoutMin: 30
+#
+# Verify that rhel8 journalctl can still read our journals https://issues.redhat.com/browse/OCPBUGS-11492
+
+set -euo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+cd $(mktemp -d)
+
+# The string Linux should match the kernel boot
+podman run --privileged --net=none -v /var/log:/var/log:ro --rm quay.io/centos/centos:stream8 journalctl -D /var/log/journal --grep="Linux" > journal.txt 2>err.txt
+if grep -qF 'uses an unsupported feature' err.txt; then
+    fatal "Got unsupported feature trying to read journal"
+fi
+if ! grep -F "Linux" journal.txt; then
+    fatal "Failed to read journal"
+fi


### PR DESCRIPTION
So that containers using rhel8 can read the host's journal directly.

xref https://issues.redhat.com/browse/LOG-3832

We can remove this in 4.14 hopefully, and almost certainly 4.15.

(cherry picked from commit 5bcda9bb20f58e8f035fea80cd773057aecf7bf8)