### PR TITLE
COS-2748: denylist: enable iscsi iso-offline-install-iscsi.bios

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -130,7 +130,7 @@ kola_test_metal() {
     cosa compress --artifact=metal --artifact=metal4k
 
     # Run all testiso scenarios on metal artifact
-    kola testiso -S --output-dir ${ARTIFACT_DIR:-/tmp}/kola-testiso
+    kola testiso -S --output-dir ${ARTIFACT_DIR:-/tmp}/kola-testiso  --denylist-test iso-offline-install-iscsi*
 }
 
 # Ensure that we can create all platform images for COSA CI

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -23,5 +23,7 @@
   osversion:
     - c9s
 
-- pattern: iso-offline-install-iscsi.bios
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1638
+# This test is failing only in prow, so it's skipped by prow
+# but not denylisted here so it can run on the rhcos pipeline
+#- pattern: iso-offline-install-iscsi.ibft.bios
+#  tracker: https://github.com/openshift/os/issues/1492


### PR DESCRIPTION
The multi-arch tests are skipped in kola code and
the x86 test have been working for some time now
See https://github.com/coreos/coreos-assembler/pull/3705