### PR TITLE
NO-JIRA: denylist: drop coreos.ignition.failure test

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -58,10 +58,5 @@
   arches:
     - ppc64le
 
-- pattern: coreos.ignition.failure
-  tracker: https://github.com/coreos/coreos-assembler/issues/3670
-  snooze: 2024-02-05
-  warn: true
-
 - pattern: iso-offline-install-iscsi.bios
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1638


### PR DESCRIPTION
Failure related to this test wasn't observed in a few weeks.

See: https://github.com/coreos/coreos-assembler/issues/3670