### PR TITLE
NO-JIRA: ci/prow-entrypoint.sh: don't use `grep -q` at the end of pipeline

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -126,12 +126,12 @@ kola_test_qemu() {
         variant="$(jq --raw-output '."coreos-assembler.config-variant"' 'src/config.json')"
         manifest="src/config/manifest-${variant}.yaml"
     fi
-    if cosa kola list --json | jq -r '.[].Name' | grep -q "basic.nvme"; then
-        if rpm-ostree compose tree --print-only "${manifest}" | jq -r '.packages[]' | grep -q "centos-stream-release"; then
+    if cosa kola list --json | jq -r '.[].Name' | grep "basic.nvme"; then
+        if rpm-ostree compose tree --print-only "${manifest}" | jq -r '.packages[]' | grep "centos-stream-release"; then
             args+="--denylist-test *.uefi-secure"
         fi
     else
-        if ! rpm-ostree compose tree --print-only "${manifest}" | jq -r '.packages[]' | grep -q "centos-stream-release"; then
+        if ! rpm-ostree compose tree --print-only "${manifest}" | jq -r '.packages[]' | grep "centos-stream-release"; then
             cosa kola --basic-qemu-scenarios --output-dir ${ARTIFACT_DIR:-/tmp}/kola-basic
         else
             cosa kola --basic-qemu-scenarios --skip-secure-boot --output-dir ${ARTIFACT_DIR:-/tmp}/kola-basic


### PR DESCRIPTION
Unlike `grep`, `grep -q` will exit 0 as soon as a match is found. This will cause whatever is writing into `grep` to hit `SIGPIPE`. And if it's not equipped to handle that signal, it'll be terminated and the overall if-condition will always fail due to `-o pipefail`.

See also https://github.com/ostreedev/ostree/pull/3203.