### PR TITLE
manifest-rhel9.4: create os-release.rhel

### DIFF
--- a/manifest-rhel-9.4.yaml
+++ b/manifest-rhel-9.4.yaml
@@ -37,7 +37,7 @@ postprocess:
      set -xeo pipefail
 
      # Tweak /usr/lib/os-release
-     grep -v "OSTREE_VERSION" /etc/os-release > /usr/lib/os-release.stream
+     grep -v "OSTREE_VERSION" /etc/os-release > /usr/lib/os-release.rhel
      OCP_RELEASE="4.15"
      (
      . /etc/os-release


### PR DESCRIPTION
Several RHCOS kola tests are failing because the file `os-release.rhel` cant be found. 
Change the extension of the os-release file in order to better configure this variant 
to look like a RHEL based RHCOS instead of a C9S based one.