### PR TITLE
azure-checkin: order checkin starting after `coreos-ignition-unique-boot`

### DIFF
--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/30rhcos-afterburn-checkin/rhcos-afterburn-checkin.service
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/30rhcos-afterburn-checkin/rhcos-afterburn-checkin.service
@@ -30,12 +30,6 @@ After=ignition-fetch.service
 # across reboots, so defer it until after the kargs reboot.
 After=coreos-kargs-reboot.service
 
-# There is race condition about checkin and coreos-ignition-unique-boot.
-# Removal of the virtual CD might cause Unique Boot Filesystem 
-# service failed, as could not find `/dev/sr0`, so make sure checkin 
-# finished before we start it.
-Before=coreos-ignition-unique-boot.service
-
 # Run before switching root.
 Before=initrd.target
 

--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/30rhcos-afterburn-checkin/rhcos-afterburn-checkin.service
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/30rhcos-afterburn-checkin/rhcos-afterburn-checkin.service
@@ -30,6 +30,12 @@ After=ignition-fetch.service
 # across reboots, so defer it until after the kargs reboot.
 After=coreos-kargs-reboot.service
 
+# There is race condition about checkin and coreos-ignition-unique-boot.
+# Removal of the virtual CD might cause Unique Boot Filesystem 
+# service failed, as could not find `/dev/sr0`, so need to wait until 
+# after coreos-ignition-unique-boot.
+After=coreos-ignition-unique-boot.service
+
 # Run before switching root.
 Before=initrd.target
 


### PR DESCRIPTION
This reverts commit e6500062fc421e32a638b87da4caed50b1616481. 

Sorry for the confusion, and should do more testing before merged.

---

azure-checkin: order checkin starting after `coreos-ignition-unique-boot`

There is race condition about checkin and coreos-ignition-unique-boot.
Removal of the virtual CD might cause Unique Boot Filesystem
service failed, as could not find `/dev/sr0`, so need to wait until
after coreos-ignition-unique-boot.
Fixes https://issues.redhat.com/browse/OCPBUGS-17643