### PR TITLE
NO-JIRA: extensions/Dockerfile: bump builder to f40

### DIFF
--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -20,7 +20,7 @@ RUN if [[ -n "${VARIANT}" ]]; then MANIFEST="manifest-${VARIANT}.yaml"; EXTENSIO
 ## Creates the repo metadata for the extensions.
 ## This uses Fedora as a lowest-common-denominator because it will work on
 ## current p8/s390x. See https://github.com/openshift/os/issues/1000
-FROM quay.io/fedora/fedora:38 as builder
+FROM quay.io/fedora/fedora:40 as builder
 COPY --from=os /usr/share/rpm-ostree/extensions/ /usr/share/rpm-ostree/extensions/
 RUN dnf install -y createrepo_c
 RUN createrepo_c /usr/share/rpm-ostree/extensions/


### PR DESCRIPTION
Fedora 38 is EOL and the repos are no longer accessible at the canonical locations.

This should probably be part of our FCOS rebase checklist.