### PR TITLE
Bump versions and snooze tests for 9.4 prep

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -1,6 +1,24 @@
 # This file documents currently known-to-fail kola tests. It is consumed by
 # coreos-assembler to automatically skip some tests. For more information,
 # see: https://github.com/coreos/coreos-assembler/pull/866.
+- pattern: iso-live-login.uefi-secure
+  tracker: https://github.com/openshift/os/issues/1237
+  snooze: 2024-02-26
+  osversion:
+  - rhel-9.4
+
+- pattern: iso-as-disk.uefi-secure
+  tracker: https://github.com/openshift/os/issues/1237
+  snooze: 2024-02-26
+  osversion:
+  - rhel-9.4
+
+- pattern: basic
+  tracker: https://github.com/openshift/os/issues/1237
+  snooze: 2024-02-26
+  osversion:
+  - rhel-9.4
+
 - pattern: ext.config.rpm-ostree.replace-rt-kernel
   tracker: https://github.com/openshift/os/issues/1315
   osversion:
@@ -10,26 +28,27 @@
   tracker: https://github.com/openshift/os/issues/1237
   osversion:
   - c9s
-  - rhel-9.4
 
 - pattern: iso-as-disk.uefi-secure
   tracker: https://github.com/openshift/os/issues/1237
   osversion:
   - c9s
-  - rhel-9.4
 
 - pattern: ext.config.rpm-ostree.replace-rt-kernel
   tracker: https://github.com/openshift/os/issues/1383
+  snooze: 2024-02-26
   osversion:
   - rhel-9.4
 
 - pattern: ext.config.shared.content-origins
   tracker: https://github.com/openshift/os/issues/1387#issuecomment-1769313807
+  snooze: 2024-02-26
   osversion:
   - rhel-9.4
 
 - pattern: ext.config.version.rhel-matches-rhcos-build
   tracker: https://github.com/openshift/os/issues/1387#issuecomment-1769313807
+  snooze: 2024-02-26
   osversion:
   - rhel-9.4
 

--- a/manifest-rhel-9.4.yaml
+++ b/manifest-rhel-9.4.yaml
@@ -22,14 +22,14 @@ repos:
   - appstream
   - rhel-9.2-fast-datapath
   # Include RHCOS 9 repo for oc, hyperkube
-  - rhel-9.2-server-ose-4.15
+  - rhel-9.2-server-ose-4.16
 
 # We include hours/minutes to avoid version number reuse
-automatic-version-prefix: "415.94.<date:%Y%m%d%H%M>"
+automatic-version-prefix: "416.94.<date:%Y%m%d%H%M>"
 # This ensures we're semver-compatible which OpenShift wants
 automatic-version-suffix: "-"
 # Keep this is sync with the version in postprocess
-mutate-os-release: "4.15"
+mutate-os-release: "4.16"
 
 postprocess:
   - |
@@ -38,7 +38,7 @@ postprocess:
 
      # Tweak /usr/lib/os-release
      grep -v "OSTREE_VERSION" /etc/os-release > /usr/lib/os-release.rhel
-     OCP_RELEASE="4.15"
+     OCP_RELEASE="4.16"
      (
      . /etc/os-release
      cat > /usr/lib/os-release <<EOF
@@ -132,7 +132,7 @@ repo-packages:
   - repo: appstream
     packages:
       - nss-altfiles
-  - repo: rhel-9.2-server-ose-4.15
+  - repo: rhel-9.2-server-ose-4.16
     packages:
       - conmon-rs
       - cri-o


### PR DESCRIPTION
Snoozing some UEFI secure boot tests until RHEL 9.4 Beta becomes available then we can switch the CS9 repos over and those test should start passing.

