### PR TITLE
OCPBUGS-37875: packages-openshift.yaml: bump OVS version to 3.4

### DIFF
--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -3,7 +3,7 @@ packages:
   # but are not present in CentOS Stream and RHEL.
   - cri-o cri-tools conmon-rs
   - openshift-clients openshift-kubelet
-  - openvswitch3.3
+  - openvswitch3.4
   # The packages below are present in CentOS Stream/RHEL,
   # and depend on one or more of the above.
   - NetworkManager-ovs


### PR DESCRIPTION
ovn-k container counterpart: https://issues.redhat.com/browse/OCPBUGS-38270
previous bump: https://github.com/openshift/os/pull/1495