### PR TITLE
OCPBUGS-30149: Revert "common.yaml: enable cliwrap"

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -33,10 +33,6 @@ conditional-include:
     # And remove some cruft from grub2
     include: fedora-coreos-config/manifests/grub2-removals.yaml
 
-# we want derivations to be able to type `dnf install ...` for a unified
-# experience
-cliwrap: true
-
 documentation: false
 
 postprocess:


### PR DESCRIPTION
This reverts commit ff686c634bf298ea69785e27cae4de11bb87be6e.

With cliwrap, rpm-ostree runs rpm with less privileges. We special-case `--query`, so e.g. `rpm -qf` still runs with dropped privileges.

But anyway, we actually want to reduce this to wrapping *just* `dnf` for now (see discussions in
https://github.com/coreos/fedora-coreos-config/pull/2887).

Resolves: https://issues.redhat.com/browse/OCPBUGS-30149