### PR TITLE
NO-JIRA: Revert "c9s: work around various SELinux issues"

### DIFF
--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -26,23 +26,3 @@ mutate-os-release: "9"
 
 packages:
  - centos-stream-release
-
-postprocess:
-  - |
-    #!/usr/bin/env bash
-    set -xeuo pipefail
-    cat > /tmp/scos-workarounds.cil << EOF
-    ; https://issues.redhat.com/browse/RHEL-49735
-    (typeattributeset cil_gen_require afterburn_t)
-    (typepermissive afterburn_t)
-
-    ; https://issues.redhat.com/browse/RHEL-38614
-    (typeattributeset cil_gen_require coreos_installer_t)
-    (typepermissive coreos_installer_t)
-
-    ; https://issues.redhat.com/browse/RHEL-47033
-    (typeattributeset cil_gen_require systemd_network_generator_t)
-    (typepermissive systemd_network_generator_t)
-    EOF
-    /usr/sbin/semodule -i /tmp/scos-workarounds.cil
-    rm /tmp/scos-workarounds.cil


### PR DESCRIPTION
This reverts commit 9ba8b7129f086c7618fcd3136d738cdae1df57b7.

All the issues here should be fixed by selinux-policy-38.1.44-1.el9 according to the linked tickets. So we shouldn't need this anymore.