### PR TITLE
[release-4.12] NO-JIRA: extensions/Dockerfile: Use FCOS defined fedora.repo file to set up container

### DIFF
--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -16,6 +16,8 @@ RUN if [[ -n "${VARIANT}" ]]; then MANIFEST="manifest-${VARIANT}.yaml"; EXTENSIO
 ## current p8/s390x. See https://github.com/openshift/os/issues/1000
 FROM quay.io/fedora/fedora:36 as builder
 COPY --from=os /usr/share/rpm-ostree/extensions/ /usr/share/rpm-ostree/extensions/
+RUN rm -f /etc/yum.repos.d/*.repo \
+&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/rhcos-4.12/fedora.repo -o /etc/yum.repos.d/fedora.repo
 RUN dnf install -y createrepo_c
 RUN createrepo_c /usr/share/rpm-ostree/extensions/
 


### PR DESCRIPTION
Backport of 8301c67 to `release-4.12`.
The commit was modified to pull from the `rhcos-4.12` branch of https://github.com/coreos/fedora-coreos-config.
This change is needed for the RHCOS Pipeline Migration to the new ITUP cluster.