### PR TITLE
COS-2613: [release-4.14]: kola: fix rhaos-pkgs-match-openshift

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -180,13 +180,18 @@ validate() {
     workdir="$(mktemp -d)"
     echo "Using $workdir as working directory"
 
+    # for `git config --global` below
+    export HOME=${workdir}
+
     # Figure out if we are running from the COSA image or directly from the Prow src image
     if [[ -d /src/github.com/openshift/os ]]; then
         cd "$workdir"
+        git config --global --add safe.directory /src/github.com/openshift/os
         git clone /src/github.com/openshift/os os
     elif [[ -d ./.git ]]; then
         srcdir="${PWD}"
         cd "$workdir"
+        git config --global --add safe.directory "${srcdir}/.git"
         git clone "${srcdir}" os
     else
         echo "Could not found source directory"

--- a/tests/kola/version/rhaos-pkgs-match-openshift
+++ b/tests/kola/version/rhaos-pkgs-match-openshift
@@ -9,6 +9,11 @@ set -xeuo pipefail
 
 . $KOLA_EXT_DATA/commonlib.sh
 
-if [[ $(rpm -qa | grep rhaos | grep -v $OPENSHIFT_VERSION) ]]; then
+# source the environment variables to get OPENSHIFT_VERSION
+source /etc/os-release
+
+rpm -qa | grep "rhaos" > /tmp/rhaos-packages.txt
+
+if grep -v "rhaos${OPENSHIFT_VERSION}" /tmp/rhaos-packages.txt; then
     fatal "Error: rhaos packages do not match OpenShift version"
 fi


### PR DESCRIPTION
See: https://github.com/openshift/os/issues/1427

Co-authored-by: Clement Verna <cverna@users.noreply.github.com>
(cherry picked from commit 219d60f52eece0b09339d0f8568d06cf2553a575)

ci/prow-entrypoint: tell git repo under /src is safe
That directory is part of the image and so not owned by us. Likely the
base image used for the src container was updated recently to include
newer git.

(cherry picked from commit https://github.com/openshift/os/commit/630d3f3d9c530c238e03c93210598101eafca266)