### PR TITLE
Enable sandboxed-container extension on s390x

### DIFF
--- a/extensions-rhel-9.2.yaml
+++ b/extensions-rhel-9.2.yaml
@@ -57,5 +57,6 @@ extensions:
   sandboxed-containers:
     architectures:
       - x86_64
+      - s390x
     packages:
       - kata-containers


### PR DESCRIPTION
The next steps from the OpenSynergy group is to enable s390x builds for sandoboxed-container extension as part of the plan to support PeerPods on s390x.

Fixes: #1206