### PR TITLE
tests/kola/version/rhel-major-version: adapt for pure RHEL variants

### DIFF
--- a/tests/kola/version/rhel-major-version
+++ b/tests/kola/version/rhel-major-version
@@ -16,6 +16,9 @@ case "${variant}" in
     "scos")
         osver="$(source /usr/lib/os-release.stream; echo "${VERSION}")"
         ;;
+    "rhel")
+        osver="$(source /etc/os-release; echo "${VERSION_ID}" | cut -d. -f1 )"
+        ;;
     "rhcos")
         osver="$(source /usr/lib/os-release.rhel; echo "${VERSION}" | cut -d. -f1 )"
         ;;


### PR DESCRIPTION
This probably should've been part of 4e09d27 ("Make c9s and rhel-9.4 variants be pure C9S/RHEL 9.4 content"), which edited that same test for the for pure CentOS Stream variant.