### PR TITLE
Bump fedora-coreos-config

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -23,6 +23,7 @@ ostree-layers:
   - overlay/25azure-udev-rules
   - overlay/30rhcos-nvme-compat-udev
   - overlay/30gcp-udev-rules
+  - overlay/30lvmdevices
 
 arch-include:
   x86_64:

--- a/overlay.d/30lvmdevices
+++ b/overlay.d/30lvmdevices
@@ -1,0 +1,1 @@
+../fedora-coreos-config/overlay.d/30lvmdevices


### PR DESCRIPTION
Created by [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/openshift-os.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/openshift-os.yml)).

```
Andrew Jeddeloh (1):
      overlay: drop coreos-root in favor of tmpfiles

Colin Walters (2):
      buildroot: Add clippy
      transposefs: Only autosave-xfs for much larger filesystems

Dusty Mabe (10):
      denylist: add denials for tests that layer packages on rawhide
      denylist: drop ext.config.toolbox denial
      denylist: drop package layer denials
      overrides: fast-track kernel-6.4.11-200.fc38
      denylist: mark snoozed tests as warn: true
      tests/kola: delete trailing whitespace in root-bash test
      overlay.d: remove trailing whitespace in ignition-ostree-populate-var.sh
      overlay.d: add 30lvmdevices overlay
      overlay.d/README: fix azure overlay title
      tests/kola: don't run fwupd-refresh-timer test on !fcos

Huijing Hei (3):
      overlay/sysusers: remove `10-groups-basic.conf` which comes from `setup` package
      tmpfiles: Move root bash files copy to tmpfiles.d
      tests: add test to verify `/var/roothome/.bash*` files exist

Michael Armijo (1):
      denylist: snooze `coreos.ignition.ssh.key` on kola-azure

Timothée Ravier (9):
      Enable fwupd refresh timer on Fedora 39
      overlay/README: Update for 17fedora-modularity overlay
      test: Disable 'source' ShellCheck warnings
      test: Remove unneeded whitespace at EOL
      overlay.d/usr/libexec/coreos-check-modularity: Remove whitespace at EOL
      ci: Add action to check for whitespace at EOL
      tests/logrotate-service: Make platform independent
      tests/kola/data/commonlib.sh: ShellCheck fixes
      overlay.d/*: ShellCheck fix for /proc/cmdline reading

YASMIN VALIM (1):
      manifests: name tzdata package in packages list

gursewak1997 (1):
      denylist: bump snooze for ext.config.kdump.crash on aarch64
```