### PR TITLE
NO-JIRA: ci: Gate secure boot tests on centos-stream-release

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -122,6 +122,10 @@ kola_test_qemu() {
     # we need to check if the basic.nvme is available in the list of tests
     local args=""
     local manifest="src/config/manifest.yaml"
+    if [[ -f "src/config.json" ]]; then
+        variant="$(jq --raw-output '."coreos-assembler.config-variant"' 'src/config.json')"
+        manifest="src/config/manifest-${variant}.yaml"
+    fi
     if cosa kola list --json | jq -r '.[].Name' | grep -q "basic.nvme"; then
         if rpm-ostree compose tree --print-only "${manifest}" | jq -r '.packages[]' | grep -q "centos-stream-release"; then
             args+="--denylist-test *.uefi-secure"

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -123,11 +123,11 @@ kola_test_qemu() {
     local args=""
     local manifest="src/config/manifest.yaml"
     if cosa kola list --json | jq -r '.[].Name' | grep -q "basic.nvme"; then
-        if rpm-ostree compose tree --print-only "${manifest}" | jq -r '.packages[]' | grep -q "centos-release"; then
+        if rpm-ostree compose tree --print-only "${manifest}" | jq -r '.packages[]' | grep -q "centos-stream-release"; then
             args+="--denylist-test *.uefi-secure"
         fi
     else
-        if ! rpm-ostree compose tree --print-only "${manifest}" | jq -r '.packages[]' | grep -q "centos-release"; then
+        if ! rpm-ostree compose tree --print-only "${manifest}" | jq -r '.packages[]' | grep -q "centos-stream-release"; then
             cosa kola --basic-qemu-scenarios --output-dir ${ARTIFACT_DIR:-/tmp}/kola-basic
         else
             cosa kola --basic-qemu-scenarios --skip-secure-boot --output-dir ${ARTIFACT_DIR:-/tmp}/kola-basic

--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -118,7 +118,7 @@ postprocess:
 packages:
  # We include the generic release package and tweak the os-release info in a
  # post-proces script
- - centos-release
+ - centos-stream-release
  # RPM GPG keys for CentOS SIG repos
  - centos-release-cloud-common
  - centos-release-nfv-common


### PR DESCRIPTION
centos-stream-release now replaces centos-release. Update the package name until CentOS Stream 9 gets the new shim release and finally passes Secure Boot tests.