### PR TITLE
extensions: limit crun-wasm package to x86_64 and aarch64

### DIFF
--- a/extensions-c9s.yaml
+++ b/extensions-c9s.yaml
@@ -8,6 +8,9 @@ repos:
 extensions:
   # https://issues.redhat.com/browse/RFE-4177
   wasm:
+    architectures:
+      - x86_64
+      - aarch64
     packages:
       - crun-wasm
   # https://github.com/coreos/fedora-coreos-tracker/issues/1504

--- a/extensions-rhel-9.2.yaml
+++ b/extensions-rhel-9.2.yaml
@@ -5,6 +5,9 @@
 extensions:
   # https://issues.redhat.com/browse/RFE-4177
   wasm:
+    architectures:
+      - x86_64
+      - aarch64
     packages:
       - crun-wasm
   # https://github.com/coreos/fedora-coreos-tracker/issues/1504


### PR DESCRIPTION
The `crun-wasm` package is [built for only these two arches](https://brewweb.engineering.redhat.com/brew/packageinfo?packageID=84555). Specify `x86_64` and `aarch64` only so that `s390x` and `ppc64le` can be unblocked.

xref: https://github.com/openshift/os/pull/1327