### PR TITLE
[release-4.12] drop compat-openssl10

### DIFF
--- a/manifest-rhel-8.6.yaml
+++ b/manifest-rhel-8.6.yaml
@@ -147,8 +147,6 @@ packages:
  # We include the generic release package and tweak the os-release info in a
  # post-proces script
  - redhat-release
- # RHEL7 compatibility
- - compat-openssl10
  # SCOS package name does not include a version number
  - openvswitch2.17
  # https://github.com/openshift/os/issues/1036


### PR DESCRIPTION
Drop compat-openssl10 from RHCOS builds based on RHEL8.

See https://issues.redhat.com/browse/COS-2461