### PR TITLE
COS-2258: prow-entrypoint: kola arg drop `--basic-qemu-scenarios`

### DIFF
--- a/docs/development-rhcos.md
+++ b/docs/development-rhcos.md
@@ -103,7 +103,7 @@ and later. For older versions, see the internal documentation.
 - You may then run tests on the image built with [`kola`][kola]:
   ```
   # Run basic QEMU scenarios
-  $ cosa kola --basic-qemu-scenarios
+  $ cosa kola run basic*
   # Run all kola tests (internal & external)
   $ cosa kola run --parallel 2
   ```

--- a/docs/development-scos.md
+++ b/docs/development-scos.md
@@ -65,7 +65,7 @@ Fedora CoreOS].
 - You may then run tests on the image built with [`kola`][kola]:
   ```
   # Run basic QEMU scenarios
-  $ cosa kola --basic-qemu-scenarios
+  $ cosa kola run basic*
   # Run all kola tests (internal & external)
   $ cosa kola run --parallel 2
   ```


### PR DESCRIPTION
With the pr https://github.com/coreos/coreos-assembler/pull/3652 the argument `basic-qemu-scenarios` are migrated to formal kola tests Additionally update `development` documentation to exercise basic tests using the glob pattern.