### PR TITLE
NO-JIRA: denylist: add iso-offline-install-iscsi.bios

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -62,3 +62,8 @@
   tracker: https://github.com/coreos/coreos-assembler/issues/3670
   snooze: 2023-12-13
   warn: true
+
+- pattern: iso-offline-install-iscsi.bios
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1638
+  snooze: 2024-01-20
+  warn: true


### PR DESCRIPTION
This test is timing out in RHCOS and FCOS. Let's denylist it to unblock the pipeline for now while we investigate https://github.com/coreos/fedora-coreos-tracker/issues/1638