### PR TITLE
COS-2758: ITUP Cluster Migration - Use HTTPS where possible

### DIFF
--- a/c9s-mirror.repo
+++ b/c9s-mirror.repo
@@ -4,7 +4,7 @@
 
 [c9s-baseos-mirror]
 name=CentOS Stream 9 - BaseOS
-baseurl=http://mirror.stream.centos.org/9-stream/BaseOS/$basearch/os
+baseurl=https://mirror.stream.centos.org/9-stream/BaseOS/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1
@@ -12,7 +12,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Officia
 
 [c9s-appstream-mirror]
 name=CentOS Stream 9 - AppStream
-baseurl=http://mirror.stream.centos.org/9-stream/AppStream/$basearch/os
+baseurl=https://mirror.stream.centos.org/9-stream/AppStream/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1
@@ -20,7 +20,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Officia
 
 [c9s-nfv-mirror]
 name=CentOS Stream 9 - NFV
-baseurl=http://mirror.stream.centos.org/9-stream/NFV/$basearch/os
+baseurl=https://mirror.stream.centos.org/9-stream/NFV/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1
@@ -28,7 +28,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Officia
 
 [c9s-rt-mirror]
 name=CentOS Stream 9 - RT
-baseurl=http://mirror.stream.centos.org/9-stream/RT/$basearch/os
+baseurl=https://mirror.stream.centos.org/9-stream/RT/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1

--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -24,6 +24,8 @@ RUN if [[ -n "${VARIANT}" ]]; then MANIFEST="manifest-${VARIANT}.yaml"; EXTENSIO
 ## current p8/s390x. See https://github.com/openshift/os/issues/1000
 FROM quay.io/fedora/fedora:40 as builder
 COPY --from=os /usr/share/rpm-ostree/extensions/ /usr/share/rpm-ostree/extensions/
+RUN rm -f /etc/yum.repos.d/*.repo \
+&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora.repo -o /etc/yum.repos.d/fedora.repo
 RUN dnf install -y createrepo_c
 RUN createrepo_c /usr/share/rpm-ostree/extensions/
 

--- a/tests/kola/rpm-ostree/replace-rt-kernel/data/c9s.repo
+++ b/tests/kola/rpm-ostree/replace-rt-kernel/data/c9s.repo
@@ -4,7 +4,7 @@
 
 [baseos]
 name=CentOS Stream 9 - BaseOS
-baseurl=http://mirror.stream.centos.org/9-stream/BaseOS/$basearch/os
+baseurl=https://mirror.stream.centos.org/9-stream/BaseOS/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1
@@ -12,7 +12,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official
 
 [appstream]
 name=CentOS Stream 9 - AppStream
-baseurl=http://mirror.stream.centos.org/9-stream/AppStream/$basearch/os
+baseurl=https://mirror.stream.centos.org/9-stream/AppStream/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1
@@ -28,7 +28,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official
 
 [nfv]
 name=CentOS Stream 9 - NFV
-baseurl=http://mirror.stream.centos.org/9-stream/NFV/$basearch/os
+baseurl=https://mirror.stream.centos.org/9-stream/NFV/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1
@@ -36,7 +36,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official
 
 [rt]
 name=CentOS Stream 9 - RT
-baseurl=http://mirror.stream.centos.org/9-stream/RT/$basearch/os
+baseurl=https://mirror.stream.centos.org/9-stream/RT/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1


### PR DESCRIPTION
These commits are needed in order to migrate the RHCOS build pipeline to the new ITUP cluster. They deal with modifying our configuration to only use HTTPS where possible since the ITUP cluster restricts the use of HTTP on port 80.

@aaradhak and I have been using these commits in a fork of this repo for testing on the cluster. We've worked out most of the issues, so let's merge them now.

```
commit 8301c67176e71ff2c6c5236109c89a149422a592
Author: Michael Armijo <marmijo@redhat.com>
Date:   Thu Jul 18 17:59:22 2024 -0600

    extensions/Dockerfile: use the FCOS defined fedora.repo to set up container
    
    Use the fedora.repo file defined in fedora-coreos-config to set up the
    container. This will force packages to be downloaded from
    dl.fedoraproject.org, as specified in the FCOS file. The ITUP cluster,
    being used by the RHCOS pipeline, requires all outbound connections
    to be specified in a Firewall Egress file, and this will ensure the
    same connection will always be used.

commit 761db82968b0caf82ce5cf7761c9bef970097237
Author: Michael Armijo <marmijo@redhat.com>
Date:   Mon Jun 24 14:19:27 2024 -0600

    c9s-mirror.repo: use https for repo baseurl
    
    We use https in the main c9s.repo file, so let's use it here
    too to be consistent. Also, the RHCOS pipeline is migrating
    to a new ITUP cluster which is restricting port 80, so
    lets just use HTTPS on port 443 which is already open.
    
    Co-authored-by: Aashish Radhakrishnan <aaradhak@redhat.com>

commit 9d4fa02d9664386f9fa137221886b8321fc1c2d9
Author: Michael Armijo <marmijo@redhat.com>
Date:   Thu Jun 20 13:28:59 2024 -0600

    tests/replace-rt-kernel: use https for baseurl for repos
    
    We use https in the main c9s.repo file, so let's use it here
    too to be consistent. Also, the RHCOS pipeline is migrating
    to a new ITUP cluster which is restricting port 80, so
    lets just use HTTPS on port 443 which is already open.
    
    Co-authored-by: Aashish Radhakrishnan <aaradhak@redhat.com>
```