### PR TITLE
Revert "Re-enable `ostree-container-inject-openshift-cvo-labels` knob"

### DIFF
--- a/image-rhel-9.2.yaml
+++ b/image-rhel-9.2.yaml
@@ -21,6 +21,3 @@ vmware-hw-version: 15
 aws-imdsv2-only: false
 aws-volume-type: "gp2"
 aws-x86-boot-mode: "legacy-bios"
-
-# add the requisite OCP metadata to our container image
-ostree-container-inject-openshift-cvo-labels: true


### PR DESCRIPTION
This reverts commit 12a9a69baabf40a90adf3ef20cb4e30307a313c4.

There are more references to machine-os-content in

https://github.com/openshift/kubernetes/blob/master/openshift-hack/images/os/Dockerfile

and

https://github.com/openshift/release/blob/master/ci-operator/config/openshift/kubernetes/openshift-kubernetes-master.yaml

that need to be removed first before we can try this again.