### PR TITLE
COS-2507: Manifests: disable default ZRAM config 

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -32,6 +32,13 @@ conditional-include:
   - if: basearch != "s390x"
     # And remove some cruft from grub2
     include: fedora-coreos-config/manifests/grub2-removals.yaml
+    #zram default config is in a subpackage in c10s
+    # Meanwhile, remove the default config from the package
+  - if: osversion == "c9s"
+    include: zram-no-defaults.yaml
+  - if: osversion == "rhel-9.4"
+    include: zram-no-defaults.yaml
+
 
 documentation: false
 

--- a/zram-no-defaults.yaml
+++ b/zram-no-defaults.yaml
@@ -1,0 +1,5 @@
+remove-from-packages:
+  # zram-generator-0.3.2 (shipped in centOS 9) provides a default
+  # zram-generator config, we want to disable it
+  - - zram-generator
+    - "/usr/lib/systemd/zram-generator.conf"


### PR DESCRIPTION
In #2937 we moved zram-generator to the system-configuration.yaml
manifest so it's shared with RHCOS.
However in the centOS stream 9 zram-generator-0.3.2 [1] ships a
default config file, resulting in a swap device being created
by default.
This ends up breaking kubelet, until kubernetes 1.30
is released. Removing the default config from the package until
c10s

[1] https://gitlab.com/redhat/centos-stream/rpms/rust-zram-generator/-/blob/c9s/zram-generator.conf?ref_type=heads

----
Builds on #1463 
