### PR TITLE
NO-JIRA: denylist: extend snooze for `coreos.ignition.failure`

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -60,7 +60,7 @@
 
 - pattern: coreos.ignition.failure
   tracker: https://github.com/coreos/coreos-assembler/issues/3670
-  snooze: 2023-12-13
+  snooze: 2024-02-05
   warn: true
 
 - pattern: iso-offline-install-iscsi.bios


### PR DESCRIPTION
This test is still failing so let's extend the snooze for a few weeks so we can continue to investigate
https://github.com/coreos/coreos-assembler/issues/3670