### PR TITLE
MCO-392: Re-enable `ostree-container-inject-openshift-cvo-labels` knob

### DIFF
--- a/image-c9s.yaml
+++ b/image-c9s.yaml
@@ -8,7 +8,8 @@ deploy-via-container: true
 # defaulting to `ip=dhcp,dhcp6 rd.neednet=1` when it doesn't see this key.
 ignition-network-kcmdline: []
 
-# In OKD, keep OpenShift metadata on our container image, but xref https://github.com/openshift/os/issues/1047
+# add the requisite OCP metadata to our container image
+# but xref https://github.com/openshift/os/issues/1047
 ostree-container-inject-openshift-cvo-labels: true
 
 # vmware-secure-boot changes the EFI secure boot option.

--- a/image-rhel-9.4.yaml
+++ b/image-rhel-9.4.yaml
@@ -8,6 +8,10 @@ deploy-via-container: true
 # defaulting to `ip=dhcp,dhcp6 rd.neednet=1` when it doesn't see this key.
 ignition-network-kcmdline: []
 
+# add the requisite OCP metadata to our container image
+# but xref https://github.com/openshift/os/issues/1047
+ostree-container-inject-openshift-cvo-labels: true
+
 # vmware-secure-boot changes the EFI secure boot option.
 # set false here due to https://bugzilla.redhat.com/show_bug.cgi?id=2106055
 vmware-secure-boot: false


### PR DESCRIPTION
This was previously enabled (#1048, #1374) and then disabled again (#1084, #1393).

The last time we tried it, the issue was that there were some references remaining in openshift/kubernetes and openshift/release. Those have been cleaned up now:

https://github.com/openshift/release/pull/49156
https://github.com/openshift/kubernetes/pull/1805

So... third time's the charm!