### PR TITLE
COS-2692: Add new variants to enable pure CentOS Stream/RHEL CoreOS builds, add Containerfile for layered OKD/OCP builds

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,33 @@
+# This builds the final OCP node image on top of the base RHCOS image. The
+# latter may be RHEL or CentOS Stream-based. This is currently only buildable
+# using podman/buildah as it uses some mounting options only available there.
+#
+# To build this, you will want to pass `--security-opt=label=disable` to avoid
+# having to relabel the context directory. Any repos found in `/run/yum.repos.d`
+# will be imported into `/etc/yum.repos.d/` and then removed in the same step (so
+# as to not end up in the final image).
+#
+# Use `--from` to override the base RHCOS image. E.g.:
+#
+# podman build --from quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-coreos-base-9.4 ...
+#
+# Or to use a locally built OCI archive:
+#
+# podman build --from oci-archive:builds/latest/x86_64/scos-9-20240416.dev.0-ostree.x86_64.ociarchive ...
+
+# If consuming from repos hosted within the RH network, you'll want to mount in
+# certs too:
+#
+# podman build -v /etc/pki/ca-trust:/etc/pki-ca-trust:ro ...
+#
+# Example invocation:
+#
+# podman build --from oci-archive:$(ls builds/latest/x86_64/*.ociarchive) \
+#   -v rhel-9.4.repo:/run/yum.repos.d/rhel-9.4.repo:ro \
+#   -v /etc/pki/ca-trust:/etc/pki/ca-trust:ro \
+#   --security-opt label=disable -t localhost/openshift-node-c9s \
+#   src/config
+
+FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev:rhel-coreos-base-c9s
+RUN --mount=type=bind,target=/run/src /run/src/scripts/apply-manifest /run/src/packages-openshift.yaml && \
+  ostree container commit

--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@ To support building both a RHEL-based and a CentOS Stream-based CoreOS, the
 coreos-assembler concept of [variants] is used. The following variants are
 supported:
 
-- `rhel-9.4`: RHEL 9.4-based CoreOS; including OpenShift components.
-- `c9s`: CentOS Stream-based CoreOS, including OpenShift components. This
+- `rhel-9.4`: Clone of `ocp-rhel-9.4` for now.
+- `ocp-rhel-9.4`: RHEL 9.4-based CoreOS; including OpenShift components.
+- `c9s`: Clone of `okd-c9s` for now.
+- `okd-c9s`: CentOS Stream-based CoreOS, including OpenShift components. This
   currently includes some packages from RHEL because not all packages required
   by OpenShift are provided in CentOS Stream.
 
-The default variant is `rhel-9.4`.
+The default variant is `ocp-rhel-9.4`.
 
 ## Reporting issues
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,15 @@ To support building both a RHEL-based and a CentOS Stream-based CoreOS, the
 coreos-assembler concept of [variants] is used. The following variants are
 supported:
 
-- `rhel-9.4`: Clone of `ocp-rhel-9.4` for now.
+- `rhel-9.4`: RHEL 9.4-based CoreOS; without OpenShift components.
 - `ocp-rhel-9.4`: RHEL 9.4-based CoreOS; including OpenShift components.
-- `c9s`: Clone of `okd-c9s` for now.
+- `c9s`: CentOS Stream-based CoreOS, without OKD components.
 - `okd-c9s`: CentOS Stream-based CoreOS, including OpenShift components. This
   currently includes some packages from RHEL because not all packages required
   by OpenShift are provided in CentOS Stream.
+
+In the future, the `ocp-*` variants will be removed. Instead, OpenShift
+components will be layered by deriving from the `rhel-9.4`/`c9s` images.
 
 The default variant is `ocp-rhel-9.4`.
 

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -305,36 +305,36 @@ main() {
             prepare_repos
             ;;
         "build" | "init-and-build-default")  # TODO: change prow job to use init-and-build-default
-            cosa_init "rhel-9.4"
+            cosa_init "ocp-rhel-9.4"
             cosa_build
             ;;
         "rhcos-cosa-prow-pr-ci")
             setup_user
-            cosa_init "rhel-9.4"
+            cosa_init "ocp-rhel-9.4"
             cosa_build
             kola_test_qemu
             ;;
         "rhcos-9-build-test-qemu")
             setup_user
-            cosa_init "rhel-9.4"
+            cosa_init "ocp-rhel-9.4"
             cosa_build
             kola_test_qemu
             ;;
         "rhcos-9-build-test-metal")
             setup_user
-            cosa_init "rhel-9.4"
+            cosa_init "ocp-rhel-9.4"
             cosa_build
             kola_test_metal
             ;;
         "scos-9-build-test-qemu")
             setup_user
-            cosa_init "c9s"
+            cosa_init "okd-c9s"
             cosa_build
             kola_test_qemu
             ;;
         "scos-9-build-test-metal")
             setup_user
-            cosa_init "c9s"
+            cosa_init "okd-c9s"
             cosa_build
             kola_test_metal
             ;;

--- a/common.yaml
+++ b/common.yaml
@@ -43,6 +43,21 @@ conditional-include:
 documentation: false
 
 postprocess:
+  # Mark the OS as of the CoreOS variant.
+  # XXX: should be part of a centos/redhat-release subpackage instead
+  - |
+     #!/usr/bin/bash
+     set -euo pipefail
+     cat >> /usr/lib/os-release <<EOF
+     VARIANT=CoreOS
+     VARIANT_ID=coreos
+     EOF
+
+     # And put "CoreOS" in NAME and PRETTY_NAME
+     sed -i -e 's/^NAME="\(.*\)"/NAME="\1 CoreOS"/' /usr/lib/os-release
+     . /usr/lib/os-release
+     sed -i -e "s/^PRETTY_NAME=.*/PRETTY_NAME=\"$NAME $VERSION\"/" /usr/lib/os-release
+
   # TEMPORARY: Create /etc/vmware-tools/tools.conf to ensure RHCOS shows up properly in VMWare
   # See https://jira.coreos.com/browse/RHCOS-258
   - |

--- a/extensions-ocp-rhel-9.4.yaml
+++ b/extensions-ocp-rhel-9.4.yaml
@@ -1,0 +1,1 @@
+extensions-rhel-9.4.yaml

--- a/extensions-okd-c9s.yaml
+++ b/extensions-okd-c9s.yaml
@@ -1,0 +1,1 @@
+extensions-c9s.yaml

--- a/extensions.yaml
+++ b/extensions.yaml
@@ -1,1 +1,1 @@
-extensions-rhel-9.4.yaml
+extensions-ocp-rhel-9.4.yaml

--- a/image-ocp-rhel-9.4.yaml
+++ b/image-ocp-rhel-9.4.yaml
@@ -1,0 +1,1 @@
+image-rhel-9.4.yaml

--- a/image-okd-c9s.yaml
+++ b/image-okd-c9s.yaml
@@ -1,0 +1,1 @@
+image-c9s.yaml

--- a/image.yaml
+++ b/image.yaml
@@ -1,1 +1,1 @@
-image-rhel-9.4.yaml
+image-ocp-rhel-9.4.yaml

--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -1,123 +1,28 @@
-# Manifest for CentOS Stream CoreOS (SCOS)
+# Manifest for CentOS Stream CoreOS 9
 
 rojig:
   license: MIT
   name: scos
-  summary: OKD 4
+  summary: CentOS Stream CoreOS 9
 
 variables:
   osversion: "c9s"
 
-# Include manifests common to all RHEL and CentOS Stream versions and manifest
-# common to RHEL 9 & C9S variants
+# Include manifests common to all RHEL and CentOS Stream versions
 include:
   - common.yaml
-  - packages-openshift.yaml
   - overrides-c9s.yaml
 
-# Starting from here, everything should be specific to SCOS
-
-# CentOS Stream 9 repos + internal repos for now
 repos:
   - c9s-baseos
   - c9s-appstream
-  # CentOS Extras Common repo for SIG RPM GPG keys
-  - c9s-extras-common
-  # CentOS NFV SIG repo for openvswitch
-  - c9s-sig-nfv
-  # CentOS Cloud SIG repo for cri-o, cri-tools and conmon-rs
-  - c9s-sig-cloud-okd
-  # Include RHCOS 9 repo for oc, hyperkube
-  - rhel-9.4-server-ose-4.17
 
-# We include hours/minutes to avoid version number reuse
-automatic-version-prefix: "417.9.<date:%Y%m%d%H%M>"
-# This ensures we're semver-compatible which OpenShift wants
-automatic-version-suffix: "-"
-# Keep this is sync with the version in postprocess
-mutate-os-release: "4.17"
+# Eventually we should try to build these images as part of the c9s composes.
+# In that case, the versioning should instead be exactly the same as the pungi
+# compose ID.
+automatic-version-prefix: "9.<date:%Y%m%d%H%M>"
 
-postprocess:
-  - |
-     #!/usr/bin/env bash
-     set -xeo pipefail
+mutate-os-release: "9"
 
-     # Tweak /usr/lib/os-release
-     grep -v -e "OSTREE_VERSION" -e "OPENSHIFT_VERSION" /etc/os-release > /usr/lib/os-release.stream
-     (
-     . /etc/os-release
-     cat > /usr/lib/os-release <<EOF
-     NAME="${NAME} CoreOS"
-     ID="scos"
-     ID_LIKE="rhel fedora"
-     VERSION="${OSTREE_VERSION}"
-     VERSION_ID="${OPENSHIFT_VERSION}"
-     VARIANT="CoreOS"
-     VARIANT_ID=coreos
-     PLATFORM_ID="${PLATFORM_ID}"
-     PRETTY_NAME="${NAME} CoreOS ${OSTREE_VERSION}"
-     ANSI_COLOR="${ANSI_COLOR}"
-     CPE_NAME="${CPE_NAME}::coreos"
-     HOME_URL="${HOME_URL}"
-     DOCUMENTATION_URL="https://docs.okd.io/latest/welcome/index.html"
-     BUG_REPORT_URL="https://access.redhat.com/labs/rhir/"
-     REDHAT_BUGZILLA_PRODUCT="OpenShift Container Platform"
-     REDHAT_BUGZILLA_PRODUCT_VERSION="${OPENSHIFT_VERSION}"
-     REDHAT_SUPPORT_PRODUCT="OpenShift Container Platform"
-     REDHAT_SUPPORT_PRODUCT_VERSION="${OPENSHIFT_VERSION}"
-     OPENSHIFT_VERSION="${OPENSHIFT_VERSION}"
-     OSTREE_VERSION="${OSTREE_VERSION}"
-     EOF
-     )
-     rm -f /etc/os-release
-     ln -s ../usr/lib/os-release /etc/os-release
-
-     # Tweak /etc/system-release, /etc/system-release-cpe & /etc/redhat-release
-     (
-     . /etc/os-release
-     cat > /usr/lib/system-release-cpe <<EOF
-     ${CPE_NAME}
-     EOF
-     cat > /usr/lib/system-release <<EOF
-     ${NAME} release ${VERSION_ID}
-     EOF
-     rm -f /etc/system-release-cpe /etc/system-release /etc/redhat-release
-     ln -s /usr/lib/system-release-cpe /etc/system-release-cpe
-     ln -s /usr/lib/system-release /etc/system-release
-     ln -s /usr/lib/system-release /etc/redhat-release
-     )
-
-     # Tweak /usr/lib/issue
-     cat > /usr/lib/issue <<EOF
-     \S \S{VERSION_ID}
-     EOF
-     rm -f /etc/issue /etc/issue.net
-     ln -s /usr/lib/issue /etc/issue
-     ln -s /usr/lib/issue /etc/issue.net
-
-# Packages that are only in SCOS and not in RHCOS or that have special
-# constraints that do not apply to RHCOS
 packages:
- # We include the generic release package and tweak the os-release info in a
- # post-proces script
  - centos-stream-release
- # RPM GPG keys for CentOS SIG repos
- - centos-release-cloud-common
- - centos-release-nfv-common
- - centos-release-virt-common
-
-# Packages pinned to specific repos in SCOS 9
-repo-packages:
-  # We always want the kernel from BaseOS
-  - repo: c9s-baseos
-    packages:
-      - kernel
-  - repo: c9s-appstream
-    packages:
-      # We want the one shipping in C9S, not the equivalently versioned one in RHAOS
-      - nss-altfiles
-      # Use the new containers/toolbox
-      - toolbox
-      # The one shipping in C9S is temporarily lower versioned, so be explicit
-      # https://github.com/openshift/os/issues/1505
-      - containers-common

--- a/manifest-ocp-rhel-9.4.yaml
+++ b/manifest-ocp-rhel-9.4.yaml
@@ -1,9 +1,10 @@
-# Manifest for RHCOS based on RHEL 9.4
+# Manifest for OCP node based on RHEL 9.4
+# Note: this manifest is temporary; in the future, OCP components will be layered instead.
 
 rojig:
   license: MIT
   name: rhcos
-  summary: OpenShift 4
+  summary: OpenShift 4.17
 
 variables:
   osversion: "rhel-9.4"
@@ -11,16 +12,12 @@ variables:
 # Include manifests common to all RHEL and CentOS Stream versions and manifest
 # common to RHEL 9 & C9S variants
 include:
-  - common.yaml
+  - manifest-rhel-9.4.yaml
   - packages-openshift.yaml
 
-# Starting from here, everything should be specific to RHCOS based on RHEL 9.4 content
-
+# Additional repos we need for OCP components
 repos:
-  - rhel-9.4-baseos
-  - rhel-9.4-appstream
   - rhel-9.4-fast-datapath
-  # Include RHCOS 9 repo for oc, kubelet
   - rhel-9.4-server-ose-4.17
 
 # We include hours/minutes to avoid version number reuse
@@ -40,15 +37,15 @@ postprocess:
      (
      . /etc/os-release
      cat > /usr/lib/os-release <<EOF
-     NAME="${NAME} CoreOS"
+     NAME="${NAME}"
      ID="rhcos"
      ID_LIKE="rhel fedora"
      VERSION="${OSTREE_VERSION}"
      VERSION_ID="${OPENSHIFT_VERSION}"
-     VARIANT="CoreOS"
-     VARIANT_ID=coreos
+     VARIANT="${VARIANT}"
+     VARIANT_ID=${VARIANT_ID}
      PLATFORM_ID="${PLATFORM_ID}"
-     PRETTY_NAME="${NAME} CoreOS ${OSTREE_VERSION}"
+     PRETTY_NAME="${NAME} ${OSTREE_VERSION}"
      ANSI_COLOR="${ANSI_COLOR}"
      CPE_NAME="${CPE_NAME}::coreos"
      HOME_URL="${HOME_URL}"
@@ -88,13 +85,6 @@ postprocess:
      rm -f /etc/issue /etc/issue.net
      ln -s /usr/lib/issue /etc/issue
      ln -s /usr/lib/issue /etc/issue.net
-
-# Packages that are only in RHCOS and not in SCOS or that have special
-# constraints that do not apply to SCOS
-packages:
- # We include the generic release package and tweak the os-release info in a
- # post-process script
- - redhat-release
 
 # Packages pinned to specific repos in RHCOS 9
 repo-packages:

--- a/manifest-ocp-rhel-9.4.yaml
+++ b/manifest-ocp-rhel-9.4.yaml
@@ -1,0 +1,110 @@
+# Manifest for RHCOS based on RHEL 9.4
+
+rojig:
+  license: MIT
+  name: rhcos
+  summary: OpenShift 4
+
+variables:
+  osversion: "rhel-9.4"
+
+# Include manifests common to all RHEL and CentOS Stream versions and manifest
+# common to RHEL 9 & C9S variants
+include:
+  - common.yaml
+  - packages-openshift.yaml
+
+# Starting from here, everything should be specific to RHCOS based on RHEL 9.4 content
+
+repos:
+  - rhel-9.4-baseos
+  - rhel-9.4-appstream
+  - rhel-9.4-fast-datapath
+  # Include RHCOS 9 repo for oc, kubelet
+  - rhel-9.4-server-ose-4.17
+
+# We include hours/minutes to avoid version number reuse
+automatic-version-prefix: "417.94.<date:%Y%m%d%H%M>"
+# This ensures we're semver-compatible which OpenShift wants
+automatic-version-suffix: "-"
+# Keep this is sync with the version in postprocess
+mutate-os-release: "4.17"
+
+postprocess:
+  - |
+     #!/usr/bin/env bash
+     set -xeo pipefail
+
+     # Tweak /usr/lib/os-release
+     grep -v -e "OSTREE_VERSION" -e "OPENSHIFT_VERSION" /etc/os-release > /usr/lib/os-release.rhel
+     (
+     . /etc/os-release
+     cat > /usr/lib/os-release <<EOF
+     NAME="${NAME} CoreOS"
+     ID="rhcos"
+     ID_LIKE="rhel fedora"
+     VERSION="${OSTREE_VERSION}"
+     VERSION_ID="${OPENSHIFT_VERSION}"
+     VARIANT="CoreOS"
+     VARIANT_ID=coreos
+     PLATFORM_ID="${PLATFORM_ID}"
+     PRETTY_NAME="${NAME} CoreOS ${OSTREE_VERSION}"
+     ANSI_COLOR="${ANSI_COLOR}"
+     CPE_NAME="${CPE_NAME}::coreos"
+     HOME_URL="${HOME_URL}"
+     DOCUMENTATION_URL="https://docs.okd.io/latest/welcome/index.html"
+     BUG_REPORT_URL="https://access.redhat.com/labs/rhir/"
+     REDHAT_BUGZILLA_PRODUCT="OpenShift Container Platform"
+     REDHAT_BUGZILLA_PRODUCT_VERSION="${OPENSHIFT_VERSION}"
+     REDHAT_SUPPORT_PRODUCT="OpenShift Container Platform"
+     REDHAT_SUPPORT_PRODUCT_VERSION="${OPENSHIFT_VERSION}"
+     OPENSHIFT_VERSION="${OPENSHIFT_VERSION}"
+     RHEL_VERSION=9.4
+     OSTREE_VERSION="${OSTREE_VERSION}"
+     EOF
+     )
+     rm -f /etc/os-release
+     ln -s ../usr/lib/os-release /etc/os-release
+
+     # Tweak /etc/system-release, /etc/system-release-cpe & /etc/redhat-release
+     (
+     . /etc/os-release
+     cat > /usr/lib/system-release-cpe <<EOF
+     ${CPE_NAME}
+     EOF
+     cat > /usr/lib/system-release <<EOF
+     ${NAME} release ${VERSION_ID}
+     EOF
+     rm -f /etc/system-release-cpe /etc/system-release /etc/redhat-release
+     ln -s /usr/lib/system-release-cpe /etc/system-release-cpe
+     ln -s /usr/lib/system-release /etc/system-release
+     ln -s /usr/lib/system-release /etc/redhat-release
+     )
+
+     # Tweak /usr/lib/issue
+     cat > /usr/lib/issue <<EOF
+     \S \S{VERSION_ID}
+     EOF
+     rm -f /etc/issue /etc/issue.net
+     ln -s /usr/lib/issue /etc/issue
+     ln -s /usr/lib/issue /etc/issue.net
+
+# Packages that are only in RHCOS and not in SCOS or that have special
+# constraints that do not apply to SCOS
+packages:
+ # We include the generic release package and tweak the os-release info in a
+ # post-process script
+ - redhat-release
+
+# Packages pinned to specific repos in RHCOS 9
+repo-packages:
+  - repo: rhel-9.4-appstream
+    packages:
+      - nss-altfiles
+  - repo: rhel-9.4-server-ose-4.17
+    packages:
+      - conmon-rs
+      - cri-o
+      - cri-tools
+      - openshift-clients
+      - openshift-kubelet

--- a/manifest-okd-c9s.yaml
+++ b/manifest-okd-c9s.yaml
@@ -1,26 +1,20 @@
-# Manifest for CentOS Stream CoreOS (SCOS)
+# Manifest for OKD node based on CentOS Stream CoreOS 9
+# Note: this manifest is temporary; in the future, OKD components will be layered instead.
 
 rojig:
   license: MIT
   name: scos
-  summary: OKD 4
+  summary: OKD 4.17
 
 variables:
   osversion: "c9s"
 
-# Include manifests common to all RHEL and CentOS Stream versions and manifest
-# common to RHEL 9 & C9S variants
 include:
-  - common.yaml
+  - manifest-c9s.yaml
   - packages-openshift.yaml
-  - overrides-c9s.yaml
 
-# Starting from here, everything should be specific to SCOS
-
-# CentOS Stream 9 repos + internal repos for now
+# Additional repos we need for OKD components
 repos:
-  - c9s-baseos
-  - c9s-appstream
   # CentOS Extras Common repo for SIG RPM GPG keys
   - c9s-extras-common
   # CentOS NFV SIG repo for openvswitch
@@ -47,15 +41,15 @@ postprocess:
      (
      . /etc/os-release
      cat > /usr/lib/os-release <<EOF
-     NAME="${NAME} CoreOS"
+     NAME="${NAME}"
      ID="scos"
      ID_LIKE="rhel fedora"
      VERSION="${OSTREE_VERSION}"
      VERSION_ID="${OPENSHIFT_VERSION}"
-     VARIANT="CoreOS"
-     VARIANT_ID=coreos
+     VARIANT="${VARIANT}"
+     VARIANT_ID=${VARIANT_ID}
      PLATFORM_ID="${PLATFORM_ID}"
-     PRETTY_NAME="${NAME} CoreOS ${OSTREE_VERSION}"
+     PRETTY_NAME="${NAME} ${OSTREE_VERSION}"
      ANSI_COLOR="${ANSI_COLOR}"
      CPE_NAME="${CPE_NAME}::coreos"
      HOME_URL="${HOME_URL}"
@@ -95,12 +89,7 @@ postprocess:
      ln -s /usr/lib/issue /etc/issue
      ln -s /usr/lib/issue /etc/issue.net
 
-# Packages that are only in SCOS and not in RHCOS or that have special
-# constraints that do not apply to RHCOS
 packages:
- # We include the generic release package and tweak the os-release info in a
- # post-proces script
- - centos-stream-release
  # RPM GPG keys for CentOS SIG repos
  - centos-release-cloud-common
  - centos-release-nfv-common

--- a/manifest-okd-c9s.yaml
+++ b/manifest-okd-c9s.yaml
@@ -1,0 +1,123 @@
+# Manifest for CentOS Stream CoreOS (SCOS)
+
+rojig:
+  license: MIT
+  name: scos
+  summary: OKD 4
+
+variables:
+  osversion: "c9s"
+
+# Include manifests common to all RHEL and CentOS Stream versions and manifest
+# common to RHEL 9 & C9S variants
+include:
+  - common.yaml
+  - packages-openshift.yaml
+  - overrides-c9s.yaml
+
+# Starting from here, everything should be specific to SCOS
+
+# CentOS Stream 9 repos + internal repos for now
+repos:
+  - c9s-baseos
+  - c9s-appstream
+  # CentOS Extras Common repo for SIG RPM GPG keys
+  - c9s-extras-common
+  # CentOS NFV SIG repo for openvswitch
+  - c9s-sig-nfv
+  # CentOS Cloud SIG repo for cri-o, cri-tools and conmon-rs
+  - c9s-sig-cloud-okd
+  # Include RHCOS 9 repo for oc, hyperkube
+  - rhel-9.4-server-ose-4.17
+
+# We include hours/minutes to avoid version number reuse
+automatic-version-prefix: "417.9.<date:%Y%m%d%H%M>"
+# This ensures we're semver-compatible which OpenShift wants
+automatic-version-suffix: "-"
+# Keep this is sync with the version in postprocess
+mutate-os-release: "4.17"
+
+postprocess:
+  - |
+     #!/usr/bin/env bash
+     set -xeo pipefail
+
+     # Tweak /usr/lib/os-release
+     grep -v -e "OSTREE_VERSION" -e "OPENSHIFT_VERSION" /etc/os-release > /usr/lib/os-release.stream
+     (
+     . /etc/os-release
+     cat > /usr/lib/os-release <<EOF
+     NAME="${NAME} CoreOS"
+     ID="scos"
+     ID_LIKE="rhel fedora"
+     VERSION="${OSTREE_VERSION}"
+     VERSION_ID="${OPENSHIFT_VERSION}"
+     VARIANT="CoreOS"
+     VARIANT_ID=coreos
+     PLATFORM_ID="${PLATFORM_ID}"
+     PRETTY_NAME="${NAME} CoreOS ${OSTREE_VERSION}"
+     ANSI_COLOR="${ANSI_COLOR}"
+     CPE_NAME="${CPE_NAME}::coreos"
+     HOME_URL="${HOME_URL}"
+     DOCUMENTATION_URL="https://docs.okd.io/latest/welcome/index.html"
+     BUG_REPORT_URL="https://access.redhat.com/labs/rhir/"
+     REDHAT_BUGZILLA_PRODUCT="OpenShift Container Platform"
+     REDHAT_BUGZILLA_PRODUCT_VERSION="${OPENSHIFT_VERSION}"
+     REDHAT_SUPPORT_PRODUCT="OpenShift Container Platform"
+     REDHAT_SUPPORT_PRODUCT_VERSION="${OPENSHIFT_VERSION}"
+     OPENSHIFT_VERSION="${OPENSHIFT_VERSION}"
+     OSTREE_VERSION="${OSTREE_VERSION}"
+     EOF
+     )
+     rm -f /etc/os-release
+     ln -s ../usr/lib/os-release /etc/os-release
+
+     # Tweak /etc/system-release, /etc/system-release-cpe & /etc/redhat-release
+     (
+     . /etc/os-release
+     cat > /usr/lib/system-release-cpe <<EOF
+     ${CPE_NAME}
+     EOF
+     cat > /usr/lib/system-release <<EOF
+     ${NAME} release ${VERSION_ID}
+     EOF
+     rm -f /etc/system-release-cpe /etc/system-release /etc/redhat-release
+     ln -s /usr/lib/system-release-cpe /etc/system-release-cpe
+     ln -s /usr/lib/system-release /etc/system-release
+     ln -s /usr/lib/system-release /etc/redhat-release
+     )
+
+     # Tweak /usr/lib/issue
+     cat > /usr/lib/issue <<EOF
+     \S \S{VERSION_ID}
+     EOF
+     rm -f /etc/issue /etc/issue.net
+     ln -s /usr/lib/issue /etc/issue
+     ln -s /usr/lib/issue /etc/issue.net
+
+# Packages that are only in SCOS and not in RHCOS or that have special
+# constraints that do not apply to RHCOS
+packages:
+ # We include the generic release package and tweak the os-release info in a
+ # post-proces script
+ - centos-stream-release
+ # RPM GPG keys for CentOS SIG repos
+ - centos-release-cloud-common
+ - centos-release-nfv-common
+ - centos-release-virt-common
+
+# Packages pinned to specific repos in SCOS 9
+repo-packages:
+  # We always want the kernel from BaseOS
+  - repo: c9s-baseos
+    packages:
+      - kernel
+  - repo: c9s-appstream
+    packages:
+      # We want the one shipping in C9S, not the equivalently versioned one in RHAOS
+      - nss-altfiles
+      # Use the new containers/toolbox
+      - toolbox
+      # The one shipping in C9S is temporarily lower versioned, so be explicit
+      # https://github.com/openshift/os/issues/1505
+      - containers-common

--- a/manifest-rhel-9.4.yaml
+++ b/manifest-rhel-9.4.yaml
@@ -3,91 +3,25 @@
 rojig:
   license: MIT
   name: rhcos
-  summary: OpenShift 4
+  summary: RHEL CoreOS 9.4
 
 variables:
   osversion: "rhel-9.4"
 
-# Include manifests common to all RHEL and CentOS Stream versions and manifest
-# common to RHEL 9 & C9S variants
+# Include manifests common to all RHEL and CentOS Stream versions
 include:
   - common.yaml
-  - packages-openshift.yaml
-
-# Starting from here, everything should be specific to RHCOS based on RHEL 9.4 content
 
 repos:
   - rhel-9.4-baseos
   - rhel-9.4-appstream
-  - rhel-9.4-fast-datapath
-  # Include RHCOS 9 repo for oc, kubelet
-  - rhel-9.4-server-ose-4.17
 
-# We include hours/minutes to avoid version number reuse
-automatic-version-prefix: "417.94.<date:%Y%m%d%H%M>"
-# This ensures we're semver-compatible which OpenShift wants
-automatic-version-suffix: "-"
-# Keep this is sync with the version in postprocess
-mutate-os-release: "4.17"
+# Eventually we should try to build these images as part of the RHEL composes.
+# In that case, the versioning should instead be exactly the same as the pungi
+# compose ID.
+automatic-version-prefix: "9.4.<date:%Y%m%d%H%M>"
 
-postprocess:
-  - |
-     #!/usr/bin/env bash
-     set -xeo pipefail
-
-     # Tweak /usr/lib/os-release
-     grep -v -e "OSTREE_VERSION" -e "OPENSHIFT_VERSION" /etc/os-release > /usr/lib/os-release.rhel
-     (
-     . /etc/os-release
-     cat > /usr/lib/os-release <<EOF
-     NAME="${NAME} CoreOS"
-     ID="rhcos"
-     ID_LIKE="rhel fedora"
-     VERSION="${OSTREE_VERSION}"
-     VERSION_ID="${OPENSHIFT_VERSION}"
-     VARIANT="CoreOS"
-     VARIANT_ID=coreos
-     PLATFORM_ID="${PLATFORM_ID}"
-     PRETTY_NAME="${NAME} CoreOS ${OSTREE_VERSION}"
-     ANSI_COLOR="${ANSI_COLOR}"
-     CPE_NAME="${CPE_NAME}::coreos"
-     HOME_URL="${HOME_URL}"
-     DOCUMENTATION_URL="https://docs.okd.io/latest/welcome/index.html"
-     BUG_REPORT_URL="https://access.redhat.com/labs/rhir/"
-     REDHAT_BUGZILLA_PRODUCT="OpenShift Container Platform"
-     REDHAT_BUGZILLA_PRODUCT_VERSION="${OPENSHIFT_VERSION}"
-     REDHAT_SUPPORT_PRODUCT="OpenShift Container Platform"
-     REDHAT_SUPPORT_PRODUCT_VERSION="${OPENSHIFT_VERSION}"
-     OPENSHIFT_VERSION="${OPENSHIFT_VERSION}"
-     RHEL_VERSION=9.4
-     OSTREE_VERSION="${OSTREE_VERSION}"
-     EOF
-     )
-     rm -f /etc/os-release
-     ln -s ../usr/lib/os-release /etc/os-release
-
-     # Tweak /etc/system-release, /etc/system-release-cpe & /etc/redhat-release
-     (
-     . /etc/os-release
-     cat > /usr/lib/system-release-cpe <<EOF
-     ${CPE_NAME}
-     EOF
-     cat > /usr/lib/system-release <<EOF
-     ${NAME} release ${VERSION_ID}
-     EOF
-     rm -f /etc/system-release-cpe /etc/system-release /etc/redhat-release
-     ln -s /usr/lib/system-release-cpe /etc/system-release-cpe
-     ln -s /usr/lib/system-release /etc/system-release
-     ln -s /usr/lib/system-release /etc/redhat-release
-     )
-
-     # Tweak /usr/lib/issue
-     cat > /usr/lib/issue <<EOF
-     \S \S{VERSION_ID}
-     EOF
-     rm -f /etc/issue /etc/issue.net
-     ln -s /usr/lib/issue /etc/issue
-     ln -s /usr/lib/issue /etc/issue.net
+mutate-os-release: "9.4"
 
 # Packages that are only in RHCOS and not in SCOS or that have special
 # constraints that do not apply to SCOS
@@ -95,16 +29,3 @@ packages:
  # We include the generic release package and tweak the os-release info in a
  # post-process script
  - redhat-release
-
-# Packages pinned to specific repos in RHCOS 9
-repo-packages:
-  - repo: rhel-9.4-appstream
-    packages:
-      - nss-altfiles
-  - repo: rhel-9.4-server-ose-4.17
-    packages:
-      - conmon-rs
-      - cri-o
-      - cri-tools
-      - openshift-clients
-      - openshift-kubelet

--- a/manifest.yaml
+++ b/manifest.yaml
@@ -1,1 +1,1 @@
-manifest-rhel-9.4.yaml
+manifest-ocp-rhel-9.4.yaml

--- a/scripts/apply-manifest
+++ b/scripts/apply-manifest
@@ -1,0 +1,75 @@
+#!/usr/bin/python3 -u
+
+# This is a hacky temporary script to apply an rpm-ostree manifest as part of a
+# derived container build. It's only required because we're in this transitional
+# state where some streams use the old way, and others use layering. Once all
+# streams use layering, we could stop using manifests for the layered bits. (An
+# obvious question here is whether we should keep extending the `rpm-ostree ex
+# rebuild` stuff to keep using manifests even in a layered build. Though likely
+# similar functionality will live in dnf instead.)
+
+# Note this only supports the subset of the manifest spec actually used in
+# `packages-openshift.yaml`.
+
+import os
+import shutil
+import subprocess
+import sys
+import yaml
+
+
+def runcmd(args):
+    print("Running:", ' '.join(args))
+    subprocess.check_call(args)
+
+
+manifest_file = sys.argv[1]
+manifest_dir = os.path.dirname(manifest_file)
+
+with open(manifest_file) as f:
+    manifest = yaml.safe_load(f)
+
+if len(manifest.get('packages', [])):
+
+    packages = []
+    for pkg in manifest['packages']:
+        packages += pkg.split()
+    rpmostree_install = ['rpm-ostree', 'install', '-y'] + packages
+
+    # XXX: temporary hack for cri-o, which wants to create dirs under /opt
+    # https://github.com/CentOS/centos-bootc/issues/393
+    if 'cri-o' in packages:
+        os.makedirs("/var/opt", exist_ok=True)
+
+    # inject mounted-in repo files
+    extra_repos_dir = '/run/yum.repos.d'
+    copied_repo_files = []
+    if os.path.isdir(extra_repos_dir):
+        for file in os.listdir(extra_repos_dir):
+            src_path = os.path.join(extra_repos_dir, file)
+            if not os.path.isfile(src_path):
+                continue
+            if not file.endswith(".repo"):
+                continue
+            dest_path = os.path.join('/etc/yum.repos.d', file)
+            if os.path.exists(dest_path):
+                raise Exception(f"Repo file {dest_path} already exists")
+            print(f"Copying repo file {file} to /etc/yum.repos.d/")
+            shutil.copy(src_path, dest_path)
+            copied_repo_files += [dest_path]
+
+    runcmd(rpmostree_install)
+
+    # delete the repo files we injected
+    for repo in copied_repo_files:
+        os.unlink(repo)
+
+
+if len(manifest.get('postprocess', [])):
+    for i, script in enumerate(manifest['postprocess']):
+        name = f"/tmp/postprocess-script-{i}"
+        with open(name, 'w') as f:
+            f.write(script)
+        os.chmod(name, 0o755)
+        runcmd([name])
+        os.unlink(name)

--- a/tests/kola/version/rhel-major-version
+++ b/tests/kola/version/rhel-major-version
@@ -10,6 +10,9 @@ set -xeuo pipefail
 
 variant="$(source /etc/os-release; echo "${ID}")"
 case "${variant}" in
+    "centos")
+        osver="$(source /etc/os-release; echo "${VERSION_ID}")"
+        ;;
     "scos")
         osver="$(source /usr/lib/os-release.stream; echo "${VERSION}")"
         ;;

--- a/tests/kola/version/rhel-matches-rhcos-build
+++ b/tests/kola/version/rhel-matches-rhcos-build
@@ -12,6 +12,11 @@ set -xeuo pipefail
 ocp_version="$(source /etc/os-release; echo "${VERSION}")"
 variant="$(source /etc/os-release; echo "${ID}")"
 case "${variant}" in
+    "centos")
+        # We skip this in the base SCOS case; our package set is pure CentOS and
+        # the version string matches the compose ID, so this test is invalid.
+        exit 0
+        ;;
     "scos")
         # on SCOS, this is just "9"
         osver="$(source /usr/lib/os-release.stream; echo "${VERSION_ID}")"


### PR DESCRIPTION
Add new `okd-c9s` and `ocp-rhel-9.4` variants

To make introducing the base RHCOS/SCOS images safer, let's create two
new variants: `okd-c9s` and `ocp-rhel-9.4`. These variants are cloned
from the existing `c9s` and `rhel-9.4` variants to start.

The new variants will track the status quo: building SCOS/RHCOS with the
OpenShift components baked in (hence the `okd`/`ocp` prefixes). This is
what the pipeline will keep building.

Meanwhile, what is currently the `c9s` and rhel-9.4` variants will
become the new base SCOS/RHCOS streams containing *purely* CentOS
Stream/RHEL content.

The default variant is still `ocp-rhel-9.4` for now.

---

Make c9s and rhel-9.4 variants be pure C9S/RHEL 9.4 content

This is the second step now in this switcheroo dance (see previous
commit). We make the `c9s` and `rhel-9.4` variants contain only C9S/
RHEL 9.4 content and then make the `okd-c9s` and `ocp-rhel-9.4` variants
inherit from those and add the OCP-specific stuff.

---

Containerfile: new file

This Containerfile allows us to build the OpenShift node image on top
of the base RHCOS/SCOS image (i.e. built from the `c9s` or `rhel-9.4`
image).

Currently, the resulting image is at parity with the base image you'd
get from building the `okd-c9s` or `ocp-rhel-9.4` variant. In the
future, those variants will go away and this will become the only way to
build the node image.

Part of: https://github.com/openshift/os/issues/799