### PR TITLE
OWNERS: Add user as approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -30,3 +30,4 @@ approvers:
   - cverna
   - Adam0Brien
   - lukewarmtemp
+  - yasminvalim


### PR DESCRIPTION
As part of the onboarding process, it is necessary to add the Github user to the OWNERS file.