### PR TITLE
NO-JIRA: Add irqbalance to aarch64 builds

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -286,6 +286,9 @@ packages-ppc64le:
   - ppc64-diag-rtas
   - rdma-core
 
+packages-aarch64:
+  - irqbalance
+
 packages-s390x:
   # Required for IBM Secure Execution. Now is part of s390utils-base.rpm
   # https://github.com/coreos/fedora-coreos-tracker/issues/1217


### PR DESCRIPTION
The irqbalance package is required for low latency applications. It is present in the x86_64 RHCOS build, but not the aarch64 build. It is already included in the aarch64 build of Fedora CoreOS so this is just bringing RHCOS up to date.
closes #1601 
