### PR TITLE
kola-denylist: drop rhcos.network.*

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -19,9 +19,6 @@
 - pattern: ext.config.rpm-ostree.replace-rt-kernel
   tracker: https://github.com/openshift/os/issues/1099
 
-- pattern: rhcos.network.*
-  tracker: https://github.com/coreos/coreos-assembler/issues/3376
-
 - pattern: ext.config.shared.networking.nmstate.*
   tracker: https://github.com/openshift/os/issues/1228
   snooze: 2023-04-17


### PR DESCRIPTION
This was fixed by https://github.com/coreos/coreos-assembler/pull/3431.