### PR TITLE
NO-JIRA: denylist: re-snooze `basic` on rhel-9.4

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -3,6 +3,12 @@
 # see: https://github.com/coreos/coreos-assembler/pull/866.
 
 # RHEL 9.4 with CentOS Stream test snooze
+- pattern: basic
+  tracker: https://github.com/openshift/os/issues/1237
+  snooze: 2024-03-18
+  osversion:
+    - rhel-9.4
+
 - pattern: iso-live-login.uefi-secure
   tracker: https://github.com/openshift/os/issues/1237
   snooze: 2024-03-18


### PR DESCRIPTION
Commit 81e5134 relies on logic in the Prow scripts to skip the Secure
Boot basic test, but that logic does not exist in the prod pipelines. So
we still need to snooze the basic test for now.

Once https://github.com/coreos/coreos-assembler/pull/3652 is in, we
should be able to clean this up.

Fixes 81e5134 ("kola-denylist: Do not snooze basic tests anymore").

