### PR TITLE
NO-JIRA: [release-4.12] ci/prow-entrypoint: tell git repo under /src is safe

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -166,13 +166,18 @@ validate() {
     workdir="$(mktemp -d)"
     echo "Using $workdir as working directory"
 
+    # for `git config --global` below
+    export HOME=${workdir}
+
     # Figure out if we are running from the COSA image or directly from the Prow src image
     if [[ -d /src/github.com/openshift/os ]]; then
         cd "$workdir"
+        git config --global --add safe.directory /src/github.com/openshift/os
         git clone /src/github.com/openshift/os os
     elif [[ -d ./.git ]]; then
         srcdir="${PWD}"
         cd "$workdir"
+        git config --global --add safe.directory "${srcdir}/.git"
         git clone "${srcdir}" os
     else
         echo "Could not found source directory"


### PR DESCRIPTION
cherry-pick https://github.com/openshift/os/commit/630d3f3d9c530c238e03c93210598101eafca266 to `release-4.12`.
CI in that branch is failing. see: https://github.com/openshift/os/pull/1579

```
commit 630d3f3d9c530c238e03c93210598101eafca266
Author: Jonathan Lebon <jonathan@jlebon.com>
Date:   Wed May 22 12:14:34 2024 -0400

    ci/prow-entrypoint: tell git repo under /src is safe
    
    That directory is part of the image and so not owned by us. Likely the
    base image used for the src container was updated recently to include
    newer git.

```