### PR TITLE
RHEL-29856: Temporarily use mirrored repos for c9s, and pin NetworkManager in rhel-9.4

### DIFF
--- a/c9s.repo
+++ b/c9s.repo
@@ -1,6 +1,8 @@
 [baseos]
 name=CentOS Stream 9 - BaseOS
-baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/BaseOS/$basearch/os
+baseurl=http://mirror.stream.centos.org/9-stream/BaseOS/$basearch/os
+# Revert back to this once rhel-9.4 has been weaned off c9s
+#baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/BaseOS/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1
@@ -8,7 +10,9 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Officia
 
 [appstream]
 name=CentOS Stream 9 - AppStream
-baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/AppStream/$basearch/os
+baseurl=http://mirror.stream.centos.org/9-stream/AppStream/$basearch/os
+# Revert back to this once rhel-9.4 has been weaned off c9s
+#baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/AppStream/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1
@@ -24,7 +28,9 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-Ext
 
 [nfv]
 name=CentOS Stream 9 - NFV
-baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/NFV/$basearch/os
+baseurl=http://mirror.stream.centos.org/9-stream/NFV/$basearch/os
+# Revert back to this once rhel-9.4 has been weaned off c9s
+#baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/NFV/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1
@@ -32,7 +38,9 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Officia
 
 [rt]
 name=CentOS Stream 9 - RT
-baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/RT/$basearch/os
+baseurl=http://mirror.stream.centos.org/9-stream/RT/$basearch/os
+# Revert back to this once rhel-9.4 has been weaned off c9s
+#baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/RT/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1

--- a/manifest-rhel-9.4.yaml
+++ b/manifest-rhel-9.4.yaml
@@ -115,6 +115,9 @@ packages:
  # We include the generic release package and tweak the os-release info in a
  # post-proces script
  - centos-release
+ # Below this are temporary overrides to not get too new content before we retarget RHEL content proper
+ # https://issues.redhat.com/browse/RHEL-29856
+ - NetworkManager-1.46.0-1.el9
 
 # Packages pinned to specific repos in SCOS 9
 repo-packages:


### PR DESCRIPTION
c9s.repo: temporarily use mirrored repos

Unlike the pungi compose output repos, the mirrors have older versions
of RPMs, which we want right now while we're in this weird period where
we'd like to be able to pin to some older content because the newer
stuff will never make it to rhel-9.4 anyway.

---

manifest-rhel-9.4: pin to NetworkManager-1.46.0-1.el9

The latest NM currently in c9s is hitting issues. But anyway, that NM is
not going to end up in 9.4. So let's just temporarily pin to the latest
version that is.

We should be able to clean this up once the rhel-9.4 variant stops
consuming from c9s.

See also: https://issues.redhat.com/browse/RHEL-29856

