### PR TITLE
NO-JIRA: extensions/Dockerfile: use latest Fedora to generate repo

### DIFF
--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -22,7 +22,7 @@ RUN if [[ -n "${VARIANT}" ]]; then MANIFEST="manifest-${VARIANT}.yaml"; EXTENSIO
 ## Creates the repo metadata for the extensions.
 ## This uses Fedora as a lowest-common-denominator because it will work on
 ## current p8/s390x. See https://github.com/openshift/os/issues/1000
-FROM quay.io/fedora/fedora:40 as builder
+FROM quay.io/fedora/fedora:latest as builder
 COPY --from=os /usr/share/rpm-ostree/extensions/ /usr/share/rpm-ostree/extensions/
 RUN rm -f /etc/yum.repos.d/*.repo \
 && curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora.repo -o /etc/yum.repos.d/fedora.repo


### PR DESCRIPTION
In this stage of the build, we're just using Fedora to generate repodata. Since this is a pretty basic operation, let's just always use the latest Fedora instead of hardcoding a specific version. This ensures that e.g. we're never going to use an EOL Fedora release.

This became an issue after 8301c67 ("extensions/Dockerfile: use the FCOS defined fedora.repo to set up container"), which was backported to older RHCOS branches that used EOL Fedora releases. Before, we were using the mirrors, which papered over the fact that the content for EOL releases actually moved to another location. But now that we're using the canonical Fedora server, we're directly exposed to that.

Really, we should just stop hardcoding Fedora versions in this repo. We shouldn't be using EOL releases at all as part of our builds or tests. (Obviously a massive offender here is cosa... though that's a discussion of its own.)

See also: https://github.com/openshift/os/issues/1546