### PR TITLE
OCPBUGS-29437: install the smaller openshift-kubelet package

### DIFF
--- a/manifest-rhel-9.2.yaml
+++ b/manifest-rhel-9.2.yaml
@@ -127,6 +127,6 @@ repo-packages:
       - cri-o
       - cri-tools
       - openshift-clients
-      - openshift-hyperkube
+      - openshift-kubelet
       # Use legacy coreos/toolbox until we're ready to use containers/toolbox
       - toolbox

--- a/manifest-rhel-9.4.yaml
+++ b/manifest-rhel-9.4.yaml
@@ -21,7 +21,7 @@ repos:
   - baseos
   - appstream
   - rhel-9.2-fast-datapath
-  # Include RHCOS 9 repo for oc, hyperkube
+  # Include RHCOS 9 repo for oc, kubelet
   - rhel-9.2-server-ose-4.16
 
 # We include hours/minutes to avoid version number reuse
@@ -139,4 +139,4 @@ repo-packages:
       - cri-o
       - cri-tools
       - openshift-clients
-      - openshift-hyperkube
+      - openshift-kubelet

--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -2,7 +2,7 @@ packages:
   # The packages below are required by OpenShift/OKD
   # but are not present in CentOS Stream and RHEL.
   - cri-o cri-tools conmon-rs
-  - openshift-clients openshift-hyperkube
+  - openshift-clients openshift-kubelet
   - openvswitch3.1
   # The packages below are present in CentOS Stream/RHEL,
   # and depend on one or more of the above.


### PR DESCRIPTION
The packaging has recently been refactored to offer a kubelet only package, which is all that RHCOS should require. This removes extraneous server binaries kube-apiserver, kube-controller-manager, and kube-scheduler