### PR TITLE
rhcos-packages: Make bootupd no arch dependent

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -242,6 +242,8 @@ packages:
  - kernel-modules-extra
  # Audit
  - audit
+ # Bootloader updater
+ - bootupd
  # Containers
  - containernetworking-plugins
  # Pinned due to cosa on Fedora not honoring RHEL 8 modules as expected

--- a/rhcos-packages.yaml
+++ b/rhcos-packages.yaml
@@ -19,9 +19,3 @@ packages:
   # for kdump:
   # https://github.com/coreos/fedora-coreos-tracker/issues/622
   - kexec-tools
-
-# See https://github.com/coreos/bootupd
-packages-x86_64:
-   - bootupd
-packages-aarch64:
-   - bootupd


### PR DESCRIPTION
We now have bootupd support across all architectures.