### PR TITLE
denylist: drop nmstate test denial/snooze; enable nmstate.service

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -19,10 +19,6 @@
 - pattern: ext.config.rpm-ostree.replace-rt-kernel
   tracker: https://github.com/openshift/os/issues/1099
 
-- pattern: ext.config.shared.networking.nmstate.*
-  tracker: https://github.com/openshift/os/issues/1228
-  snooze: 2023-05-29
-
 - pattern: iso-live-login.uefi-secure
   tracker: https://github.com/openshift/os/issues/1237
   osversion:

--- a/overlay.d/05rhcos/usr/lib/systemd/system-preset/43-manifest-rhcos.preset
+++ b/overlay.d/05rhcos/usr/lib/systemd/system-preset/43-manifest-rhcos.preset
@@ -20,3 +20,6 @@ enable logrotate.timer
 # removed once RHCOS catches up to CLHM v0.21+.
 enable console-login-helper-messages-issuegen.service
 enable console-login-helper-messages-issuegen.path
+# Enable nmstate. We can drop this when it is in
+# /usr/lib/systemd/system-preset/90-default.preset
+enable nmstate.service


### PR DESCRIPTION
```
commit d7843c75c4025ec563fb4ef205608d82f41012ba
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri May 26 17:23:22 2023 -0400

    overlay.d/05rhcos: add nmstate to systemd-preset file
    
    This is so we can continue to enable the nmstate.service by default
    even though it's being dropped from 05core in fedora-coreos-configs
    upstream [1].
    
    [1] https://github.com/coreos/fedora-coreos-config/pull/2439

commit f4971a539d58286d6c359fc47bf74549385bd8c9
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Fri May 26 17:18:57 2023 -0400

    denylist: drop nmstate test denial/snooze
    
    These appear to be passing now.
```
