### PR TITLE
extensions: add crun-wasm to enable wasm support in OCP

### DIFF
--- a/extensions-c9s.yaml
+++ b/extensions-c9s.yaml
@@ -6,6 +6,10 @@ repos:
   - sig-virtualization
 
 extensions:
+  # https://issues.redhat.com/browse/RFE-4177
+  wasm:
+    packages:
+      - crun-wasm
   # https://github.com/coreos/fedora-coreos-tracker/issues/1504
   ipsec:
     packages:

--- a/extensions-rhel-9.2.yaml
+++ b/extensions-rhel-9.2.yaml
@@ -3,6 +3,10 @@
 # and https://github.com/coreos/fedora-coreos-tracker/issues/401
 
 extensions:
+  # https://issues.redhat.com/browse/RFE-4177
+  wasm:
+    packages:
+      - crun-wasm
   # https://github.com/coreos/fedora-coreos-tracker/issues/1504
   ipsec:
     packages:


### PR DESCRIPTION
This package enables wasm-supported workloads in OCP. 

xref: https://issues.redhat.com/browse/RFE-4177