### PR TITLE
kola: add openvswitch in hugetlbfs group test

### DIFF
--- a/tests/kola/files/openvswitch-hugetlbfs-groups
+++ b/tests/kola/files/openvswitch-hugetlbfs-groups
@@ -1,0 +1,13 @@
+#!/bin/bash
+## kola:
+##   exclusive: false
+##   architectures: "x86_64 ppc64le"
+##   description: Verify openvswitch user is in the hugetlbfs group.
+
+set -xeuo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+if ! sudo getent group hugetlbfs | grep openvswitch; then
+  fatal "openvswitch user is not in hugetlbfs group"
+fi


### PR DESCRIPTION
openvswitch %pre scriptlet adds the openvswitch user to the hugetblfs group. Since %pre runs without `set -e` by default the failures are ignored resulting in worker nodes that do not come online during a cluster install. This seems to be happening on only RHCOS based on RHEL 9.2 on ppc64le.

These errors are showing up during the rpm-ostree compose:

14:30:05  openvswitch3.1.prein: usermod.rpmostreesave: /etc/passwd.6: lock file already used 14:30:05  openvswitch3.1.prein: usermod.rpmostreesave: cannot lock /etc/passwd; try again later. `:

xref: https://github.com/coreos/fedora-coreos-tracker/issues/1250