### PR TITLE
OCPBUGS-39536: Only run rhcos-fips services if fips=1

### DIFF
--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips-dracut-boot-fix.service
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips-dracut-boot-fix.service
@@ -2,7 +2,7 @@
 Description=Workaround dracut FIPS unmounting /boot
 DefaultDependencies=false
 ConditionKernelCommandLine=ignition.firstboot
-ConditionKernelCommandLine=fips
+ConditionKernelCommandLine=fips=1
 ConditionPathExists=/run/ostree-live
 # Work around the lack of https://github.com/dracutdevs/dracut/commit/ab26ad2c2ab4a5884e392951998d40829f130387 in RHEL 9.2
 # We're going to undo the damage it did.

--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips-finish.service
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/rhcos-fips-finish.service
@@ -3,7 +3,7 @@ Description=Finish FIPS mode setup
 DefaultDependencies=false
 # we run in the second boot after the one where we set fips=1
 ConditionKernelCommandLine=ignition.firstboot
-ConditionKernelCommandLine=fips
+ConditionKernelCommandLine=fips=1
 Before=initrd.target
 
 # we want to run after Ignition drops its files


### PR DESCRIPTION
The existence of the fips kernel param doesn't imply fips is enabled. It needs to be set to a '1' for the kenel to enable fips
https://github.com/torvalds/linux/blob/88fac17500f4ea49c7bac136cf1b27e7b9980075/crypto/fips.c#L23