### PR TITLE
rhsm: add `rhsm.conf` which is from `subscription-manager`

### DIFF
--- a/overlay.d/05rhcos/etc/rhsm/rhsm.conf
+++ b/overlay.d/05rhcos/etc/rhsm/rhsm.conf
@@ -1,0 +1,110 @@
+# Red Hat Subscription Manager Configuration File:
+
+# Unified Entitlement Platform Configuration
+[server]
+# Server hostname:
+hostname = subscription.rhsm.redhat.com
+
+# Server prefix:
+prefix = /subscription
+
+# Server port:
+port = 443
+
+# Set to 1 to disable certificate validation:
+insecure = 0
+
+# an http proxy server to use
+proxy_hostname =
+
+# The scheme to use for the proxy when updating repo definitions, if needed
+# e.g. http or https
+proxy_scheme = http
+
+# port for http proxy server
+proxy_port =
+
+# user name for authenticating to an http proxy, if needed
+proxy_user =
+
+# password for basic http proxy auth, if needed
+proxy_password =
+
+# host/domain suffix blocklist for proxy, if needed
+no_proxy =
+
+[rhsm]
+# Content base URL:
+baseurl = https://cdn.redhat.com
+
+# Repository metadata GPG key URL:
+repomd_gpg_url =
+
+# Server CA certificate location:
+ca_cert_dir = /etc/rhsm/ca/
+
+# Default CA cert to use when generating yum repo configs:
+repo_ca_cert = %(ca_cert_dir)sredhat-uep.pem
+
+# Where the certificates should be stored
+productCertDir = /etc/pki/product
+entitlementCertDir = /etc/pki/entitlement
+consumerCertDir = /etc/pki/consumer
+
+# Manage generation of yum repositories for subscribed content:
+manage_repos = 1
+
+# Refresh repo files with server overrides on every yum command
+full_refresh_on_yum = 0
+
+# If set to zero, the client will not report the package profile to
+# the subscription management service.
+report_package_profile = 1
+
+# The directory to search for subscription manager plugins
+pluginDir = /usr/share/rhsm-plugins
+
+# The directory to search for plugin configuration files
+pluginConfDir = /etc/rhsm/pluginconf.d
+
+# Manage automatic enabling of yum/dnf plugins (product-id, subscription-manager)
+auto_enable_yum_plugins = 1
+
+# Run the package profile on each yum/dnf transaction
+package_profile_on_trans = 0
+
+# Inotify is used for monitoring changes in directories with certificates.
+# Currently only the /etc/pki/consumer directory is monitored by the
+# rhsm.service. When this directory is mounted using a network file system
+# without inotify notification support (e.g. NFS), then disabling inotify
+# is strongly recommended. When inotify is disabled, periodical directory
+# polling is used instead.
+inotify = 1
+
+# Write progress messages when waiting for API response.
+progress_messages = 1
+
+[rhsmcertd]
+# Interval to run cert check (in minutes):
+certCheckInterval = 240
+# Interval to run auto-attach (in minutes):
+autoAttachInterval = 1440
+# If set to zero, the checks done by the rhsmcertd daemon will not be splayed (randomly offset)
+splay = 1
+# If set to 1, rhsmcertd will not execute.
+disable = 0
+# Set to 1 when rhsmcertd should attempt automatic registration.
+# Setting this option makes sense only on machines running on public
+# clouds. Currently only AWS, Azure and GCP are supported
+auto_registration = 0
+# Interval to run auto-registration (in minutes):
+auto_registration_interval = 60
+
+[logging]
+default_log_level = INFO
+# subscription_manager = DEBUG
+# subscription_manager.managercli = DEBUG
+# rhsm = DEBUG
+# rhsm.connection = DEBUG
+# rhsm-app = DEBUG
+# rhsmcertd = DEBUG


### PR DESCRIPTION
`rhsm.conf` (from `subscription-manager`) is missing on RHCOS, which causes `rpm-ostree install <pkg>` failed with entitlement build, as the SSL CA cert path is wrong to set
`/etc/rhsm-host-host/ca/redhat-uep.pem`.

```
STEP 3/5: RUN rpm-ostree install libreswan

error: Updating rpm-md repo 'rhel-9-for-x86_64-baseos-rpms': cannot update repo 'rhel-9-for-x86_64-baseos-rpms': Cannot download repomd.xml: Curl error (77): Problem with the SSL CA cert (path? access rights?) for https://cdn.redhat.com/content/dist/rhel9/9/x86_64/baseos/os/repodata/repomd.xml [error setting certificate file: /etc/rhsm-host-host/ca/redhat-uep.pem]
error: build error: building at STEP "RUN rpm-ostree install libreswan": while running runtime: exit status 1
```

https://issues.redhat.com/browse/RHEL-1451 meant to track from `librhsm` side, but was closed because of risky.

Fixes: https://issues.redhat.com/browse/OCPBUGS-11181