### PR TITLE
[release-4.16] c9s.repo: Use okd-4.16 yum repo

### DIFF
--- a/c9s.repo
+++ b/c9s.repo
@@ -55,8 +55,8 @@ enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-Virtualization
 
 [c9s-sig-cloud-okd]
-name=CentOS Stream 9 - SIG Cloud OKD 4.15
-baseurl=https://mirror.stream.centos.org/SIGs/9-stream/cloud/$basearch/okd-4.15/
+name=CentOS Stream 9 - SIG Cloud OKD 4.16
+baseurl=https://mirror.stream.centos.org/SIGs/9-stream/cloud/$basearch/okd-4.16/
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1


### PR DESCRIPTION
This is required for outside-of-Prow SCOS composes