### PR TITLE
extensions: Remove explicit mention to appstream repo

### DIFF
--- a/extensions-rhel-9.2.yaml
+++ b/extensions-rhel-9.2.yaml
@@ -52,7 +52,5 @@ extensions:
   sandboxed-containers:
     architectures:
       - x86_64
-    repos:
-      - rhel-9.2-appstream
     packages:
       - kata-containers


### PR DESCRIPTION
This repo is already enabled in the main RHEL 9.2 manifest thus we don't need to explicitely re-enable it here.