### PR TITLE
NO-JIRA: kola-denylist: add fips.* and ext.config.shared.networking.* on c9s

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -23,6 +23,11 @@
   osversion:
     - c9s
 
+- pattern: ext.config.shared.networking.*
+  tracker: https://issues.redhat.com/browse/RHEL-47033
+  osversion:
+    - c9s
+
 # we're missing a cri-o rebuild for 4.17, which blocks on buildroot issues
 - pattern: ext.config.version.rhaos-pkgs-match-openshift
   tracker: https://issues.redhat.com/browse/RHEL-35883

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -18,6 +18,11 @@
   osversion:
     - c9s
 
+- pattern: fips.*
+  tracker: https://github.com/openshift/os/issues/1540
+  osversion:
+    - c9s
+
 # we're missing a cri-o rebuild for 4.17, which blocks on buildroot issues
 - pattern: ext.config.version.rhaos-pkgs-match-openshift
   tracker: https://issues.redhat.com/browse/RHEL-35883


### PR DESCRIPTION
We're currently hitting OpenSSL issues there:
https://github.com/openshift/os/issues/1540

---

kola-denylist: add ext.config.shared.networking.* on c9s

A bunch of tests are failing because `systemd-network-generator.service`
is hitting SELinux denials:

https://issues.redhat.com/browse/RHEL-47033

Some of these tests are testing things that don't strictly need that
service, but test kargs that trigger it anyway. Other tests do (e.g.
`ifname=`) and so that functionality is indeed currently broken on c9s.

That said, there's continuing requests to have preliminary c9s
bootimages for testing. So let's not block on this issue for now.

