### PR TITLE
Bump fedora-coreos-config

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -1,9 +1,9 @@
 # We inherit from Fedora CoreOS' base configuration
 include:
+  - fedora-coreos-config/manifests/system-configuration.yaml
   - fedora-coreos-config/manifests/ignition-and-ostree.yaml
   - fedora-coreos-config/manifests/file-transfer.yaml
   - fedora-coreos-config/manifests/networking-tools.yaml
-  - fedora-coreos-config/manifests/system-configuration.yaml
   - fedora-coreos-config/manifests/user-experience.yaml
   - fedora-coreos-config/manifests/shared-workarounds.yaml
   - fedora-coreos-config/manifests/shared-el9.yaml


### PR DESCRIPTION
Created by [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/openshift-os.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/openshift-os.yml)).

```
Benjamin Gilbert (1):
      overlay.d/20platform-chrony: accept ec2 and gce platform IDs

Dusty Mabe (5):
      manifests/system-configuration: drop kdump ignition.firstboot workaround
      drop fallback hostname handling
      tests: use Fedora 38 container images
      manifests: move systemd-repart to shared manifest
      denylist: deny reprovision tests on ppc64le/rawhide
```