### PR TITLE
COS-1935: overlay: include 40grub overlay from FCOS configs

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -25,6 +25,7 @@ ostree-layers:
   - overlay/30rhcos-nvme-compat-udev
   - overlay/30gcp-udev-rules
   - overlay/30lvmdevices
+  - overlay/40grub
 
 arch-include:
   x86_64:

--- a/overlay.d/40grub
+++ b/overlay.d/40grub
@@ -1,0 +1,1 @@
+../fedora-coreos-config/overlay.d/40grub


### PR DESCRIPTION
See https://github.com/coreos/fedora-coreos-config/pull/2769

This won't really have any effect right now but will enable someone to use the generated ociarchive container images in the OSBuild workflow that calls bootupctl with the --with-static-configs argument.