### PR TITLE
OCPBUGS 11935: Pin container-selinux to ART candidate repo

### DIFF
--- a/manifest-rhel-9.2.yaml
+++ b/manifest-rhel-9.2.yaml
@@ -122,6 +122,7 @@ repo-packages:
       - nss-altfiles
   - repo: rhel-9.2-server-ose-4.13
     packages:
+      - container-selinux
       - conmon-rs
       - cri-o
       - cri-tools


### PR DESCRIPTION
Fixing https://issues.redhat.com/browse/OCPBUGS-11935
[slack ref](https://redhat-internal.slack.com/archives/CB95J6R4N/p1681826692751499)