### PR TITLE
tests/kola/trust-cpu: comment out comment even more

### DIFF
--- a/tests/kola/files/trust-cpu
+++ b/tests/kola/files/trust-cpu
@@ -3,10 +3,11 @@
 ##   exclusive: false
 ##   description: Verify CONFIG_RANDOM_TRUST_CPU is enabled by default.
 ##   architectures: x86_64
-##     This test can be removed when RHCOS gets to kernel version 6.2+
-##     https://github.com/coreos/fedora-coreos-tracker/issues/1369
-##     https://github.com/coreos/fedora-coreos-config/pull/2155
-##     https://bugzilla.redhat.com/show_bug.cgi?id=1830280  
+
+# This test can be removed when RHCOS gets to kernel version 6.2+
+# https://github.com/coreos/fedora-coreos-tracker/issues/1369
+# https://github.com/coreos/fedora-coreos-config/pull/2155
+# https://bugzilla.redhat.com/show_bug.cgi?id=1830280  
 
 set -xeuo pipefail
 


### PR DESCRIPTION
Otherwise, it's interpreted as a continuation of `architectures` which leads to quite breathtaking table output from `kola list`.