### PR TITLE
NO-JIRA: Revert "denylist: skip PXE tests on ppc64le"

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -49,12 +49,5 @@
   osversion:
     - c9s
 
-# Other failing tests
-- pattern: pxe-*.ppcfw
-  tracker: https://github.com/coreos/coreos-assembler/issues/3370
-  # nb: testiso doesn't read this, so it's just for consistency
-  arches:
-    - ppc64le
-
 - pattern: iso-offline-install-iscsi.bios
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1638


### PR DESCRIPTION
This reverts commit 5e5cbecf6d50e31d452531726f5b8db8525b3dbb.

Those tests should work now with the workaround added in https://github.com/coreos/coreos-assembler/pull/3661.