### PR TITLE
[Release 4.14] NO-JIRA: ITUP Cluster Migration - Use HTTPS where possible

### DIFF
--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -22,6 +22,8 @@ RUN if [[ -n "${VARIANT}" ]]; then MANIFEST="manifest-${VARIANT}.yaml"; EXTENSIO
 ## current p8/s390x. See https://github.com/openshift/os/issues/1000
 FROM quay.io/fedora/fedora:40 as builder
 COPY --from=os /usr/share/rpm-ostree/extensions/ /usr/share/rpm-ostree/extensions/
+RUN rm -f /etc/yum.repos.d/*.repo \
+&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/rhcos-4.14/fedora.repo -o /etc/yum.repos.d/fedora.repo
 RUN dnf install -y createrepo_c
 RUN createrepo_c /usr/share/rpm-ostree/extensions/
 

--- a/tests/kola/rpm-ostree/replace-rt-kernel/data/c9s.repo
+++ b/tests/kola/rpm-ostree/replace-rt-kernel/data/c9s.repo
@@ -1,6 +1,6 @@
 [baseos]
 name=CentOS Stream 9 - BaseOS
-baseurl=http://mirror.stream.centos.org/9-stream/BaseOS/$basearch/os
+baseurl=https://mirror.stream.centos.org/9-stream/BaseOS/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1
@@ -8,7 +8,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official
 
 [appstream]
 name=CentOS Stream 9 - AppStream
-baseurl=http://mirror.stream.centos.org/9-stream/AppStream/$basearch/os
+baseurl=https://mirror.stream.centos.org/9-stream/AppStream/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1
@@ -24,7 +24,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official
 
 [nfv]
 name=CentOS Stream 9 - NFV
-baseurl=http://mirror.stream.centos.org/9-stream/NFV/$basearch/os
+baseurl=https://mirror.stream.centos.org/9-stream/NFV/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1
@@ -32,7 +32,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-Official
 
 [rt]
 name=CentOS Stream 9 - RT
-baseurl=http://mirror.stream.centos.org/9-stream/RT/$basearch/os
+baseurl=https://mirror.stream.centos.org/9-stream/RT/$basearch/os
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1


### PR DESCRIPTION
backport to release-4.14: 
- [COS-2758: ITUP Cluster Migration - Use HTTPS where possible](https://github.com/openshift/os/pull/1571)
- Notes:
  - c9s-mirror.repo does not exist in `release-4.14`, so the commit to update that file (https://github.com/openshift/os/pull/1571/commits/761db82968b0caf82ce5cf7761c9bef970097237) was omitted from this backport
  - extensions/Dockerfile: use fedora.repo file from the `rhcos-4.14` branch in fedora-coreos-config to set up the container