### PR TITLE
OCPBUGS-15843: Enable rhcos-fips-finish.service in diskless cases

### DIFF
--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/module-setup.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/module-setup.sh
@@ -31,10 +31,9 @@ install() {
     # for a true FIPS boot: https://bugzilla.redhat.com/show_bug.cgi?id=1778940
     echo "# RHCOS FIPS mode installation complete" > "$initdir/etc/system-fips"
 
-    # We don't support FIPS in diskless cases currently
-    target=ignition-diskful.target
     # note we `|| exit 1` here so we error out if e.g. the units are missing
     # see https://github.com/coreos/fedora-coreos-config/issues/799
-    systemctl -q --root="$initdir" add-requires "$target" rhcos-fips.service || exit 1
-    systemctl -q --root="$initdir" add-requires "$target" rhcos-fips-finish.service || exit 1
+    # We don't support reconfiguring the bootloader for FIPS in diskless cases
+    systemctl -q --root="$initdir" add-requires ignition-diskful.target rhcos-fips.service || exit 1
+    systemctl -q --root="$initdir" add-requires initrd.target rhcos-fips-finish.service || exit 1
 }

--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips.sh
@@ -65,6 +65,10 @@ firstboot() {
 }
 
 finish() {
+    if [ "$(</proc/sys/crypto/fips_enabled)" -ne 1 ]; then
+        fatal "FIPS mode is not enabled."
+    fi
+
     # This is analogous to Anaconda's `chroot /sysroot fips-mode-setup`. Though
     # of course, since our approach is "Ignition replaces Anaconda", we have to
     # do it on firstboot ourselves. The key part here is that we do this


### PR DESCRIPTION
Allow the user to enable FIPS by passing fips=1 on the kernel command line, even in diskless cases such as the live ISO.

The rhcos-fips.service (which reads the MachineConfig and sets up fips=1 on the kernel command line before triggering a reboot) works only once the OS is written to disk. The same is not true of rhcos-fips-finish.service, which runs after fips=1 is passed at boot time. The former is not needed if fips=1 is already passed on the kernel command line, but the latter is required to set up the crypto policies.