### PR TITLE
NO-JIRA: denylist: re-deny `iso-offline-install-iscsi.bios`

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -65,5 +65,3 @@
 
 - pattern: iso-offline-install-iscsi.bios
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1638
-  snooze: 2024-01-20
-  warn: true


### PR DESCRIPTION
It's known failing in the pipelines, so there's no use snoozing it. Let's keep it off until we've debugged and fixed it.