### PR TITLE
[release-4.17] NO-JIRA: extensions/Dockerfile - Use fedora:latest

### DIFF
--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -22,10 +22,10 @@ RUN if [[ -n "${VARIANT}" ]]; then MANIFEST="manifest-${VARIANT}.yaml"; EXTENSIO
 ## Creates the repo metadata for the extensions.
 ## This uses Fedora as a lowest-common-denominator because it will work on
 ## current p8/s390x. See https://github.com/openshift/os/issues/1000
-FROM quay.io/fedora/fedora:40 as builder
+FROM quay.io/fedora/fedora:latest as builder
 COPY --from=os /usr/share/rpm-ostree/extensions/ /usr/share/rpm-ostree/extensions/
 RUN rm -f /etc/yum.repos.d/*.repo \
-&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/rhcos-4.17/fedora.repo -o /etc/yum.repos.d/fedora.repo
+&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora.repo -o /etc/yum.repos.d/fedora.repo
 RUN dnf install -y createrepo_c
 RUN createrepo_c /usr/share/rpm-ostree/extensions/
 


### PR DESCRIPTION
The fedora modular repo is not used anymore and the repo download link seems broken after switching to fedora:40.

Hence, we are changing fedora version to be latest.