### PR TITLE
COS-2608: Switch from c9s content to RHEL 9.4 beta content

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -74,21 +74,16 @@ prepare_repos() {
     rhelver=$(rpm-ostree compose tree --print-only "${manifest}" | jq -r '.["automatic-version-prefix"]' | cut -f2 -d.)
 
     # Temporary workaround until we publish builds in the default path
-    if [[ "${rhelver}" == "92" ]]; then
-        prev_build_url="${REDIRECTOR_URL}/${ocpver}-9.2/builds/"
+    if [[ "${rhelver}" == "94" ]]; then
+        prev_build_url="${REDIRECTOR_URL}/${ocpver}-9.4/builds/"
         # Fetch the previous build
         cosa buildfetch --url="${prev_build_url}"
     fi
 
     # Fetch the repos corresponding to the release we are building
     case "${rhelver}" in
-        92)
+        92|94)
             curl --fail -L "http://base-${ocpver_mut}-rhel${rhelver}.ocp.svc.cluster.local" -o "src/config/ocp.repo"
-            cat src/config/ocp.repo
-            ;;
-        94)
-            # For now, the 9.4 variant is mostly C9S, but we do still need some packages from 9.2 repos
-            curl --fail -L "http://base-${ocpver_mut}-rhel92.ocp.svc.cluster.local" -o "src/config/ocp.repo"
             cat src/config/ocp.repo
             ;;
         *)

--- a/extensions-rhel-9.4.yaml
+++ b/extensions-rhel-9.4.yaml
@@ -9,7 +9,7 @@ extensions:
       - x86_64
       - aarch64
     repos:
-      - rhel-9.2-server-ose-4.16
+      - rhel-9.4-server-ose-4.16
     packages:
       - crun-wasm
   # https://github.com/coreos/fedora-coreos-tracker/issues/1504
@@ -52,7 +52,7 @@ extensions:
     architectures:
       - x86_64
     repos:
-      - nfv
+      - rhel-9.4-nfv
     packages:
       - kernel-rt-core
       - kernel-rt-kvm
@@ -69,7 +69,7 @@ extensions:
       - x86_64
       - s390x
     repos:
-      - rhel-9.2-server-ose-4.16
+      - rhel-9.4-server-ose-4.16
     packages:
       - kata-containers
   # https://issues.redhat.com/browse/COS-2402

--- a/manifest-rhel-9.4.yaml
+++ b/manifest-rhel-9.4.yaml
@@ -16,13 +16,12 @@ include:
 
 # Starting from here, everything should be specific to RHCOS based on RHEL 9.4 content
 
-# CentOS Stream 9 repos + internal repos for now
 repos:
-  - baseos
-  - appstream
-  - rhel-9.2-fast-datapath
+  - rhel-9.4-baseos
+  - rhel-9.4-appstream
+  - rhel-9.4-fast-datapath
   # Include RHCOS 9 repo for oc, kubelet
-  - rhel-9.2-server-ose-4.16
+  - rhel-9.4-server-ose-4.16
 
 # We include hours/minutes to avoid version number reuse
 automatic-version-prefix: "416.94.<date:%Y%m%d%H%M>"
@@ -113,22 +112,15 @@ postprocess:
 # constraints that do not apply to SCOS
 packages:
  # We include the generic release package and tweak the os-release info in a
- # post-proces script
- - centos-release
- # Below this are temporary overrides to not get too new content before we retarget RHEL content proper
- # https://issues.redhat.com/browse/RHEL-29856
- - NetworkManager-1.46.0-1.el9
+ # post-process script
+ - redhat-release
 
-# Packages pinned to specific repos in SCOS 9
+# Packages pinned to specific repos in RHCOS 9
 repo-packages:
-  # We always want the kernel from BaseOS
-  - repo: baseos
-    packages:
-      - kernel
-  - repo: appstream
+  - repo: rhel-9.4-appstream
     packages:
       - nss-altfiles
-  - repo: rhel-9.2-server-ose-4.16
+  - repo: rhel-9.4-server-ose-4.16
     packages:
       - conmon-rs
       - cri-o


### PR DESCRIPTION
RHEL 9.4 customer beta is now publicly available.