### PR TITLE
NO-JIRA: tests/replace-rt-kernel: fix and improve

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -18,11 +18,6 @@
   osversion:
     - c9s
 
-- pattern: ext.config.rpm-ostree.replace-rt-kernel
-  tracker: https://github.com/openshift/os/issues/1315
-  osversion:
-    - c9s
-
 # This test is failing only in prow, so it's skipped by prow
 # but not denylisted here so it can run on the rhcos pipeline
 #- pattern: iso-offline-install-iscsi.ibft.bios

--- a/tests/kola/rpm-ostree/replace-rt-kernel/data/c9s.repo
+++ b/tests/kola/rpm-ostree/replace-rt-kernel/data/c9s.repo
@@ -1,0 +1,63 @@
+[baseos]
+name=CentOS Stream 9 - BaseOS
+baseurl=http://mirror.stream.centos.org/9-stream/BaseOS/$basearch/os
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official
+
+[appstream]
+name=CentOS Stream 9 - AppStream
+baseurl=http://mirror.stream.centos.org/9-stream/AppStream/$basearch/os
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official
+
+[extras-common]
+name=CentOS Stream 9 - Extras packages
+baseurl=https://mirror.stream.centos.org/SIGs/9-stream/extras/$basearch/extras-common
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official
+
+[nfv]
+name=CentOS Stream 9 - NFV
+baseurl=http://mirror.stream.centos.org/9-stream/NFV/$basearch/os
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official
+
+[rt]
+name=CentOS Stream 9 - RT
+baseurl=http://mirror.stream.centos.org/9-stream/RT/$basearch/os
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official
+
+[sig-nfv]
+name=CentOS Stream 9 - SIG NFV
+baseurl=https://mirror.stream.centos.org/SIGs/9-stream/nfv/$basearch/openvswitch-2/
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official
+
+[sig-virtualization]
+name=CentOS Stream 9 - SIG Virtualization
+baseurl=https://mirror.stream.centos.org/SIGs/9-stream/virt/$basearch/kata-containers/
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official
+
+[sig-cloud-okd]
+name=CentOS Stream 9 - SIG Cloud OKD 4.15
+baseurl=https://mirror.stream.centos.org/SIGs/9-stream/cloud/$basearch/okd-4.15/
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official

--- a/tests/kola/rpm-ostree/replace-rt-kernel/data/commonlib.sh
+++ b/tests/kola/rpm-ostree/replace-rt-kernel/data/commonlib.sh
@@ -1,0 +1,1 @@
+../../../../../fedora-coreos-config/tests/kola/data/commonlib.sh


### PR DESCRIPTION
It's a bit odd to have this test pull the `c9s.repo` yum repo from the
master branch of openshift/os. We don't want to be in a situation where
a change in master breaks older branches.

But also, `c9s.repo` could at any point in time refer to either the
latest compose output or the official mirrors. But we always want to
use the official mirrors for this test since that has multiple package
versions and we need to be able to select a kernel version which is not
equal to ours.

We could curl the official `centos.repo` file (and actually, in the
SCOS case, it's already in the image), but that file doesn't include
additional repos like `rt` and `nfv` which we need for our test.

Instead, just bake the config into the test data. That way we don't need
to curl anything at all, and the repo definition is naturally bound to
the test and can be modified together atomically.

A few additional changes:
1. only do all the repo preparations stuff on the first boot
2. add logic to pick a kernel that's different from the one we're on if
   we're already CentOS-based (this fixes #1383)
3. add a stub for c10s for when we're ready

Closes: #1383

