### PR TITLE
NO-JIRA: denylist: skip `coreos.unique.boot.failure` on aarch64

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -38,3 +38,15 @@
   # nb: testiso doesn't read this, so it's just for consistency
   arches:
     - ppc64le
+
+- pattern: coreos.unique.boot.failure
+  tracker: https://github.com/coreos/coreos-assembler/issues/3669
+  snooze: 2023-12-13
+  warn: true
+  arches:
+    - aarch64
+
+- pattern: coreos.ignition.failure
+  tracker: https://github.com/coreos/coreos-assembler/issues/3670
+  snooze: 2023-12-13
+  warn: true


### PR DESCRIPTION
`coreos.unique.boot.failure` has been failing on aarch64 builds
 and `coreos.ignition.failure` has been failing on RHCOS in general.
 Let's denylist them and add a snooze while we investigate
 the issues.
    
 See: https://github.com/coreos/coreos-assembler/issues/3670 and https://github.com/coreos/coreos-assembler/issues/3669

EDIT: updated to add `coreos.ignition.failure`