### PR TITLE
OCPBUGS-26477: Enable ima signatures

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -38,6 +38,8 @@ arch-include:
 
 documentation: false
 
+ima: true
+
 postprocess:
   - |
      #!/usr/bin/env bash
@@ -313,3 +315,6 @@ remove-from-packages:
   # by MCD or kubelet.  See above.
   - - conntrack-tools
     - /usr/lib/systemd/system
+  # Fix IMA issues
+  - - systemd-libs
+    - /usr/share/licenses/systemd/LICENSE.LGPL2.1


### PR DESCRIPTION
As requested in OCPBUGS-26477, adding this flag to common.yaml will cause any IMA signatures to be installed from the RPMs to the RHCOS image.

They can then be used to locally cryptographically attest to the authenticity of the Red Hat-provided file contents at runtime.