### PR TITLE
COS-2520: Bump fedora-coreos-config

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -1,5 +1,6 @@
 # We inherit from Fedora CoreOS' base configuration
 include:
+  - fedora-coreos-config/manifests/kernel.yaml
   - fedora-coreos-config/manifests/system-configuration.yaml
   - fedora-coreos-config/manifests/ignition-and-ostree.yaml
   - fedora-coreos-config/manifests/file-transfer.yaml


### PR DESCRIPTION
Created by [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/openshift-os.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/openshift-os.yml)).

```
Colin Walters (2):
      buildroot: Enable testing-devel
      manifests: Move kernel into separate manifest

Dusty Mabe (5):
      tests/kernel-replace: update to f38 kernel; drop cruft
      tests/kernel-replace: extend timeout to 20m
      Add the candidate compose repo
      Revert "lockfiles: bump to latest"
      manifests: include wasm packages in fedora-coreos-base manifest

Jonathan Lebon (7):
      05core: make `coreos-copy-firstboot-network` dep on bootfs explicit
      05core: run `coreos-gpt-setup` and `ignition-ostree-uuid-boot` later
      05core: adapt `coreos-ignition-setup-user.service` for iSCSI boot
      05core: neuter `coreos-copy-firstboot-network.service` for iSCSI boot
      05core: don't teardown network on switchroot for iSCSI boot
      05core: make coreos-secex-ignition-decrypt.service virtio device dep explicit
      05core: order boot UUID restamp before ignition-kargs.service

Michael Armijo (1):
      denylist: extend snooze for failing kola tests

Yasmin Valim (1):
      Move to Fedora Linux 39

gursewak1997 (1):
      denylist: extend snoozes for kdump.crash For rawhide ppc64le failure, we don't have a fixed kernel yet. For the aarch64 selinux failure, it's been fixed in kexec-tools 2.0.27 which is now in F39. Will remove this once the prod streams have moved to F39
```