### PR TITLE
OKD-223: Load custom SELinux rules in SCOS and workaround afterburn failures

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -18,6 +18,11 @@
   osversion:
     - c9s
 
+- pattern: fips.*
+  tracker: https://github.com/openshift/os/issues/1540
+  osversion:
+    - c9s
+
 # we're missing a cri-o rebuild for 4.17, which blocks on buildroot issues
 - pattern: ext.config.version.rhaos-pkgs-match-openshift
   tracker: https://issues.redhat.com/browse/RHEL-35883

--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -26,3 +26,23 @@ mutate-os-release: "9"
 
 packages:
  - centos-stream-release
+
+postprocess:
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    cat > /tmp/scos-workarounds.cil << EOF
+    ; https://issues.redhat.com/browse/RHEL-49735
+    (typeattributeset cil_gen_require afterburn_t)
+    (typepermissive afterburn_t)
+
+    ; https://issues.redhat.com/browse/RHEL-38614
+    (typeattributeset cil_gen_require coreos_installer_t)
+    (typepermissive coreos_installer_t)
+
+    ; https://issues.redhat.com/browse/RHEL-47033
+    (typeattributeset cil_gen_require systemd_network_generator_t)
+    (typepermissive systemd_network_generator_t)
+    EOF
+    /usr/sbin/semodule -i /tmp/scos-workarounds.cil
+    rm /tmp/scos-workarounds.cil


### PR DESCRIPTION
Recent changes in the SELinux policy to make more service confined has
broken a lot of our code. The SELinux team is working through relaxing
the policy, but in the meantime, let's revert back the affected types to
permissive mode:

1. afterburn fail when trying to write to `/run`, `/run/metadata` and
   `/home/$user/.ssh`.
   See: https://issues.redhat.com/browse/RHEL-49735
2. coreos-installer installation fails due to various denials.
   See: https://issues.redhat.com/browse/RHEL-38614
3. network functionality that rely on systemd-network-generator is
   broken due to the latter being unable to create temporary files.
   See: https://issues.redhat.com/browse/RHEL-47033