### PR TITLE
image.yaml: aws; add old defaults for new fields

### DIFF
--- a/image-c9s.yaml
+++ b/image-c9s.yaml
@@ -18,3 +18,9 @@ vmware-os-type: rhel8_64Guest
 # VMware hardware versions: https://kb.vmware.com/s/article/1003746
 # Supported VMware versions: https://lifecycle.vmware.com/
 vmware-hw-version: 15
+
+# see https://github.com/coreos/coreos-assembler/pull/3607
+# Defaults for AWS
+aws-imdsv2-only: false
+aws-volume-type: "gp2"
+aws-x86-boot-mode: "legacy-bios"

--- a/image-rhel-9.2.yaml
+++ b/image-rhel-9.2.yaml
@@ -15,3 +15,9 @@ vmware-os-type: rhel8_64Guest
 # VMware hardware versions: https://kb.vmware.com/s/article/1003746
 # Supported VMware versions: https://lifecycle.vmware.com/
 vmware-hw-version: 15
+
+# see https://github.com/coreos/coreos-assembler/pull/3607
+# Defaults for AWS
+aws-imdsv2-only: false
+aws-volume-type: "gp2"
+aws-x86-boot-mode: "legacy-bios"


### PR DESCRIPTION
see https://github.com/coreos/coreos-assembler/pull/3607

With the above PR, cosa's image-default.yaml adds 3 configuration fields. The defaults provided differ from before. Overide the new configuration fields to maintain old defaults.