### PR TITLE
overlay: disable iscsi.service by default

### DIFF
--- a/overlay.d/07el9/usr/lib/systemd/system-preset/36-iscsid-disabled.preset
+++ b/overlay.d/07el9/usr/lib/systemd/system-preset/36-iscsid-disabled.preset
@@ -1,1 +1,7 @@
 disable iscsid.socket
+
+# force disable until the following patches are in c9s/el9:
+# https://src.fedoraproject.org/rpms/iscsi-initiator-utils/c/1e689cd0c6667eca838c85975a1b7a070209e5ad
+# https://src.fedoraproject.org/rpms/fedora-release/pull-request/246
+# then it'll be off by default and we won't need this
+disable iscsi.service

--- a/tests/kola/systemd/network-online/config.bu
+++ b/tests/kola/systemd/network-online/config.bu
@@ -1,0 +1,32 @@
+variant: fcos
+version: 1.4.0
+systemd:
+  units:
+    - name: ovs-configuration.service
+      enabled: true
+      contents: |
+        [Unit]
+        Requires=openvswitch.service
+        After=NetworkManager-wait-online.service openvswitch.service
+        Before=network-online.target kubelet.service
+
+        [Service]
+        Type=oneshot
+        RemainAfterExit=yes
+        ExecStart=sleep infinity
+
+        [Install]
+        WantedBy=network-online.target
+    - name: kubelet.service
+      enabled: true
+      contents: |
+        [Unit]
+        Wants=network-online.target
+        After=network-online.target
+
+        [Service]
+        Type=simple
+        ExecStart=sleep infinity
+
+        [Install]
+        WantedBy=multi-user.target

--- a/tests/kola/systemd/network-online/data/commonlib.sh
+++ b/tests/kola/systemd/network-online/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../../../fedora-coreos-config/tests/kola/data/commonlib.sh

--- a/tests/kola/systemd/network-online/test.sh
+++ b/tests/kola/systemd/network-online/test.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+## kola:
+##   description: Verify that network-online.target doesn't block login
+##   tags: platform-independent
+##   # this really shouldn't take long; if it does, it's that we're hitting the
+##   # very issue we're testing for
+##   timeoutMin: 3
+
+# https://github.com/openshift/os/pull/1279
+# https://issues.redhat.com/browse/OCPBUGS-11124
+
+set -euo pipefail
+
+. $KOLA_EXT_DATA/commonlib.sh
+
+# The fact that we're here means that logins must be working since kola was able
+# to SSH to start us. But let's do some sanity-checks to verify that the test
+# was valid.
+
+# verify that ovs-configuration is still activating
+if [[ $(systemctl show ovs-configuration.service -p ActiveState) != "ActiveState=activating" ]]; then
+  systemctl status ovs-configuration.service
+  fatal "ovs-configuration.service isn't activating"
+fi
+
+if [[ $(systemctl show network-online.target -p ActiveState) != "ActiveState=inactive" ]]; then
+  systemctl status network-online.target
+  fatal "network-online.target isn't inactive"
+fi
+
+echo "ok network-online.target does not block login"


### PR DESCRIPTION
`iscsi.service` has `Before=remote-fs-pre.target` *and* `After=network-online.target`. This forces `remote-fs-pre.target` to block on `network-online.target` and hence in OCP, on `ovs-configuration.service` (which has `Before=network-online.target`).

So this transitively makes `systemd-user-sessions.service` block on `network-online.target`.

This was an issue in Fedora as well and was discussed in a devel thread[[1]]. `iscsi.service` was subsequently reworked[[2]][[3]] so that it was only activated if iSCSI was actually used by the system.

On RHEL 8, `iscsi.service` and co. were directly enabled by RPM scriptlets rather than using presets. In RHCOS, we explicitly make presets canonical[[4]] so we shipped with `iscsi.service` disabled by default. On RHEL 9, the units were fixed to use presets[[5]]. This is why we started seeing this issue after moving to RHEL 9.

So all we need in theory is to have the Fedora patch backported to RHEL
9. However, since we don't really need the functionality from `iscsi.service` by default in RHCOS, we can fast-track its (re-)disablement and not wait for the `iscsi-starter.service` workaround.

Note that `iscsi.service` is only used to bring up iSCSI sessions marked for autostart in `/var/lib/iscsi/nodes` and is separate from `iscsid.service`, which is what actually manages the iSCSI connections. In OpenShift, we rely on the latter only (e.g. configured iSCSI PVCs are done by the kubelet directly calling out to `iscsiadm`). It's also separate from iSCSI devices that use host bus adapters, which are transparent to RHCOS/OCP.

Fixes: https://issues.redhat.com/browse/OCPBUGS-11124

[1]: https://lists.fedoraproject.org/archives/list/devel@lists.fedoraproject.org/thread/HACVEJ3FMOIM2TOENOVH5CPOUNR7NCMS
[2]: https://src.fedoraproject.org/rpms/iscsi-initiator-utils/c/1e689cd0c6667eca838c85975a1b7a070209e5ad
[3]: https://src.fedoraproject.org/rpms/fedora-release/pull-request/246
[4]: https://github.com/coreos/fedora-coreos-config/blob/1553518214088a89d6a2360a6fcdddbd3915628a/manifests/ignition-and-ostree.yaml#L35-L44
[5]: https://bugzilla.redhat.com/show_bug.cgi?id=1930458