### PR TITLE
[release-4.14] NO-JIRA: denylist: add dhcp-propagation and podman.rootless-systemd

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -28,3 +28,9 @@
   tracker: https://github.com/openshift/os/issues/1237
   osversion:
   - c9s
+
+- pattern: ext.config.shared.podman.rootless-systemd
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1760
+
+- pattern: ext.config.shared.ntp.chrony.dhcp-propagation
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1761


### PR DESCRIPTION
In 4.14, these tests are using the F38 container. The F38 content was moved to the archive on the mirrors but the metalinks still reference the non-archive URLs causing these tests to fail.

Let's denylist them for now until https://pagure.io/releng/issue/12204 is resolved.