### PR TITLE
NO-JIRA: ci: Remove Secure Boot test workaround

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -115,29 +115,7 @@ cosa_build() {
 # Build QEMU image and run all kola tests
 kola_test_qemu() {
     cosa buildextend-qemu
-
-    # Skip Secure Boot tests on SCOS for now
-    # See: https://github.com/openshift/os/issues/1237
-    # Due to the changes in https://github.com/coreos/coreos-assembler/pull/3652
-    # we need to check if the basic.nvme is available in the list of tests
-    local args=""
-    local manifest="src/config/manifest.yaml"
-    if [[ -f "src/config.json" ]]; then
-        variant="$(jq --raw-output '."coreos-assembler.config-variant"' 'src/config.json')"
-        manifest="src/config/manifest-${variant}.yaml"
-    fi
-    if cosa kola list --json | jq -r '.[].Name' | grep "basic.nvme"; then
-        if rpm-ostree compose tree --print-only "${manifest}" | jq -r '.packages[]' | grep "centos-stream-release"; then
-            args+="--denylist-test *.uefi-secure"
-        fi
-    else
-        if ! rpm-ostree compose tree --print-only "${manifest}" | jq -r '.packages[]' | grep "centos-stream-release"; then
-            cosa kola --basic-qemu-scenarios --output-dir ${ARTIFACT_DIR:-/tmp}/kola-basic
-        else
-            cosa kola --basic-qemu-scenarios --skip-secure-boot --output-dir ${ARTIFACT_DIR:-/tmp}/kola-basic
-        fi
-    fi
-    cosa kola run ${args} --parallel 2 --output-dir ${ARTIFACT_DIR:-/tmp}/kola
+    cosa kola run --parallel 2 --output-dir ${ARTIFACT_DIR:-/tmp}/kola
 }
 
 # Build metal, metal4k & live images and run kola tests

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -3,6 +3,11 @@
 # see: https://github.com/coreos/coreos-assembler/pull/866.
 
 # CentOS Stream specific indefinite snooze
+- pattern: basic.uefi-secure
+  tracker: https://github.com/openshift/os/issues/1237
+  osversion:
+    - c9s
+
 - pattern: iso-live-login.uefi-secure
   tracker: https://github.com/openshift/os/issues/1237
   osversion:

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -2,43 +2,6 @@
 # coreos-assembler to automatically skip some tests. For more information,
 # see: https://github.com/coreos/coreos-assembler/pull/866.
 
-# RHEL 9.4 with CentOS Stream test snooze
-- pattern: basic
-  tracker: https://github.com/openshift/os/issues/1237
-  snooze: 2024-04-01
-  osversion:
-    - rhel-9.4
-
-- pattern: iso-live-login.uefi-secure
-  tracker: https://github.com/openshift/os/issues/1237
-  snooze: 2024-04-01
-  osversion:
-    - rhel-9.4
-
-- pattern: iso-as-disk.uefi-secure
-  tracker: https://github.com/openshift/os/issues/1237
-  snooze: 2024-04-01
-  osversion:
-    - rhel-9.4
-
-- pattern: ext.config.rpm-ostree.replace-rt-kernel
-  tracker: https://github.com/openshift/os/issues/1383
-  snooze: 2024-04-01
-  osversion:
-    - rhel-9.4
-
-- pattern: ext.config.shared.content-origins
-  tracker: https://github.com/openshift/os/issues/1387#issuecomment-1769313807
-  snooze: 2024-04-01
-  osversion:
-    - rhel-9.4
-
-- pattern: ext.config.version.rhel-matches-rhcos-build
-  tracker: https://github.com/openshift/os/issues/1387#issuecomment-1769313807
-  snooze: 2024-04-01
-  osversion:
-    - rhel-9.4
-
 # CentOS Stream specific indefinite snooze
 - pattern: iso-live-login.uefi-secure
   tracker: https://github.com/openshift/os/issues/1237


### PR DESCRIPTION
Update kola denylist with the new tests names.

See: https://github.com/openshift/os/issues/1237
See: https://github.com/coreos/coreos-assembler/pull/3652