### PR TITLE
OCPBUGS-22929: [release-4.11]: drop compat-openssl10

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -315,8 +315,6 @@ packages:
  - systemd-journal-remote
  # Extras
  - systemd-journal-gateway
- # RHEL7 compatibility
- - compat-openssl10
  # Make sure we pull in at least clevis 15; it drops the rd.neednet=1 hardcode
  # and has a few other patches we need.
  # https://bugzilla.redhat.com/show_bug.cgi?id=1853651


### PR DESCRIPTION
Drop compat-openssl10 from RHCOS builds based on RHEL8.

See https://issues.redhat.com/browse/COS-2461