### PR TITLE
NO-JIRA: manifests: add bootc to c9s and rhel-9.4 variants

### DIFF
--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -130,6 +130,7 @@ packages:
  - centos-release-cloud-common
  - centos-release-nfv-common
  - centos-release-virt-common
+ - bootc
 
 # Packages pinned to specific repos in SCOS 9
 repo-packages:

--- a/manifest-rhel-9.4.yaml
+++ b/manifest-rhel-9.4.yaml
@@ -122,6 +122,7 @@ packages:
  # We include the generic release package and tweak the os-release info in a
  # post-proces script
  - centos-release
+ - bootc
 
 # Packages pinned to specific repos in SCOS 9
 repo-packages:


### PR DESCRIPTION
The MCO team at least wants to start experimenting with using bootc for various operations.