### PR TITLE
manifests: include kubernetes.yaml

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -6,6 +6,7 @@ include:
   - fedora-coreos-config/manifests/networking-tools.yaml
   - fedora-coreos-config/manifests/user-experience.yaml
   - fedora-coreos-config/manifests/shared-workarounds.yaml
+  - fedora-coreos-config/manifests/kubernetes.yaml
   # RHCOS owned packages
   - packages-rhcos.yaml
 


### PR DESCRIPTION
FCOS had shipped ZRAM-generator for a while but it was not shared with RHCOS. Moved the package to a different sub-manifest that would regroup kubernetes-specific things.
The swap on ZRAM would still need to be actually enabled through a config file [1] but that should be done by the MCO.

[1] https://github.com/systemd/zram-generator/blob/main/man/zram-generator.conf.md

ref: https://github.com/coreos/fedora-coreos-config/pull/2937
ref: https://issues.redhat.com/browse/COS-2507