### PR TITLE
drop hardcoded openvswitch user/group definitions

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -189,6 +189,16 @@ postprocess:
      # but we have containers that expect it to be mounted so for now let's continue
      # generating it.
      ln -sr /usr/share/zoneinfo/UTC /etc/localtime
+  - |
+     #!/usr/bin/env bash
+     set -xeo pipefail
+     # Add the hugetlbfs group to the openvswitch user if the openvswitch-hugetlbfs.conf
+     # sysusers fragment exists. This is a workaround for a bug somewhere in the stack
+     # that we need to investigate further.
+     # https://github.com/openshift/os/issues/1274#issuecomment-1595860275
+     if [ -f /usr/lib/sysusers.d/openvswitch-hugetlbfs.conf ]; then
+         usermod -a -G hugetlbfs openvswitch
+     fi
 
 remove-files:
   # We don't ship man(1) or info(1)

--- a/group
+++ b/group
@@ -42,5 +42,3 @@ nfsnobody:x:65534:
 kube:x:994:
 sshd:x:74:
 chrony:x:992:
-openvswitch:x:800:
-hugetlbfs:x:801:

--- a/passwd
+++ b/passwd
@@ -24,4 +24,3 @@ nfsnobody:x:65534:65534:Anonymous NFS User:/var/lib/nfs:/sbin/nologin
 kube:x:996:994:Kubernetes user:/:/sbin/nologin
 sshd:x:74:74:Privilege-separated SSH:/var/empty/sshd:/sbin/nologin
 chrony:x:994:992::/var/lib/chrony:/sbin/nologin
-openvswitch:x:800:800::/:/sbin/nologin


### PR DESCRIPTION
The RPM is now using systemd-sysusers fragments [1] so we can drop the hardcoded definitions. One problem here, though, is that the hugetlbfs group never gets added to the openswitch user [2] so let's add a workaround for that for now.

One side effect of this is that it does change the previously defined UID/GIDs from 800/801 to different values (dynamically generated at build time). I assume this is OK because of some of the discussion in [1].

[1] https://github.com/openshift/os/issues/1274#issuecomment-1593690794
[2] https://github.com/openshift/os/issues/1274#issuecomment-1595860275