### PR TITLE
NO-JIRA: extensions/Dockerfile: fix for okd-c9s variant

### DIFF
--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -10,7 +10,7 @@ ARG COSA
 ARG VARIANT
 RUN if [[ -z "$COSA" ]] ; then ci/get-ocp-repo.sh ; fi
 # on SCOS, we need to add the GPG keys of the various SIGs we need
-RUN if rpm -q centos-stream-release; then dnf install -y centos-release-{cloud,nfv,virt}-common; fi
+RUN if rpm -q centos-stream-release && ! rpm -q centos-release-cloud; then dnf install -y centos-release-{cloud,nfv,virt}-common; fi
 RUN mkdir -p /usr/share/distribution-gpg-keys/centos
 RUN ln -s /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial /usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
 RUN ln -s {/etc/pki/rpm-gpg,/usr/share/distribution-gpg-keys/centos}/RPM-GPG-KEY-CentOS-SIG-Cloud


### PR DESCRIPTION
In fc9e703 ("extensions/Dockerfile: install SIG GPG keys on CentOS"), we
fixed the extensions container build for the `c9s` variant, but that
broke it for the `okd-c9s` variant, which CI currently still tests.

We should switch CI over to target the `c9s` variant and get rid of
`okd-c9s`, but for now at least let's keep it happy.

The problem is that in the `okd-c9s` variant, we disable all the repos
as part of `packages-openshift.yaml`. But anyway, we also already
include the various release packages containing the GPG keys there, so
we can skip this step entirely.

Fixes fc9e703 ("extensions/Dockerfile: install SIG GPG keys on CentOS").
Fixes: #1564