### PR TITLE
OCPBUGS-32927: Bump OVS version to 3.3.

### DIFF
--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -3,7 +3,7 @@ packages:
   # but are not present in CentOS Stream and RHEL.
   - cri-o cri-tools conmon-rs
   - openshift-clients openshift-kubelet
-  - openvswitch3.1
+  - openvswitch3.3
   # The packages below are present in CentOS Stream/RHEL,
   # and depend on one or more of the above.
   - NetworkManager-ovs


### PR DESCRIPTION
Open vSwitch 3.3 is going to be a new LTS version.  It contains performance improvements and features required for future releases of OVN.

ovn-kubernetes container image is moving to this version as well, and it's better to keep them in sync.

ovn-kubernetes counterpart: https://github.com/openshift/ovn-kubernetes/pull/2142