### PR TITLE
NO-JIRA: extensions-9.4: remove sig-virtualization repo definition

### DIFF
--- a/extensions-rhel-9.4.yaml
+++ b/extensions-rhel-9.4.yaml
@@ -2,9 +2,6 @@
 # https://github.com/openshift/enhancements/blob/master/enhancements/rhcos/extensions.md
 # and https://github.com/coreos/fedora-coreos-tracker/issues/401
 
-repos:
-  - sig-virtualization
-
 extensions:
   # https://issues.redhat.com/browse/RFE-4177
   wasm:


### PR DESCRIPTION
We are using the `rhel-9.2-server-ose-4.16` repo for the kata-containers package for the RHEL-9.4 variant, so sig-virtualization isn't needed in this extensions file.
    
See: https://github.com/openshift/os/issues/1434
