### PR TITLE
COS-2696: common.yaml: enable cliwrap

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -33,6 +33,10 @@ conditional-include:
     # And remove some cruft from grub2
     include: fedora-coreos-config/manifests/grub2-removals.yaml
 
+# we want derivations to be able to type `dnf install ...` for a unified
+# experience
+cliwrap: true
+
 documentation: false
 
 postprocess:


### PR DESCRIPTION
As part of the bootable containers effort, we want to put emphasis on a consistent experience when deriving images. A big part of that is being able to type `dnf install -y ...` in one's `Containerfile`.

Let's turn on cliwrap for this. This matches the change in FCOS.[[1]]

[1]: https://github.com/coreos/fedora-coreos-config/pull/2858