### PR TITLE
kola-denylist: bump snooze for ext.config.shared.networking.nmstate

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -21,7 +21,7 @@
 
 - pattern: ext.config.shared.networking.nmstate.*
   tracker: https://github.com/openshift/os/issues/1228
-  snooze: 2023-05-08
+  snooze: 2023-05-29
 
 - pattern: iso-live-login.uefi-secure
   tracker: https://github.com/openshift/os/issues/1237


### PR DESCRIPTION
These tests are still failing in RHCOS. See:
https://github.com/openshift/os/issues/1228