### PR TITLE
extensions: remove wasm extension from C9S

### DIFF
--- a/extensions-c9s.yaml
+++ b/extensions-c9s.yaml
@@ -7,12 +7,14 @@ repos:
 
 extensions:
   # https://issues.redhat.com/browse/RFE-4177
-  wasm:
-    architectures:
-      - x86_64
-      - aarch64
-    packages:
-      - crun-wasm
+  # wasm:
+  #   architectures:
+  #     - x86_64
+  #     - aarch64
+  #   repos:
+  #     - appstream
+  #   packages:
+  #     - crun-wasm
   # https://github.com/coreos/fedora-coreos-tracker/issues/1504
   ipsec:
     packages:


### PR DESCRIPTION
`crun-wasm` isn't built for C9S, so skip this to avoid SCOS build failure.