### PR TITLE
[release-4.13] OCPBUGS-11657: Bump fedora-coreos-config

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -61,5 +61,13 @@
 # lift when systemd in c9s has the compat patch
 - pattern: ext.config.systemd.journal-compat
   tracker: https://github.com/openshift/os/pull/1230
+
+- pattern: iso-live-login.uefi-secure
+  tracker: https://github.com/openshift/os/issues/1237
+  osversion:
+  - c9s
+
+- pattern: iso-as-disk.uefi-secure
+  tracker: https://github.com/openshift/os/issues/1237
   osversion:
   - c9s


### PR DESCRIPTION
Dusty Mabe (1):
      coreos-teardown-initramfs: teardown after NM has exited

Renata Ravanelli (3):
      overlay.d: create new 30gcp-udev-rules overlay
      overlay.d: Add/Update udev rules for GCP
      Add 30gcp-udev-rules overlay to the manifest