### PR TITLE
NO-JIRA: common.yaml: include passwd RPM in manifest

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -261,6 +261,8 @@ packages:
  - authselect
  # https://bugzilla.redhat.com/show_bug.cgi?id=1900759
  - qemu-guest-agent
+ # passwd was obsoleted by shadow-utils in F40+, but still needed here
+ - passwd
  # BELOW HERE ARE PACKAGES NOT IN RHEL
  # Gluster - Used for Openshift e2e gluster testcases
  # Reverts https://gitlab.cee.redhat.com/coreos/redhat-coreos/merge_requests/367 and add it for all arches


### PR DESCRIPTION
This package will drop out of the FCOS manifests in Fedora 40+ because the shadow-utils RPM now provides it [1]. Let's name it here so we continue to include it in RHCOS until it is also removed from RHEL (assuming that will happen).

[1] https://src.fedoraproject.org/rpms/shadow-utils/c/91360f25a8c8b810d59bec2803a2477a2647c775?branch=rawhide