### PR TITLE
OCPBUGS-15843: Finish FIPS + ISO support

### DIFF
--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips.sh
@@ -69,6 +69,17 @@ finish() {
         fatal "FIPS mode is not enabled."
     fi
 
+    # If we're running from a live system, then set things up so that the dracut fips
+    # module will find the kernel binary.  TODO change dracut to look in /usr/lib/modules/$(uname -r)
+    # directly.
+    if test -f /etc/coreos-live-initramfs; then
+        # See the dracut source
+        rhevh_livedir=/run/initramfs/live
+        mkdir -p "${rhevh_livedir}"
+        # Why "vmlinuz0"?  I have no idea; it's what the dracut fips module uses.
+        ln -sr /usr/lib/modules/$(uname -r)/vmlinuz ${rhevh_livedir}/vmlinuz0
+    fi
+
     # This is analogous to Anaconda's `chroot /sysroot fips-mode-setup`. Though
     # of course, since our approach is "Ignition replaces Anaconda", we have to
     # do it on firstboot ourselves. The key part here is that we do this

--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips.sh
@@ -89,7 +89,7 @@ sysroot_bwrap() {
       mount --bind /$mnt /mnt/bwrap/$mnt
     done
     touch /mnt/bwrap/run/ostree-booted
-    mount --bind /sysroot /mnt/bwrap/sysroot
+    mount --rbind /sysroot /mnt/bwrap/sysroot
     chroot /mnt/bwrap env --chdir /sysroot bwrap \
         --unshare-pid --unshare-uts --unshare-ipc --unshare-net \
         --unshare-cgroup-try --dev /dev --proc /proc --chdir / \


### PR DESCRIPTION
fips: use --rbind for sysroot

This is necessary for the Live ISO case where we have a `/sysroot/etc`
mount that we need to pick up.

---

initramfs/fips: Pretend we're RHEV-H for verifying Live ISO

A while ago, the RHEV-H folks added special case code
to the dracut initramfs FIPS path, because how the bootloader(s)
pass `BOOT_IMAGE` is less reliable in a Live (particularly PXE)
path.

Pretend we're RHEV-H here by creating a symlink from the place
they picked in `/run` into what I consider the canonical location
of `/usr/lib/modules/$kver`.

And we should definitely change dracut to look there in the
future as it would drop out a lot of special case hacks in that code.

Requires: https://github.com/coreos/coreos-assembler/pull/3599
xref https://issues.redhat.com/browse/OCPBUGS-15843

---

