### PR TITLE
[release-4.15] OCPBUGS-35749: Bump fedora-coreos-config

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -180,13 +180,18 @@ validate() {
     workdir="$(mktemp -d)"
     echo "Using $workdir as working directory"
 
+    # for `git config --global` below
+    export HOME=${workdir}
+
     # Figure out if we are running from the COSA image or directly from the Prow src image
     if [[ -d /src/github.com/openshift/os ]]; then
         cd "$workdir"
+        git config --global --add safe.directory /src/github.com/openshift/os
         git clone /src/github.com/openshift/os os
     elif [[ -d ./.git ]]; then
         srcdir="${PWD}"
         cd "$workdir"
+        git config --global --add safe.directory "${srcdir}/.git"
         git clone "${srcdir}" os
     else
         echo "Could not found source directory"


### PR DESCRIPTION
Created by [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/openshift-os.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/openshift-os.yml)).

```
Jonathan Lebon (1):
      overlays: drop `coreos-multipath-trigger.service`
```