### PR TITLE
OCPBUGS-38501: gitmodules: track rhcos-4.17 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "fedora-coreos-config"]
 	path = fedora-coreos-config
 	url = https://github.com/coreos/fedora-coreos-config
-	branch = testing-devel
+	branch = rhcos-4.17


### PR DESCRIPTION
Start tracking the rhcos-4.17 branch of fedora-coreos-config as a part of branching 4.18