### PR TITLE
OCPBUGS-11124, OCPBUGS-11411: overlay: Mask pcrphase service

### DIFF
--- a/manifest-rhel-9.2.yaml
+++ b/manifest-rhel-9.2.yaml
@@ -108,6 +108,9 @@ postprocess:
      ---
      EOF
 
+     # Tweak dependencies of systemd-user-sessions.service to not rely on network.
+     sed -i 's/^After=.*/After=nss-user-lookup.target home.mount/' /usr/lib/systemd/system/systemd-user-sessions.service
+
 # Packages that are only in RHCOS and not in SCOS or that have special
 # constraints that do not apply to SCOS
 packages:

--- a/overlay.d/15rhcos-pcrphase-mask/etc/systemd/system/systemd-pcrphase.service
+++ b/overlay.d/15rhcos-pcrphase-mask/etc/systemd/system/systemd-pcrphase.service
@@ -1,0 +1,1 @@
+/dev/null

--- a/overlay.d/15rhcos-pcrphase-mask/statoverride
+++ b/overlay.d/15rhcos-pcrphase-mask/statoverride
@@ -1,0 +1,2 @@
+# Config file for overriding permission bits on overlay files/dirs
+# Format: =<file mode in decimal> <absolute path to a file or directory>


### PR DESCRIPTION
This PR masks systemd-pcrphase service which is not used at the moment. Its existence creates issues as it depends on the remote-fs and as a consequence blocks access to the system if network configuration is not correct.

Anyway in OpenShift we are not using remote home directories, so this would not be useful for us.

We are also modifying dependencies of systemd-user-sessions.service so that we are explicitly saying that we do not need network in order to allow access to the node.

Fixes: OCPBUGS-11124
Fixes: OCPBUGS-11411