### PR TITLE
COS-2746: common.yaml: add dnf

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -176,8 +176,6 @@ check-groups:
 exclude-packages:
   # https://bugzilla.redhat.com/show_bug.cgi?id=1798278
   - subscription-manager
-  # And this one shouldn't come in
-  - dnf
   # https://github.com/coreos/rpm-ostree/pull/1789/files/a0cd999a8acd5b40ec1024a794a642916fbc8ff8#diff-fc2076dc46933204a7a798f544ce3734
   # People need to use `rpm-ostree kargs` instead.
   - grubby
@@ -253,6 +251,8 @@ packages:
  - crypto-policies-scripts
  # For semanage
  - policycoreutils-python-utils
+ # https://github.com/coreos/fedora-coreos-tracker/issues/1687
+ - dnf
 
 packages-x86_64:
   # Temporary add of open-vm-tools. Should be removed when containerized

--- a/overlay.d/05rhcos/usr/lib/systemd/system-preset/43-manifest-rhcos.preset
+++ b/overlay.d/05rhcos/usr/lib/systemd/system-preset/43-manifest-rhcos.preset
@@ -23,3 +23,7 @@ enable console-login-helper-messages-issuegen.path
 # Enable nmstate. We can drop this when it is in
 # /usr/lib/systemd/system-preset/90-default.preset
 enable nmstate.service
+
+# This unit is not activated on OSTree systems, but it still pulls in
+# `network-online.target`. Explicitly disable it.
+disable dnf-makecache.timer


### PR DESCRIPTION
As per discussions in
https://github.com/coreos/fedora-coreos-tracker/issues/1687, we will add dnf to RHCOS so it can be used for derivation.