### PR TITLE
OCPBUGS-25662: Adds ecr-image-credential-provider

### DIFF
--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -7,3 +7,4 @@ packages:
   # The packages below are present in CentOS Stream/RHEL,
   # and depend on one or more of the above.
   - NetworkManager-ovs
+  - ose-aws-ecr-image-credential-provider


### PR DESCRIPTION
This change adds the aws ecr-image-credential-provider package that kubelet will use to retrieve ecr authentication credentials