### PR TITLE
OCPBUGS-11613: manifests: Use a file drop in for sshd config in EL9

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -63,13 +63,6 @@ postprocess:
      #!/usr/bin/env bash
      set -xeo pipefail
 
-     # Disable PasswordAuthentication in SSH
-     sed -i "s|^PasswordAuthentication yes$|PasswordAuthentication no|g" /etc/ssh/sshd_config
-     # Disable root login because don't do that.
-     sed -i "s|^PermitRootLogin yes$|PermitRootLogin no|g" /etc/ssh/sshd_config
-     # Enable ClientAliveInterval and set to 180 per https://bugzilla.redhat.com/show_bug.cgi?id=1701050
-     sed -i "s|^#ClientAliveInterval 0$|ClientAliveInterval 180|g" /etc/ssh/sshd_config
-
      # TEMPORARY: Create /etc/vmware-tools/tools.conf to ensure RHCOS shows up properly in VMWare
      # See https://jira.coreos.com/browse/RHCOS-258
      if [ "$(uname -m)" == "x86_64" ]; then

--- a/overlay.d/07el9/etc/ssh/sshd_config.d/40-rhcos-defaults.conf
+++ b/overlay.d/07el9/etc/ssh/sshd_config.d/40-rhcos-defaults.conf
@@ -1,0 +1,10 @@
+# Disable PasswordAuthentication and PermitRootLogin to preserve RHCOS 8
+# defaults for now
+# See: https://issues.redhat.com/browse/OCPBUGS-11613
+# See: https://github.com/openshift/os/issues/1216
+PasswordAuthentication no
+PermitRootLogin no
+
+# Enable ClientAliveInterval and set to 180
+# See: https://bugzilla.redhat.com/show_bug.cgi?id=1701050
+ClientAliveInterval 180


### PR DESCRIPTION
manifests: Use a file drop in for sshd config in EL9

The first two sed lines were silently broken with the default
configuration change in EL 9. Restore a subset as a drop-in config file:

- PasswordAuthentication: Kept disabled for now until the MCO learns to
  disable it once a password is set for a user.
- PermitRootLogin: Kept disabled as well for now. The new default in
  RHEL 9 is to not accept a password to log in as root. We will likely change
  back to this default in an future release.
- ClientAliveInterval: Kept as is until we investigate more.

Fixes: https://github.com/openshift/os/issues/1216
See: https://issues.redhat.com/browse/OCPBUGS-11613