### PR TITLE
NO-JIRA: nmstate, configure nmstate to keep service yamls

### DIFF
--- a/overlay.d/05rhcos/etc/nmstate/nmstate.conf
+++ b/overlay.d/05rhcos/etc/nmstate/nmstate.conf
@@ -1,0 +1,2 @@
+[service]
+keep_state_file_after_apply = true


### PR DESCRIPTION
When https://github.com/nmstate/nmstate/pull/2546 land to RHCOS the nmstate service will go back to previous behaviour, the /etc/nmstate/*.yml files are moved to .applied files, so we need to configure nmstate to keep the those files, if we don't do so MCO complains at in place upgrades since the file system has change.

The original in place problem is described at https://github.com/nmstate/nmstate/pull/2499:

```
At some envs like openshift machine-config-operator moving configuration files can break in place upgrades. This change use symlinks instead of rename to mark a .yml file as applied so the original file is preserved.
```

And the original issue was:
https://issues.redhat.com/browse/RHEL-19680