### PR TITLE
overlay.d: Add 30gcp-udev-rules overlay from FCOS

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -24,6 +24,7 @@ ostree-layers:
   - overlay/21dhcp-chrony
   - overlay/25azure-udev-rules
   - overlay/30rhcos-nvme-compat-udev
+  - overlay/30gcp-udev-rules
 
 arch-include:
   x86_64:

--- a/overlay.d/30gcp-udev-rules
+++ b/overlay.d/30gcp-udev-rules
@@ -1,0 +1,1 @@
+../fedora-coreos-config/overlay.d/30gcp-udev-rules


### PR DESCRIPTION
 - Add 30gcp-udev-rules from FCOS
 - See https://github.com/coreos/fedora-coreos-config/pull/2350 for more info.