### PR TITLE
COS-2473: Re-enable `ostree-container-inject-openshift-cvo-labels` knob

### DIFF
--- a/image-rhel-9.2.yaml
+++ b/image-rhel-9.2.yaml
@@ -21,3 +21,6 @@ vmware-hw-version: 15
 aws-imdsv2-only: false
 aws-volume-type: "gp2"
 aws-x86-boot-mode: "legacy-bios"
+
+# add the requisite OCP metadata to our container image
+ostree-container-inject-openshift-cvo-labels: true


### PR DESCRIPTION
This was previously enabled (#1048) and then disabled again (#1084) because `oc` doesn't know how to handle multiple images with those labels in the release payload. We'll need to solve this eventually if we want to be able to ship multiple OS images in the payload (that's tracked in #1047), but we don't need to block on this if we can remove the legacy `machine-os-content` at the same time.

See also: https://github.com/openshift/driver-toolkit/issues/101
See also: https://github.com/openshift/machine-config-operator/pull/3364