### PR TITLE
denylist: remove ext.config.kdump.crash denial

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -11,10 +11,6 @@
    - rhel-8.6
   arches:
   - s390x
-- pattern: ext.config.shared.kdump.crash
-  tracker: https://github.com/coreos/coreos-assembler/issues/2725
-  arches:
-  - ppc64le
 - pattern: coreos.boot-mirror.luks
   tracker: https://github.com/coreos/coreos-assembler/issues/2725
   arches:


### PR DESCRIPTION
The underlying issue for kdump crash test failure on ppc64le has been fixed in the upstream kernel [1]. We can remove this test from the denylist now since the fix has made it to all streams that we care about.

[1] coreos/coreos-assembler#2725 (comment)
Signed-off-by: Shilpi Das <shdas@redhat.com>