### PR TITLE
COS-2902: Add C10s variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ supported:
 
 - `rhel-9.6`: RHEL 9.6-based CoreOS; without OpenShift components.
 - `ocp-rhel-9.6`: RHEL 9.6-based CoreOS; including OpenShift components.
-- `c9s`: CentOS Stream-based CoreOS, without OKD components.
+- `c9s`/`c10s`: CentOS Stream-based CoreOS, without OKD components.
 
 In the future, the `ocp-*` variants will be removed. Instead, OpenShift
 components will be layered by deriving from the `rhel-9.X`/`c9s` images.

--- a/build-node-image.sh
+++ b/build-node-image.sh
@@ -14,6 +14,9 @@ if [ "${OPENSHIFT_CI}" != 0 ]; then
     /run/src/ci/get-ocp-repo.sh /etc/yum.repos.d/ocp.repo
 fi
 
+# add all the repos from the src repo into `/etc/yum.repos.d` so dnf sees them
+cat /run/src/*.repo >> /etc/yum.repos.d/git.repo
+
 source /etc/os-release
 
 # XXX: For SCOS, only allow certain packages to come from ART; everything else
@@ -21,7 +24,7 @@ source /etc/os-release
 if [ $ID = centos ]; then
     # this says: "if the line starts with [.*], turn off printing. if the line starts with [our-repo], turn it on."
     awk "/\[.*\]/{p=0} /\[rhel-9.6-server-ose-4.19\]/{p=1} p" /etc/yum.repos.d/*.repo > /etc/yum.repos.d/okd.repo.tmp
-    sed -i -e 's,rhel-9.6-server-ose-4.19,rhel-9.6-server-ose-4.19-okd,' /etc/yum.repos.d/okd.repo.tmp
+    sed -i -e 's,\[rhel-9.6-server-ose-4.19\],\[rhel-9.6-server-ose-4.19-okd\],' /etc/yum.repos.d/okd.repo.tmp
     echo 'includepkgs=openshift-*,ose-aws-ecr-*,ose-azure-acr-*,ose-gcp-gcr-*' >> /etc/yum.repos.d/okd.repo.tmp
     mv /etc/yum.repos.d/okd.repo{.tmp,}
 fi
@@ -34,10 +37,8 @@ mkdir -p /var/opt
 rpm-ostree experimental compose treefile-apply \
     --var id=$ID /run/src/packages-openshift.yaml
 
-# cleanup the repo file we injected
-if [ "${OPENSHIFT_CI}" != 0 ]; then
-    rm /etc/yum.repos.d/ocp.repo
-fi
+# cleanup any repo files we injected
+rm -f /etc/yum.repos.d/{ocp,git,okd}.repo
 
 find /usr -name '*.pyc.bak' -exec sh -c 'mv $1 ${1%.bak}' _ {} \;
 ostree container commit

--- a/c10s-mirror.repo
+++ b/c10s-mirror.repo
@@ -1,0 +1,36 @@
+# These are the official c10s repos. They are slower to update, but contain older
+# versions of packages, which is useful when pinning for lack of a "coreos-pool"
+# equivalent. When no pinning is needed you may find the compose repo URLs
+# defined in c10s.repo are quicker to get new content.
+
+[c10s-baseos-mirror]
+name=CentOS Stream 10 - BaseOS
+baseurl=https://mirror.stream.centos.org/10-stream/BaseOS/$basearch/os
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial-SHA256
+
+[c10s-appstream-mirror]
+name=CentOS Stream 10 - AppStream
+baseurl=https://mirror.stream.centos.org/10-stream/AppStream/$basearch/os
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial-SHA256
+
+[c10s-nfv-mirror]
+name=CentOS Stream 10 - NFV
+baseurl=https://mirror.stream.centos.org/10-stream/NFV/$basearch/os
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial-SHA256
+
+[c10s-rt-mirror]
+name=CentOS Stream 10 - RT
+baseurl=https://mirror.stream.centos.org/10-stream/RT/$basearch/os
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial-SHA256

--- a/c10s.repo
+++ b/c10s.repo
@@ -1,0 +1,77 @@
+# These are compose repo URLs that represent the latest composes in
+# CentOS Stream 10. Sometimes these repos get content a little faster
+# than the mirror repos defined in c10s-mirror.repo, but they won't
+# have multiple versions of packages, which make them not ideal when
+# needing to pin on older package versions.
+
+[c10s-baseos]
+name=CentOS Stream 10 - BaseOS
+baseurl=https://composes.stream.centos.org/stream-10/production/latest-CentOS-Stream/compose/BaseOS/$basearch/os
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial-SHA256
+
+[c10s-appstream]
+name=CentOS Stream 10 - AppStream
+baseurl=https://composes.stream.centos.org/stream-10/production/latest-CentOS-Stream/compose/AppStream/$basearch/os
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial-SHA256
+
+[c10s-nfv]
+name=CentOS Stream 10 - NFV
+baseurl=https://composes.stream.centos.org/stream-10/production/latest-CentOS-Stream/compose/NFV/$basearch/os
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial-SHA256
+
+[c10s-rt]
+name=CentOS Stream 10 - RT
+baseurl=https://composes.stream.centos.org/stream-10/production/latest-CentOS-Stream/compose/RT/$basearch/os
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial-SHA256
+
+# Note: We can't find a composes.stream.centos.org URL for this repo
+# so we use the mirror.stream.centos.org URL here.
+[c10s-extras-common]
+name=CentOS Stream 10 - Extras packages
+baseurl=https://mirror.stream.centos.org/SIGs/10-stream/extras/$basearch/extras-common
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Extras-SHA512
+
+# Note: We can't find a composes.stream.centos.org URL for this repo
+# so we use the mirror.stream.centos.org URL here.
+[c10s-sig-nfv]
+name=CentOS Stream 10 - SIG NFV
+baseurl=https://mirror.stream.centos.org/SIGs/10-stream/nfv/$basearch/openvswitch-2/
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-NFV
+
+# Note: We can't find a composes.stream.centos.org URL for this repo
+# so we use the mirror.stream.centos.org URL here.
+[c10s-sig-virtualization]
+name=CentOS Stream 10 - SIG Virtualization
+baseurl=https://mirror.stream.centos.org/SIGs/10-stream/virt/$basearch/kata-containers/
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Virtualization
+
+# Note: We can't find a composes.stream.centos.org URL for this repo
+# so we use the mirror.stream.centos.org URL here.
+[c10s-sig-cloud-okd]
+name=CentOS Stream 10 - SIG Cloud OKD 4.19
+baseurl=https://mirror.stream.centos.org/SIGs/10-stream/cloud/$basearch/okd-4.19/
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Cloud

--- a/c9s.repo
+++ b/c9s.repo
@@ -20,19 +20,6 @@ repo_gpgcheck=0
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 
-# Note: We can't find a composes.stream.centos.org URL for this repo
-# so we use the mirror.stream.centos.org URL here.
-[c9s-extras-common]
-name=CentOS Stream 9 - Extras packages
-# Note: the hardcoded x86_64 is not a mistake. Extras just has noarch RPMs that
-# contain GPG keys and repo files but for some reason only the x86_64 repo has
-# them...
-baseurl=https://mirror.stream.centos.org/SIGs/9-stream/extras/x86_64/extras-common
-gpgcheck=1
-repo_gpgcheck=0
-enabled=1
-gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Extras-SHA512
-
 [c9s-nfv]
 name=CentOS Stream 9 - NFV
 baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/NFV/$basearch/os
@@ -48,6 +35,19 @@ gpgcheck=1
 repo_gpgcheck=0
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
+
+# Note: the hardcoded x86_64 is not a mistake. Extras just has noarch RPMs that
+# contain GPG keys and repo files but for some reason only the x86_64 repo has
+# them... Drop hardcoded arch once https://pagure.io/centos-infra/issue/1635 is fixed
+# Note: We can't find a composes.stream.centos.org URL for this repo
+# so we use the mirror.stream.centos.org URL here.
+[c9s-extras-common]
+name=CentOS Stream 9 - Extras packages
+baseurl=https://mirror.stream.centos.org/SIGs/9-stream/extras/x86_64/extras-common
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Extras-SHA512
 
 # Note: We can't find a composes.stream.centos.org URL for this repo
 # so we use the mirror.stream.centos.org URL here.

--- a/c9s.repo
+++ b/c9s.repo
@@ -20,6 +20,8 @@ repo_gpgcheck=0
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 
+# Note: We can't find a composes.stream.centos.org URL for this repo
+# so we use the mirror.stream.centos.org URL here.
 [c9s-extras-common]
 name=CentOS Stream 9 - Extras packages
 # Note: the hardcoded x86_64 is not a mistake. Extras just has noarch RPMs that
@@ -47,6 +49,8 @@ repo_gpgcheck=0
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 
+# Note: We can't find a composes.stream.centos.org URL for this repo
+# so we use the mirror.stream.centos.org URL here.
 [c9s-sig-nfv]
 name=CentOS Stream 9 - SIG NFV
 baseurl=https://mirror.stream.centos.org/SIGs/9-stream/nfv/$basearch/openvswitch-2/
@@ -55,6 +59,8 @@ repo_gpgcheck=0
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-NFV
 
+# Note: We can't find a composes.stream.centos.org URL for this repo
+# so we use the mirror.stream.centos.org URL here.
 [c9s-sig-virtualization]
 name=CentOS Stream 9 - SIG Virtualization
 baseurl=https://mirror.stream.centos.org/SIGs/9-stream/virt/$basearch/kata-containers/
@@ -63,6 +69,8 @@ repo_gpgcheck=0
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Virtualization
 
+# Note: We can't find a composes.stream.centos.org URL for this repo
+# so we use the mirror.stream.centos.org URL here.
 [c9s-sig-cloud-okd]
 name=CentOS Stream 9 - SIG Cloud OKD 4.19
 baseurl=https://mirror.stream.centos.org/SIGs/9-stream/cloud/$basearch/okd-4.19/

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -99,29 +99,6 @@ kola_test_metal() {
     kola testiso -S --output-dir ${ARTIFACT_DIR:-/tmp}/kola-testiso  --denylist-test iso-offline-install-iscsi* --denylist-test pxe-offline-install.rootfs-appended.bios
 }
 
-# Ensure that we can create all platform images for COSA CI
-cosa_buildextend_all() {
-    # Build RHCOS non-qemu artifacts 
-    cosa osbuild   \
-        aliyun     \
-        aws        \
-        azure      \
-        azurestack \
-        dasd       \
-        gcp        \
-        ibmcloud   \
-        kubevirt   \
-        live       \
-        metal      \
-        metal4k    \
-        nutanix    \
-        openstack  \
-
-    # These few still aren't in OSBuild yet
-    cosa buildextend powervs
-    cosa buildextend vmware
-}
-
 # Basic syntaxt validation for manifests
 validate() {
     # Create a temporary copy

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -82,16 +82,14 @@ cosa_build_extensions() {
 
 # Build QEMU image and run all kola tests
 kola_test_qemu() {
-    cosa buildextend-qemu
+    cosa osbuild qemu
     cosa kola run --parallel 2 --output-dir ${ARTIFACT_DIR:-/tmp}/kola --rerun --allow-rerun-success tags=needs-internet "$@"
 }
 
 # Build metal, metal4k & live images and run kola tests
 kola_test_metal() {
     # Build metal + installer now so we can test them
-    cosa buildextend-metal
-    cosa buildextend-metal4k
-    cosa buildextend-live
+    cosa osbuild metal metal4k live
 
     # Compress the metal and metal4k images now so we're testing
     # installs with the image format we ship
@@ -103,30 +101,25 @@ kola_test_metal() {
 
 # Ensure that we can create all platform images for COSA CI
 cosa_buildextend_all() {
-    cosa buildextend-aliyun
-    cosa buildextend-aws
-    cosa buildextend-azure
-    cosa buildextend-azurestack
-    cosa buildextend-dasd
-    cosa buildextend-gcp
-    cosa buildextend-ibmcloud
-    cosa buildextend-kubevirt
-    cosa buildextend-live
-    cosa buildextend-metal
-    cosa buildextend-metal4k
-    cosa buildextend-nutanix
-    cosa buildextend-openstack
-    cosa buildextend-powervs
-    cosa buildextend-vmware
+    # Build RHCOS non-qemu artifacts 
+    cosa osbuild   \
+        aliyun     \
+        aws        \
+        azure      \
+        azurestack \
+        dasd       \
+        gcp        \
+        ibmcloud   \
+        kubevirt   \
+        live       \
+        metal      \
+        metal4k    \
+        nutanix    \
+        openstack  \
 
-    # Will be done in another step
-    # cosa buildextend-qemu
-
-    # Currently not available for RHCOS
-    # cosa buildextend-digitalocean
-    # cosa buildextend-exoscale
-    # cosa buildextend-virtualbox
-    # cosa buildextend-vultr
+    # These few still aren't in OSBuild yet
+    cosa buildextend powervs
+    cosa buildextend vmware
 }
 
 # Basic syntaxt validation for manifests

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -312,10 +312,16 @@ main() {
             kola_test_metal
             ;;
         "scos-10-build-test-qemu")
-            exit 0
+            setup_user
+            cosa_init "c10s"
+            cosa_build
+            kola_test_qemu --tag '!openshift'
             ;;
         "scos-10-build-test-metal")
-            exit 0
+            setup_user
+            cosa_init "c10s"
+            cosa_build
+            kola_test_metal
             ;;
         "rhcos-10-build-test-qemu")
             exit 0

--- a/common.yaml
+++ b/common.yaml
@@ -31,15 +31,15 @@ conditional-include:
   - if: basearch != "s390x"
     # And remove some cruft from grub2
     include: fedora-coreos-config/manifests/grub2-removals.yaml
-  - if: osversion == "c9s"
-    include: manifest-el9-shared.yaml
-  - if: osversion == "rhel-9.6"
-    include: manifest-el9-shared.yaml
   # Packages specific to el9
   - if: osversion == "c9s"
-    include: fedora-coreos-config/manifests/shared-el9.yaml
+    include:
+      - fedora-coreos-config/manifests/shared-el9.yaml
+      - manifest-el9-shared.yaml
   - if: osversion == "rhel-9.6"
-    include: fedora-coreos-config/manifests/shared-el9.yaml
+    include:
+      - fedora-coreos-config/manifests/shared-el9.yaml
+      - manifest-el9-shared.yaml
   - if: inherit_tier_x == true
     include: fedora-coreos-config/manifests/tier-x.yaml
   - if: inherit_tier_x == false
@@ -222,7 +222,6 @@ packages:
  # Bootloader updater
  - bootupd
  # Containers
- - containernetworking-plugins
  - container-selinux
  # Needed for newer rpm-ostree
  - "'skopeo >= 2:1.7.0'"
@@ -253,9 +252,6 @@ packages:
  - qemu-guest-agent
  # passwd was obsoleted by shadow-utils in F40+, but still needed here
  - passwd
- # Gluster - Used for Openshift e2e gluster testcases
- # Reverts https://gitlab.cee.redhat.com/coreos/redhat-coreos/merge_requests/367 and add it for all arches
- - glusterfs-fuse
  # Needed for kernel-devel extension: https://bugzilla.redhat.com/show_bug.cgi?id=1885408
  # x86_64 and s390x have these packages installed as dependencies of other packages, ppc64le does not
  # FIXME: once the below BZs have been resolved to remove perl dependencies, this can be done in the extensions script

--- a/common.yaml
+++ b/common.yaml
@@ -40,6 +40,9 @@ conditional-include:
     include:
       - fedora-coreos-config/manifests/shared-el9.yaml
       - manifest-el9-shared.yaml
+  - if: osversion == "c10s"
+    include:
+      - fedora-coreos-config/manifests/shared-el10.yaml
   - if: inherit_tier_x == true
     include: fedora-coreos-config/manifests/tier-x.yaml
   - if: inherit_tier_x == false

--- a/extensions-okd-c10s.yaml
+++ b/extensions-okd-c10s.yaml
@@ -1,0 +1,103 @@
+# RPMs as operating system extensions, distinct from the base ostree commit/image
+# https://github.com/openshift/enhancements/blob/master/enhancements/rhcos/extensions.md
+# and https://github.com/coreos/fedora-coreos-tracker/issues/401
+
+# RULE: Do not add repos to specific extensions below if the extension is not
+# multi-arch, but the repos are. Instead, put them in the global repos list at
+# the top. Otherwise, we can have consistency issues across arches. See e.g.
+# https://issues.redhat.com/browse/OCPBUGS-52293.
+
+repos:
+  - c10s-sig-nfv
+  # Some of the extensions here have version bindings to host packages. Add the
+  # mirrors since those retain multiple versions of packages in case the latest
+  # compose has already moved since the last base image build.
+  - c10s-baseos-mirror
+  - c10s-appstream-mirror
+  - c10s-nfv-mirror
+  - c10s-rt-mirror
+
+extensions:
+  # https://issues.redhat.com/browse/RFE-4177
+  # wasm:
+  #   architectures:
+  #     - x86_64
+  #     - aarch64
+  #   packages:
+  #     - crun-wasm
+  # https://github.com/coreos/fedora-coreos-tracker/issues/1504
+  ipsec:
+    packages:
+      - libreswan
+      - NetworkManager-libreswan
+      - openvswitch3.5-ipsec
+  # https://github.com/coreos/fedora-coreos-tracker/issues/326
+  usbguard:
+    packages:
+      - usbguard
+  kerberos:
+    packages:
+      - krb5-workstation
+      - libkadm5
+  # https://github.com/kmods-via-containers/kmods-via-containers/issues/3
+  # https://gitlab.cee.redhat.com/coreos/redhat-coreos/merge_requests/866
+  # These are currently overlaid onto the host so that they can be bind-mounted
+  # into build containers... in the future they should be a `development`
+  # extension: https://github.com/openshift/machine-config-operator/pull/2143.
+  kernel-devel:
+    packages:
+      - kernel-devel
+      - kernel-headers
+    match-base-evr: kernel
+  # These are already in the base, so they're not OS extensions, but they're
+  # useful to have in RPM form to install in kmod build containers.
+  kernel:
+    kind: development
+    packages:
+      - kernel
+      - kernel-core
+      - kernel-modules
+      - kernel-modules-extra
+    match-base-evr: kernel
+  # GRPA-2822
+  # https://github.com/openshift/machine-config-operator/pull/1330
+  # https://github.com/openshift/enhancements/blob/master/enhancements/support-for-realtime-kernel.md
+  kernel-rt:
+    architectures:
+      - x86_64
+    repos:
+      # this is not available on all arches, so keep here and not in the global repo list
+      - c10s-nfv
+    packages:
+      - kernel-rt-core
+      - kernel-rt-kvm
+      - kernel-rt-modules
+      - kernel-rt-modules-extra
+      - kernel-rt-devel
+    match-base-evr: kernel
+  # https://github.com/openshift/machine-config-operator/pull/2456
+  # https://github.com/openshift/enhancements/blob/master/enhancements/sandboxed-containers/sandboxed-containers-tech-preview.md
+  # GRPA-3123
+  # kata-containers is not yet shipped in CS10, see https://mirror.stream.centos.org/SIGs/10-stream/virt/x86_64/
+  # Please uncomment the section once available
+  # sandboxed-containers:
+  #   architectures:
+  #     - x86_64
+  #   repos:
+  #     # this is not available on all arches, so keep here and not in the global repo list
+  #     - c10s-sig-virtualization
+  #   packages:
+  #     - kata-containers
+  # https://issues.redhat.com/browse/COS-2402
+  kernel-64k:
+    architectures:
+      - aarch64
+    packages:
+      - kernel-64k-core
+      - kernel-64k-modules
+      - kernel-64k-modules-core
+      - kernel-64k-modules-extra
+  # https://issues.redhat.com/browse/COS-2940
+  sysstat:
+    packages:
+      - sysstat

--- a/extensions-okd-c9s.yaml
+++ b/extensions-okd-c9s.yaml
@@ -8,6 +8,7 @@
 # https://issues.redhat.com/browse/OCPBUGS-52293.
 
 repos:
+  - c9s-sig-nfv
   # Some of the extensions here have version bindings to host packages. Add the
   # mirrors since those retain multiple versions of packages in case the latest
   # compose has already moved since the last base image build.

--- a/extensions-okd-c9s.yaml
+++ b/extensions-okd-c9s.yaml
@@ -8,7 +8,6 @@
 # https://issues.redhat.com/browse/OCPBUGS-52293.
 
 repos:
-  - c9s-sig-virtualization
   # Some of the extensions here have version bindings to host packages. Add the
   # mirrors since those retain multiple versions of packages in case the latest
   # compose has already moved since the last base image build.
@@ -23,8 +22,6 @@ extensions:
   #   architectures:
   #     - x86_64
   #     - aarch64
-  #   repos:
-  #     - appstream
   #   packages:
   #     - crun-wasm
   # https://github.com/coreos/fedora-coreos-tracker/issues/1504
@@ -68,6 +65,7 @@ extensions:
     architectures:
       - x86_64
     repos:
+      # this is not available on all arches, so keep here and not in the global repo list
       - c9s-nfv
     packages:
       - kernel-rt-core
@@ -79,11 +77,11 @@ extensions:
   # https://github.com/openshift/machine-config-operator/pull/2456
   # https://github.com/openshift/enhancements/blob/master/enhancements/sandboxed-containers/sandboxed-containers-tech-preview.md
   # GRPA-3123
-  # - kata-containers
   sandboxed-containers:
     architectures:
       - x86_64
     repos:
+      # this is not available on all arches, so keep here and not in the global repo list
       - c9s-sig-virtualization
     packages:
       - kata-containers

--- a/image-c10s.yaml
+++ b/image-c10s.yaml
@@ -1,0 +1,1 @@
+image-rhel-9.6.yaml

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -7,16 +7,19 @@
   tracker: https://github.com/openshift/os/issues/1237
   osversion:
     - c9s
+    - c10s
 
 - pattern: iso-live-login.uefi-secure
   tracker: https://github.com/openshift/os/issues/1237
   osversion:
     - c9s
+    - c10s
 
 - pattern: iso-as-disk.uefi-secure
   tracker: https://github.com/openshift/os/issues/1237
   osversion:
     - c9s
+    - c10s
 
 # The 4.17 and 4.18 build of Ignition encounters a FIPS panic so
 # we are using the 4.16 build for now while that is under investigation.
@@ -40,5 +43,46 @@
 
 - pattern: ostree.sync
   tracker: https://github.com/openshift/os/issues/1751
+  osversion:
+    - c10s
+
+# Will fail until we have proper RHEL 10 builds of OCP packages
+- pattern: ext.config.version.rhel-major-version
+  tracker: TODO
+  osversion:
+    - c10s
+
+- pattern: multipath.day1
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1894
+  osversion:
+    - c10s
+
+- pattern: multipath.day2
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1894
+  osversion:
+    - c10s
+
+- pattern: multipath.partition
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1894
+  osversion:
+    - c10s
+
+- pattern: iso-offline-install*mpath.bios
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1894
+  osversion:
+    - c10s
+
+- pattern: ext.config.shared.root-reprovision.luks.multipath
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1894
+  osversion:
+    - c10s
+
+- pattern: ext.config.shared.networking.nm-ifcfg-rh-plugin
+  tracker: https://github.com/openshift/os/pull/1759#issuecomment-2779700581
+  osversion:
+    - c10s
+
+- pattern: ext.config.shared.networking.team-dhcp-via-ignition
+  tracker: https://github.com/openshift/os/pull/1759#issuecomment-2779700581
   osversion:
     - c10s

--- a/manifest-c10s.yaml
+++ b/manifest-c10s.yaml
@@ -1,0 +1,33 @@
+# Manifest for CentOS Stream CoreOS 10
+
+metadata:
+  license: MIT
+  name: scos
+  summary: CentOS Stream CoreOS 10
+
+variables:
+  id: "centos"
+  osversion: "c10s"
+  inherit_tier_x: true
+
+# Include manifests common to all RHEL and CentOS Stream versions
+include:
+  - common.yaml
+  - overrides-c10s.yaml
+
+repos:
+  - c10s-baseos
+  - c10s-appstream
+  - c10s-extras-common
+
+automatic-version-prefix: "10.0.<date:%Y%m%d>"
+# This ensures we're semver-compatible which OpenShift wants
+automatic-version-suffix: "-"
+
+mutate-os-release: "10"
+
+packages:
+ - centos-stream-release
+ - centos-release-cloud-common
+ - centos-release-nfv-common
+ - centos-release-virt-common

--- a/manifest-el9-shared.yaml
+++ b/manifest-el9-shared.yaml
@@ -1,5 +1,11 @@
 # Place here configuration that should happen on all el9* builds
 
+packages:
+ - containernetworking-plugins
+ # Gluster - Used for Openshift e2e gluster testcases
+ # Reverts https://gitlab.cee.redhat.com/coreos/redhat-coreos/merge_requests/367 and add it for all arches
+ - glusterfs-fuse
+
 #zram default config is in a subpackage in c10s
 # Meanwhile, remove the default config from the package
 remove-from-packages:

--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips.sh
@@ -69,6 +69,13 @@ finish() {
         fatal "FIPS mode is not enabled."
     fi
 
+    # on EL10 fips-mode-setup was removed and these steps are
+    # no longer needed. Please delete this function and sysroot_bwrap
+    # when EL9 is no longer supported.
+    if [ ! -e /sysroot/usr/bin/fips-mode-setup ]; then
+        return 0
+    fi
+
     # If we're running from a live system, then set things up so that the dracut fips
     # module will find the kernel binary.  TODO change dracut to look in /usr/lib/modules/$(uname -r)
     # directly.

--- a/overrides-c10s.yaml
+++ b/overrides-c10s.yaml
@@ -1,0 +1,10 @@
+# This is a poor man's version of an override lockfile for c10s. When needed, we
+# can enable the mirror repos here (which hold older RPMs) and list the NEVRs
+# we need in the `packages` section. When not needed. Empty or comment out this
+# file (except this comment).
+
+repos:
+ - c10s-baseos-mirror
+ - c10s-appstream-mirror
+
+#packages:

--- a/tests/kola/rpm-ostree/replace-rt-kernel/data/c10s.repo
+++ b/tests/kola/rpm-ostree/replace-rt-kernel/data/c10s.repo
@@ -1,0 +1,43 @@
+# This repo is based on the c10s.repo file at the top-level, but *always* refers
+# to the mirrors and never to the latest compose output. For more information, see:
+# https://github.com/openshift/os/commit/15c7bf96b70b014f6dd55f25195cf1a341b6c6e0
+
+[baseos]
+name=CentOS Stream 10 - BaseOS
+baseurl=https://mirror.stream.centos.org/10-stream/BaseOS/$basearch/os
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial-SHA256
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+
+[appstream]
+name=CentOS Stream 10 - AppStream
+baseurl=https://mirror.stream.centos.org/10-stream/AppStream/$basearch/os
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial-SHA256
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+
+[extras-common]
+name=CentOS Stream 10 - Extras packages
+baseurl=https://mirror.stream.centos.org/SIGs/10-stream/extras/$basearch/extras-common
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Extras-SHA512
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+
+[nfv]
+name=CentOS Stream 10 - NFV
+baseurl=https://mirror.stream.centos.org/10-stream/NFV/$basearch/os
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial-SHA256
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+
+[rt]
+name=CentOS Stream 10 - RT
+baseurl=https://mirror.stream.centos.org/10-stream/RT/$basearch/os
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial-SHA256
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1

--- a/tests/kola/rpm-ostree/replace-rt-kernel/test.sh
+++ b/tests/kola/rpm-ostree/replace-rt-kernel/test.sh
@@ -25,9 +25,15 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     case "${major}" in
         9)
             repo_name=c9s.repo
+            if [ ! -e /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official ]; then
+                runv curl -sSLf https://centos.org/keys/RPM-GPG-KEY-CentOS-Official-SHA256 -o /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official
+            fi
             ;;
         10)
             repo_name=c10s.repo
+            if [ ! -e /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial-SHA256 ]; then
+                runv curl -sSLf https://centos.org/keys/RPM-GPG-KEY-CentOS-Official-SHA256 -o /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial-SHA256
+            fi
             ;;
         *)  fatal "Unhandled major RHEL/SCOS VERSION=${major}"
             ;;
@@ -36,7 +42,6 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     # setup repos
     runv rm -rf /etc/yum.repos.d/*
     runv cp "$KOLA_EXT_DATA/$repo_name" /etc/yum.repos.d/cs.repo
-    runv curl -sSLf https://centos.org/keys/RPM-GPG-KEY-CentOS-Official -o /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official
     # Disable all repos except baseos and appstream as not all of them have support for all RHCOS/SCOS supported architectures
     runv sed -i 's/enabled=1/enabled=0/g' /etc/yum.repos.d/cs.repo
     runv sed -i '/\[baseos\]/,/^ *\[/ s/enabled=0/enabled=1/' /etc/yum.repos.d/cs.repo


### PR DESCRIPTION
c9s: Point image-c9s to image-rhel-9.4

---

c9s: Use RPMs from 9.4 RHAOS repo

---

Revert "c9s.repo: temporarily use mirrored repos"

This reverts commit 88e41a0fef0dbe8e0b2d103cadd37217c8cd0933.

---

DoNotMerge: CI changes to test C10S builds

---

manifests: Add initial c10s based variant

See: https://github.com/openshift/os/issues/1466

---

kola-denylist.yaml: Update for c10s variant

---

c10s.repo: Skip GPG checks for now

---

Corresponding Fedora CoreOS changes: https://github.com/coreos/fedora-coreos-config/pull/3015