### PR TITLE
catch coreos.ignition.failure err on 4.16 pipeline

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -4,49 +4,37 @@
 - pattern: ext.config.rpm-ostree.replace-rt-kernel
   tracker: https://github.com/openshift/os/issues/1315
   osversion:
-  - c9s
+    - c9s
 
 - pattern: iso-live-login.uefi-secure
   tracker: https://github.com/openshift/os/issues/1237
   osversion:
-  - c9s
-  - rhel-9.4
+    - c9s
+    - rhel-9.4
 
 - pattern: iso-as-disk.uefi-secure
   tracker: https://github.com/openshift/os/issues/1237
   osversion:
-  - c9s
-  - rhel-9.4
+    - c9s
+    - rhel-9.4
 
 - pattern: ext.config.rpm-ostree.replace-rt-kernel
   tracker: https://github.com/openshift/os/issues/1383
   osversion:
-  - rhel-9.4
+    - rhel-9.4
 
 - pattern: ext.config.shared.content-origins
   tracker: https://github.com/openshift/os/issues/1387#issuecomment-1769313807
   osversion:
-  - rhel-9.4
+    - rhel-9.4
 
 - pattern: ext.config.version.rhel-matches-rhcos-build
   tracker: https://github.com/openshift/os/issues/1387#issuecomment-1769313807
   osversion:
-  - rhel-9.4
+    - rhel-9.4
 
 - pattern: pxe-*.ppcfw
   tracker: https://github.com/coreos/coreos-assembler/issues/3370
   # nb: testiso doesn't read this, so it's just for consistency
   arches:
     - ppc64le
-
-- pattern: coreos.unique.boot.failure
-  tracker: https://github.com/coreos/coreos-assembler/issues/3669
-  snooze: 2023-12-13
-  warn: true
-  arches:
-    - aarch64
-
-- pattern: coreos.ignition.failure
-  tracker: https://github.com/coreos/coreos-assembler/issues/3670
-  snooze: 2023-12-13
-  warn: true


### PR DESCRIPTION
After failing to reproduce `coreos.ignition.failure` locally I am removing it from denylist in order to catch errors in the pipeline. The goal of this PR is to allow it in RHCOS 4.16, catch the errors from the log and re-introduce `coreos.ignition.failure` to kola-denylist while working on solution.

See: https://github.com/coreos/coreos-assembler/issues/3670