### PR TITLE
NO-JIRA: More prep patches for split rhel-coreos-base

### DIFF
--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -42,8 +42,7 @@ postprocess:
      set -xeo pipefail
 
      # Tweak /usr/lib/os-release
-     grep -v "OSTREE_VERSION" /etc/os-release > /usr/lib/os-release.stream
-     OCP_RELEASE="4.16"
+     grep -v -e "OSTREE_VERSION" -e "OPENSHIFT_VERSION" /etc/os-release > /usr/lib/os-release.stream
      (
      . /etc/os-release
      cat > /usr/lib/os-release <<EOF
@@ -51,7 +50,7 @@ postprocess:
      ID="scos"
      ID_LIKE="rhel fedora"
      VERSION="${OSTREE_VERSION}"
-     VERSION_ID="${OCP_RELEASE}"
+     VERSION_ID="${OPENSHIFT_VERSION}"
      VARIANT="CoreOS"
      VARIANT_ID=coreos
      PLATFORM_ID="${PLATFORM_ID}"
@@ -62,10 +61,10 @@ postprocess:
      DOCUMENTATION_URL="https://docs.okd.io/latest/welcome/index.html"
      BUG_REPORT_URL="https://access.redhat.com/labs/rhir/"
      REDHAT_BUGZILLA_PRODUCT="OpenShift Container Platform"
-     REDHAT_BUGZILLA_PRODUCT_VERSION="${OCP_RELEASE}"
+     REDHAT_BUGZILLA_PRODUCT_VERSION="${OPENSHIFT_VERSION}"
      REDHAT_SUPPORT_PRODUCT="OpenShift Container Platform"
-     REDHAT_SUPPORT_PRODUCT_VERSION="${OCP_RELEASE}"
-     OPENSHIFT_VERSION="${OCP_RELEASE}"
+     REDHAT_SUPPORT_PRODUCT_VERSION="${OPENSHIFT_VERSION}"
+     OPENSHIFT_VERSION="${OPENSHIFT_VERSION}"
      OSTREE_VERSION="${OSTREE_VERSION}"
      EOF
      )
@@ -94,24 +93,6 @@ postprocess:
      rm -f /etc/issue /etc/issue.net
      ln -s /usr/lib/issue /etc/issue
      ln -s /usr/lib/issue /etc/issue.net
-
-     # Let's have a non-boring motd, just like CL (although theirs is more subdued
-     # nowadays compared to early versions with ASCII art).  One thing we do here
-     # is add --- as a "separator"; the idea is that any "dynamic" information should
-     # be below that.
-     # See: https://projects.engineering.redhat.com/browse/COREOS-1029
-     . /etc/os-release
-     cat > /etc/motd <<EOF
-     CentOS Stream CoreOS $VERSION
-       Part of OKD ${OPENSHIFT_VERSION}, SCOS is a Kubernetes native operating system
-       managed by the Machine Config Operator (\`clusteroperator/machine-config\`).
-
-     WARNING: Direct SSH access to machines is not recommended; instead,
-     make configuration changes via \`machineconfig\` objects:
-       https://docs.openshift.com/container-platform/${OPENSHIFT_VERSION}/architecture/architecture-rhcos.html
-
-     ---
-     EOF
 
 # Packages that are only in SCOS and not in RHCOS or that have special
 # constraints that do not apply to RHCOS

--- a/manifest-rhel-9.4.yaml
+++ b/manifest-rhel-9.4.yaml
@@ -36,8 +36,7 @@ postprocess:
      set -xeo pipefail
 
      # Tweak /usr/lib/os-release
-     grep -v "OSTREE_VERSION" /etc/os-release > /usr/lib/os-release.rhel
-     OCP_RELEASE="4.16"
+     grep -v -e "OSTREE_VERSION" -e "OPENSHIFT_VERSION" /etc/os-release > /usr/lib/os-release.rhel
      (
      . /etc/os-release
      cat > /usr/lib/os-release <<EOF
@@ -45,7 +44,7 @@ postprocess:
      ID="rhcos"
      ID_LIKE="rhel fedora"
      VERSION="${OSTREE_VERSION}"
-     VERSION_ID="${OCP_RELEASE}"
+     VERSION_ID="${OPENSHIFT_VERSION}"
      VARIANT="CoreOS"
      VARIANT_ID=coreos
      PLATFORM_ID="${PLATFORM_ID}"
@@ -56,10 +55,10 @@ postprocess:
      DOCUMENTATION_URL="https://docs.okd.io/latest/welcome/index.html"
      BUG_REPORT_URL="https://access.redhat.com/labs/rhir/"
      REDHAT_BUGZILLA_PRODUCT="OpenShift Container Platform"
-     REDHAT_BUGZILLA_PRODUCT_VERSION="${OCP_RELEASE}"
+     REDHAT_BUGZILLA_PRODUCT_VERSION="${OPENSHIFT_VERSION}"
      REDHAT_SUPPORT_PRODUCT="OpenShift Container Platform"
-     REDHAT_SUPPORT_PRODUCT_VERSION="${OCP_RELEASE}"
-     OPENSHIFT_VERSION="${OCP_RELEASE}"
+     REDHAT_SUPPORT_PRODUCT_VERSION="${OPENSHIFT_VERSION}"
+     OPENSHIFT_VERSION="${OPENSHIFT_VERSION}"
      RHEL_VERSION=9.4
      OSTREE_VERSION="${OSTREE_VERSION}"
      EOF
@@ -89,24 +88,6 @@ postprocess:
      rm -f /etc/issue /etc/issue.net
      ln -s /usr/lib/issue /etc/issue
      ln -s /usr/lib/issue /etc/issue.net
-
-     # Let's have a non-boring motd, just like CL (although theirs is more subdued
-     # nowadays compared to early versions with ASCII art).  One thing we do here
-     # is add --- as a "separator"; the idea is that any "dynamic" information should
-     # be below that.
-     # See: https://projects.engineering.redhat.com/browse/COREOS-1029
-     . /etc/os-release
-     cat > /etc/motd <<EOF
-     Red Hat Enterprise Linux CoreOS $VERSION
-       Part of OpenShift ${OPENSHIFT_VERSION}, RHCOS is a Kubernetes native operating system
-       managed by the Machine Config Operator (\`clusteroperator/machine-config\`).
-
-     WARNING: Direct SSH access to machines is not recommended; instead,
-     make configuration changes via \`machineconfig\` objects:
-       https://docs.openshift.com/container-platform/${OPENSHIFT_VERSION}/architecture/architecture-rhcos.html
-
-     ---
-     EOF
 
 # Packages that are only in RHCOS and not in SCOS or that have special
 # constraints that do not apply to SCOS

--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -85,3 +85,43 @@ postprocess:
     # Oh right but the MCO overrides that too so...
     mkdir -p /usr/libexec/crio
     ln -sr /usr/bin/conmon /usr/libexec/crio/conmon
+
+  # Inject OpenShift-specific release fields
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    cat >> /usr/lib/os-release <<EOF
+    OPENSHIFT_VERSION="4.16"
+    EOF
+
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    # Let's have a non-boring motd, just like CL (although theirs is more subdued
+    # nowadays compared to early versions with ASCII art).  One thing we do here
+    # is add --- as a "separator"; the idea is that any "dynamic" information should
+    # be below that.
+    # See: https://projects.engineering.redhat.com/browse/COREOS-1029
+    . /etc/os-release
+    # This works around the fact that we can't currently access manifest
+    # variables from postprocess scripts, though we just use the name, since
+    # it's easier.
+    variant=$(jq -r .rojig.name /usr/share/rpm-ostree/treefile.json)
+    if [ $variant = "scos" ]; then
+      colloquial_name=SCOS
+      project_name=OKD
+    else
+      colloquial_name=RHCOS
+      project_name=OpenShift
+    fi
+    cat > /etc/motd <<EOF
+    $NAME CoreOS $OSTREE_VERSION
+      Part of ${project_name} ${OPENSHIFT_VERSION}, ${colloquial_name} is a Kubernetes-native operating system
+      managed by the Machine Config Operator (\`clusteroperator/machine-config\`).
+
+    WARNING: Direct SSH access to machines is not recommended; instead,
+    make configuration changes via \`machineconfig\` objects:
+      https://docs.openshift.com/container-platform/${OPENSHIFT_VERSION}/architecture/architecture-rhcos.html
+
+    ---
+    EOF

--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -57,7 +57,22 @@ postprocess:
     # that stopped working in the sysusers conversion. We should be able to drop this
     # when a bug gets fixed in systemd: https://github.com/openshift/os/issues/1274#issuecomment-1605507390
     if [ -f /usr/lib/sysusers.d/openvswitch-hugetlbfs.conf ]; then
+        if [ -f /run/.containerenv ]; then
+            # We're running as part of a derivation; `usermod` will not work
+            # because it doesn't go through NSS. Hackily put the /usr/lib files
+            # in /etc temporarily then put them back
+            mv /etc/passwd /etc/passwd.bak
+            mv /etc/group /etc/group.bak
+            mv /usr/lib/passwd /etc/passwd
+            mv /usr/lib/group /etc/group
+        fi
         usermod -a -G hugetlbfs openvswitch
+        if [ -f /run/.containerenv ]; then
+            mv /etc/passwd /usr/lib/passwd
+            mv /etc/group /usr/lib/group
+            mv /etc/passwd.bak /etc/passwd
+            mv /etc/group.bak /etc/group
+        fi
     fi
 
   - |


### PR DESCRIPTION
This is prep for https://github.com/openshift/os/pull/1445, which I'm working on updating soon.