### PR TITLE
OCPBUGS-23269: bump openvswitch to 3.1

### DIFF
--- a/manifest-rhel-8.6.yaml
+++ b/manifest-rhel-8.6.yaml
@@ -150,7 +150,7 @@ packages:
  # RHEL7 compatibility
  - compat-openssl10
  # SCOS package name does not include a version number
- - openvswitch2.17
+ - openvswitch3.1
  # https://github.com/openshift/os/issues/1036
  - libsemanage-2.9-8.el8
 


### PR DESCRIPTION
See https://issues.redhat.com/browse/OCPBUGS-22701