### PR TITLE
OCPBUGS-34026: [release-4.16] gitmodules: track rhcos-4.16 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "fedora-coreos-config"]
 	path = fedora-coreos-config
 	url = https://github.com/coreos/fedora-coreos-config
-	branch = testing-devel
+	branch = rhcos-4.16

--- a/c9s-mirror.repo
+++ b/c9s-mirror.repo
@@ -1,0 +1,35 @@
+# These are the official c9s repos. They are slower to update, but contain older
+# versions of packages, which is useful when pinning for lack of a "coreos-pool"
+# equivalent. They are unused when no pinning is needed.
+
+[c9s-baseos-mirror]
+name=CentOS Stream 9 - BaseOS
+baseurl=http://mirror.stream.centos.org/9-stream/BaseOS/$basearch/os
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+
+[c9s-appstream-mirror]
+name=CentOS Stream 9 - AppStream
+baseurl=http://mirror.stream.centos.org/9-stream/AppStream/$basearch/os
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+
+[c9s-nfv-mirror]
+name=CentOS Stream 9 - NFV
+baseurl=http://mirror.stream.centos.org/9-stream/NFV/$basearch/os
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
+
+[c9s-rt-mirror]
+name=CentOS Stream 9 - RT
+baseurl=http://mirror.stream.centos.org/9-stream/RT/$basearch/os
+gpgcheck=1
+repo_gpgcheck=0
+enabled=1
+gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -167,13 +167,18 @@ validate() {
     workdir="$(mktemp -d)"
     echo "Using $workdir as working directory"
 
+    # for `git config --global` below
+    export HOME=${workdir}
+
     # Figure out if we are running from the COSA image or directly from the Prow src image
     if [[ -d /src/github.com/openshift/os ]]; then
         cd "$workdir"
+        git config --global --add safe.directory /src/github.com/openshift/os
         git clone /src/github.com/openshift/os os
     elif [[ -d ./.git ]]; then
         srcdir="${PWD}"
         cd "$workdir"
+        git config --global --add safe.directory "${srcdir}/.git"
         git clone "${srcdir}" os
     else
         echo "Could not found source directory"

--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -13,6 +13,7 @@ variables:
 include:
   - common.yaml
   - packages-openshift.yaml
+  - overrides-c9s.yaml
 
 # Starting from here, everything should be specific to SCOS
 

--- a/overrides-c9s.yaml
+++ b/overrides-c9s.yaml
@@ -1,0 +1,12 @@
+# This is a poor man's version of an override lockfile for c9s. When needed, we
+# can enable the mirror repos here (which hold older RPMs) and list the NEVRs
+# we need in the `packages` section. When not needed. Empty or comment out this
+# file (except this comment).
+
+repos:
+  - c9s-baseos-mirror
+  - c9s-appstream-mirror
+
+packages:
+  # https://github.com/openshift/os/issues/1514
+  - selinux-policy-38.1.36-1.el9


### PR DESCRIPTION
Start tracking the rhcos-4.16 branch of fedora-coreos-config as a part of branching 4.16.