### PR TITLE
[release-4.11] denylist: skip ext.config.shared.chrony.dhcp-propagation

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -27,3 +27,9 @@
   tracker: https://github.com/coreos/coreos-assembler/issues/2725
   arches:
   - ppc64le
+- pattern: ext.config.shared.chrony.dhcp-propagation
+  tracker: https://github.com/openshift/os/issues/1352
+  snooze: 2023-09-22
+  arches:
+  - s390x
+  - ppc64le


### PR DESCRIPTION
This test is failing on s390x and ppc64le because the fedora36 image used in the tests can't install rpms anymore. Snooze failing test till 2023-09-22

Ref: https://github.com/openshift/os/issues/1352