### PR TITLE
tests/trust-cpu: support v6.x kernels

### DIFF
--- a/tests/kola/files/trust-cpu
+++ b/tests/kola/files/trust-cpu
@@ -2,9 +2,8 @@
 ## kola:
 ##   exclusive: false
 ##   description: Verify CONFIG_RANDOM_TRUST_CPU is enabled by default.
-##     This is RHCOS only.
-##     This test will start failing and can be removed when RHCOS
-##     gets to kernel version 6.2+
+##   architectures: x86_64
+##     This test can be removed when RHCOS gets to kernel version 6.2+
 ##     https://github.com/coreos/fedora-coreos-tracker/issues/1369
 ##     https://github.com/coreos/fedora-coreos-config/pull/2155
 ##     https://bugzilla.redhat.com/show_bug.cgi?id=1830280  
@@ -13,12 +12,12 @@ set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
 
-case "$(arch)" in
-    x86_64)
+case "$(uname -r)" in
+    5.*|6.0.*|6.1.*)
         config=$(grep ^CONFIG_RANDOM_TRUST_CPU /lib/modules/$(uname -r)/config)
         if [ "$config" != "CONFIG_RANDOM_TRUST_CPU=y" ]; then
-            fatal "Error: Failed to find crng trusting CPU"
+            fatal "config missing CONFIG_RANDOM_TRUST_CPU"
         fi
         ok "random trust cpu" ;;
-    *) echo "Don't know how to test hardware RNG state on arch=$(arch)" ;;
+    *) echo "CPU trusting is always enabled" ;;
 esac


### PR DESCRIPTION
RHEL 10 will have a v6.x kernel (and RHEL 9.6 and onwards as an option). We'd like to do some early testing of RHCOS and OCP with that kernel since it also includes other major changes such as a new RPM name (`kernel-redhat`).

Adapt this test to run fine on 6.x kernels, automatically noop'ing on versions where we know `CONFIG_RANDOM_TRUST_CPU` was removed as per https://github.com/coreos/fedora-coreos-tracker/issues/1369.

While we're here, use `architectures` to gate the whole test on x86_64 rather than noop'ing at runtime.