### PR TITLE
[Release 4.17] NO-JIRA: ITUP Cluster Migration - Use HTTPS where possible

### DIFF
--- a/c9s-mirror.repo
+++ b/c9s-mirror.repo
@@ -4,7 +4,7 @@
 
 [c9s-baseos-mirror]
 name=CentOS Stream 9 - BaseOS
-baseurl=http://mirror.stream.centos.org/9-stream/BaseOS/$basearch/os
+baseurl=https://mirror.stream.centos.org/9-stream/BaseOS/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1
@@ -12,7 +12,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Officia
 
 [c9s-appstream-mirror]
 name=CentOS Stream 9 - AppStream
-baseurl=http://mirror.stream.centos.org/9-stream/AppStream/$basearch/os
+baseurl=https://mirror.stream.centos.org/9-stream/AppStream/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1
@@ -20,7 +20,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Officia
 
 [c9s-nfv-mirror]
 name=CentOS Stream 9 - NFV
-baseurl=http://mirror.stream.centos.org/9-stream/NFV/$basearch/os
+baseurl=https://mirror.stream.centos.org/9-stream/NFV/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1
@@ -28,7 +28,7 @@ gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Officia
 
 [c9s-rt-mirror]
 name=CentOS Stream 9 - RT
-baseurl=http://mirror.stream.centos.org/9-stream/RT/$basearch/os
+baseurl=https://mirror.stream.centos.org/9-stream/RT/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1

--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -24,6 +24,8 @@ RUN if [[ -n "${VARIANT}" ]]; then MANIFEST="manifest-${VARIANT}.yaml"; EXTENSIO
 ## current p8/s390x. See https://github.com/openshift/os/issues/1000
 FROM quay.io/fedora/fedora:40 as builder
 COPY --from=os /usr/share/rpm-ostree/extensions/ /usr/share/rpm-ostree/extensions/
+RUN rm -f /etc/yum.repos.d/*.repo \
+&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/rhcos-4.17/fedora.repo -o /etc/yum.repos.d/fedora.repo
 RUN dnf install -y createrepo_c
 RUN createrepo_c /usr/share/rpm-ostree/extensions/
 

--- a/tests/kola/rpm-ostree/replace-rt-kernel/data/c9s.repo
+++ b/tests/kola/rpm-ostree/replace-rt-kernel/data/c9s.repo
@@ -4,7 +4,7 @@
 
 [baseos]
 name=CentOS Stream 9 - BaseOS
-baseurl=http://mirror.stream.centos.org/9-stream/BaseOS/$basearch/os
+baseurl=https://mirror.stream.centos.org/9-stream/BaseOS/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1
@@ -12,7 +12,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official
 
 [appstream]
 name=CentOS Stream 9 - AppStream
-baseurl=http://mirror.stream.centos.org/9-stream/AppStream/$basearch/os
+baseurl=https://mirror.stream.centos.org/9-stream/AppStream/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1
@@ -28,7 +28,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official
 
 [nfv]
 name=CentOS Stream 9 - NFV
-baseurl=http://mirror.stream.centos.org/9-stream/NFV/$basearch/os
+baseurl=https://mirror.stream.centos.org/9-stream/NFV/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1
@@ -36,7 +36,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official
 
 [rt]
 name=CentOS Stream 9 - RT
-baseurl=http://mirror.stream.centos.org/9-stream/RT/$basearch/os
+baseurl=https://mirror.stream.centos.org/9-stream/RT/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1


### PR DESCRIPTION
backport to release-4.17: 
- [COS-2758: ITUP Cluster Migration - Use HTTPS where possible](https://github.com/openshift/os/pull/1571)
- Note:
  -  extensions/Dockerfile: use fedora.repo file from the `rhcos-4.17` branch in fedora-coreos-config to set up the container 