### PR TITLE
NO-JIRA: ci/prow-entrypoint: build extensions-container instead

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -113,8 +113,8 @@ cosa_build() {
     cosa fetch
     # Only build the ostree image by default
     cosa build ostree
-    # Build extensions
-    cosa buildextend-extensions
+    # Build extensions container
+    cosa buildextend-extensions-container
 }
 
 # Build QEMU image and run all kola tests


### PR DESCRIPTION
The `cosa buildextend-extensions` command is deprecated and its
output has not been used in RHCOS/OCP for a while. Test the extensions
container instead.

See also https://github.com/coreos/coreos-assembler/pull/3765.

