### PR TITLE
denylist: drop ext.config.shared.kdump.crash and coreos.boot-mirror tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -1,15 +1,6 @@
 # This file documents currently known-to-fail kola tests. It is consumed by
 # coreos-assembler to automatically skip some tests. For more information,
 # see: https://github.com/coreos/coreos-assembler/pull/866.
-- pattern: coreos.boot-mirror.luks
-  tracker: https://github.com/coreos/coreos-assembler/issues/2725
-  arches:
-  - ppc64le
-- pattern: coreos.boot-mirror
-  tracker: https://github.com/coreos/coreos-assembler/issues/2725
-  arches:
-  - ppc64le
-
 - pattern: ext.config.rpm-ostree.replace-rt-kernel
   tracker: https://github.com/openshift/os/issues/1315
   osversion:

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -1,10 +1,6 @@
 # This file documents currently known-to-fail kola tests. It is consumed by
 # coreos-assembler to automatically skip some tests. For more information,
 # see: https://github.com/coreos/coreos-assembler/pull/866.
-- pattern: ext.config.shared.kdump.crash
-  tracker: https://github.com/coreos/coreos-assembler/issues/2725
-  arches:
-  - ppc64le
 - pattern: coreos.boot-mirror.luks
   tracker: https://github.com/coreos/coreos-assembler/issues/2725
   arches:


### PR DESCRIPTION
denylist: drop ext.config.shared.kdump.crash

This was fixed at some point in the last 1.5 years, likely when we moved
to RHEL9.

---

denylist: drop coreos.boot-mirror tests

These should now be fixed by
https://github.com/coreos/coreos-assembler/pull/3611.