### PR TITLE
OCPBUGS-18833: google_nvme_id: sync with latest upstream version

### DIFF
--- a/overlay.d/30gcp-udev-rules/usr/lib/udev/google_nvme_id
+++ b/overlay.d/30gcp-udev-rules/usr/lib/udev/google_nvme_id
@@ -59,7 +59,7 @@ function err() {
 #######################################
 function get_namespace_device_name() {
   local nvme_json
-  nvme_json="$("$nvme_cli_bin" id-ns -b "$1" | cut -b 384-)"
+  nvme_json="$("$nvme_cli_bin" id-ns -b "$1" | dd bs=1 skip=384 2>/dev/null)"
   if [[ $? -ne 0 ]]; then
     return 1
   fi


### PR DESCRIPTION
Sync with https://github.com/GoogleCloudPlatform/guest-configs/pull/56

Probably fixes: [OCPBUGS-18833](https://issues.redhat.com/browse/OCPBUGS-18833)