### PR TITLE
OCPBUGS-15843: initramfs/40rhcos-fips: Workaround dracut unmounting /boot

### DIFF
--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/module-setup.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/module-setup.sh
@@ -25,6 +25,8 @@ install() {
         "$systemdsystemunitdir/rhcos-fips.service"
     inst_simple "$moddir/rhcos-fips-finish.service" \
         "$systemdsystemunitdir/rhcos-fips-finish.service"
+    inst_simple "$moddir/rhcos-fips-dracut-boot-fix.service" \
+        "$systemdsystemunitdir/rhcos-fips-dracut-boot-fix.service"
 
     # Unconditionally include /etc/system-fips in the initrd. This has no
     # practical effect if fips=1 isn't also enabled. OTOH, it is a *requirement*

--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips-dracut-boot-fix.service
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips-dracut-boot-fix.service
@@ -1,0 +1,24 @@
+[Unit]
+Description=Workaround dracut FIPS unmounting /boot
+DefaultDependencies=false
+ConditionKernelCommandLine=ignition.firstboot
+ConditionKernelCommandLine=fips
+ConditionPathExists=/run/ostree-live
+# Work around the lack of https://github.com/dracutdevs/dracut/commit/ab26ad2c2ab4a5884e392951998d40829f130387 in RHEL 9.2
+# We're going to undo the damage it did.
+After=dracut-pre-pivot.service
+# We need to run before this though which starts the switchroot process.
+Before=initrd-cleanup.service
+
+# See comment about this in ignition-complete.target.
+OnFailure=emergency.target
+OnFailureJobMode=isolate
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# We operate in the target root, before switching
+WorkingDirectory=/sysroot
+ExecStart=/bin/bash -c 'if ! findmnt boot &>/dev/null; then mount --bind sysroot/boot boot; echo enabled dracut fips workaround; fi'
+
+# No install section, this is only pulled in by rhcos-fips-finish.service

--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips-finish.service
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips-finish.service
@@ -9,6 +9,8 @@ Before=initrd.target
 # we want to run after Ignition drops its files
 After=ignition-files.service
 
+Wants=rhcos-fips-dracut-boot-fix.service
+
 # See comment about this in ignition-complete.target.
 OnFailure=emergency.target
 OnFailureJobMode=isolate


### PR DESCRIPTION
We enabled FIPS in our ISO, but that triggers a new corner case because of how we handle `/boot` there.

Work around the lack of
https://github.com/dracutdevs/dracut/commit/ab26ad2c2ab4a5884e392951998d40829f130387 in RHEL 9.2.