### PR TITLE
manifest-rhel-9.4: use runc from rhaos repos

### DIFF
--- a/manifest-rhel-9.4.yaml
+++ b/manifest-rhel-9.4.yaml
@@ -135,3 +135,6 @@ repo-packages:
       - cri-tools
       - openshift-clients
       - openshift-kubelet
+      # Carry runc from the rhaos branches, as it has a patch needed for OCPBUGS-30806
+      # and it is too late in the RHEL development cycle to update it in time.
+      - runc 


### PR DESCRIPTION
as the one in RHEL is missing a required patch, and it was decided we'd use the RHAOS one instead [xref](https://redhat-internal.slack.com/archives/C999USB0D/p1712067961154739)