### PR TITLE
NO-JIRA: [release-4.15] NO-JIRA: Bump fedora-coreos-config

### DIFF
--- a/tests/kola/files/env-godebug
+++ b/tests/kola/files/env-godebug
@@ -10,9 +10,7 @@ set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
 
-source /etc/os-release
-ostree_conf="/boot/loader.1/entries/ostree-1-${ID}.conf"
-initramfs=/boot$(grep initrd ${ostree_conf} | sed 's/initrd //g')
+initramfs=$(ls /boot/ostree/*/initramfs-*)
 conf="etc/systemd/system.conf.d/10-default-env-godebug.conf"
 tempd=$(mktemp -d)
 # unpack 10-default-env-godebug.conf from initramfs file


### PR DESCRIPTION
Created by [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/openshift-os.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/openshift-os.yml)).

```
Jonathan Lebon (1):
      tests/var-mount/scsi-id: simplify bootloader entry finding
```