### PR TITLE
OCPBUGS-22929: [release-4.11]: manifests: drop compat-openssl10

### DIFF
--- a/manifest.yaml
+++ b/manifest.yaml
@@ -277,6 +277,8 @@ exclude-packages:
   # See: https://bugzilla.redhat.com/show_bug.cgi?id=1930468
   # See: https://bugzilla.redhat.com/show_bug.cgi?id=1800901
   - dhcp-client
+  # https://issues.redhat.com/browse/COS-2461
+  - compat-openssl10
 
 # Try to maintain this list ordering by "in RHEL, then not in RHEL".
 # To verify, disable all repos except the ootpa ones and then comment
@@ -315,8 +317,6 @@ packages:
  - systemd-journal-remote
  # Extras
  - systemd-journal-gateway
- # RHEL7 compatibility
- - compat-openssl10
  # Make sure we pull in at least clevis 15; it drops the rd.neednet=1 hardcode
  # and has a few other patches we need.
  # https://bugzilla.redhat.com/show_bug.cgi?id=1853651


### PR DESCRIPTION
Drop compat-openssl10 from RHCOS builds based on RHEL8 and make sure we don't include it via an exclude.

See: https://issues.redhat.com/browse/COS-2461