### PR TITLE
OCPBUGS-35247: common.yaml: add subscription-manager

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -189,8 +189,6 @@ check-groups:
   filename: "group"
 
 exclude-packages:
-  # https://bugzilla.redhat.com/show_bug.cgi?id=1798278
-  - subscription-manager
   # https://github.com/coreos/rpm-ostree/pull/1789/files/a0cd999a8acd5b40ec1024a794a642916fbc8ff8#diff-fc2076dc46933204a7a798f544ce3734
   # People need to use `rpm-ostree kargs` instead.
   - grubby
@@ -268,6 +266,8 @@ packages:
  - policycoreutils-python-utils
  # https://github.com/coreos/fedora-coreos-tracker/issues/1687
  - dnf
+ # https://issues.redhat.com/browse/OCPBUGS-35247
+ - subscription-manager
 
 packages-x86_64:
   # Temporary add of open-vm-tools. Should be removed when containerized


### PR DESCRIPTION
We currently ship dnf in RHCOS but it's cumbersome to use because the
librhsm magic we had for rpm-ostree to make content available during
builds on a subscribed node doesn't work with dnf. For that, it seems
like we need full-blown subscription-manager in the container image.

Add it.

This matches centos-bootc/rhel-bootc shipping subman as well, though I'd
like in the future to investigate lowering the dependency requirements
to just a dnf plugin + librhsm.

Fixes: https://issues.redhat.com/browse/OCPBUGS-35247