### PR TITLE
[release 4.13] NO-JIRA: extensions/Dockerfile: Use FCOS defined fedora.repo file to set up container

### DIFF
--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -21,6 +21,8 @@ RUN if [[ -n "${VARIANT}" ]]; then MANIFEST="manifest-${VARIANT}.yaml"; EXTENSIO
 ## current p8/s390x. See https://github.com/openshift/os/issues/1000
 FROM quay.io/fedora/fedora:37 as builder
 COPY --from=os /usr/share/rpm-ostree/extensions/ /usr/share/rpm-ostree/extensions/
+RUN rm -f /etc/yum.repos.d/*.repo \
+&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/rhcos-4.13/fedora.repo -o /etc/yum.repos.d/fedora.repo
 RUN dnf install -y createrepo_c
 RUN createrepo_c /usr/share/rpm-ostree/extensions/
 


### PR DESCRIPTION
Backport of https://github.com/openshift/os/commit/8301c67176e71ff2c6c5236109c89a149422a592 to `release-4.13`. 
The commit was modified to pull from the `rhcos-4.13` branch of https://github.com/coreos/fedora-coreos-config.
This change is needed for the RHCOS Pipeline Migration to the new ITUP cluster.
