### PR TITLE
OCPBUGS-22928: [release-4.12] manifests: drop compat-openssl10

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -160,6 +160,8 @@ exclude-packages:
   # See: https://bugzilla.redhat.com/show_bug.cgi?id=1930468
   # See: https://bugzilla.redhat.com/show_bug.cgi?id=1800901
   - dhcp-client
+  # https://issues.redhat.com/browse/COS-2461
+  - compat-openssl10
 
 # Try to maintain this list ordering by "in RHEL, then not in RHEL".
 # To verify, disable all repos except the ootpa ones and then comment

--- a/manifest-rhel-8.6.yaml
+++ b/manifest-rhel-8.6.yaml
@@ -147,8 +147,6 @@ packages:
  # We include the generic release package and tweak the os-release info in a
  # post-proces script
  - redhat-release
- # RHEL7 compatibility
- - compat-openssl10
  # SCOS package name does not include a version number
  - openvswitch3.1
  # https://github.com/openshift/os/issues/1036


### PR DESCRIPTION
Drop compat-openssl10 from RHCOS builds based on RHEL8 and make sure we don't include it via an exclude.

See: https://issues.redhat.com/browse/COS-2461