### PR TITLE
ci: Use 'centos-release' package to detect if we are testing CentOS S…

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -123,12 +123,7 @@ kola_test_qemu() {
 
     # Skip Secure Boot tests on SCOS for now
     # See: https://github.com/openshift/os/issues/1237
-    if [[ -f "src/config.json" ]]; then
-        variant="$(jq --raw-output '."coreos-assembler.config-variant"' 'src/config.json')"
-    else
-        variant="default"
-    fi
-    if [[ "${variant}" != "scos" ]]; then
+    if rpm-ostree compose tree --print-only "${manifest}" | jq -r '.packages[]' | grep -q "centos-release"; then
         cosa kola --basic-qemu-scenarios
     else
         cosa kola --basic-qemu-scenarios --skip-secure-boot


### PR DESCRIPTION
…tream

Until https://github.com/openshift/os/issues/1237 is resolved, we need to skip Secure Boot tests for CentOS Stream based variants.

As we now use CentOS Stream packages for other variants than the `scos` one for pre-testing, we can not rely on the variant name and instead have to look at the list of included packages to differentiate between RHEL and CentOS Stream based builds.