### PR TITLE
OCPCLOUD-2484,OCPCLOUD-2481: Adds acr and gcr image credential providers

### DIFF
--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -8,3 +8,5 @@ packages:
   # and depend on one or more of the above.
   - NetworkManager-ovs
   - ose-aws-ecr-image-credential-provider
+  - ose-azure-acr-image-credential-provider
+  - ose-gcp-gcr-image-credential-provider


### PR DESCRIPTION
This change adds the azure acr-image-credential-provider and gcp gcr-image-credential-provider packages that kubelet will use to retrieve authentication credentials