### PR TITLE
NO-JIRA: extensions/Dockerfile: use fedora-archive.repo and revert "use fedora:latest"

### DIFF
--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -22,7 +22,7 @@ RUN if [[ -n "${VARIANT}" ]]; then MANIFEST="manifest-${VARIANT}.yaml"; EXTENSIO
 ## Creates the repo metadata for the extensions.
 ## This uses Fedora as a lowest-common-denominator because it will work on
 ## current p8/s390x. See https://github.com/openshift/os/issues/1000
-FROM quay.io/fedora/fedora:latest as builder
+FROM quay.io/fedora/fedora:40 as builder
 COPY --from=os /usr/share/rpm-ostree/extensions/ /usr/share/rpm-ostree/extensions/
 RUN rm -f /etc/yum.repos.d/*.repo \
 && curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora.repo -o /etc/yum.repos.d/fedora.repo

--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -25,7 +25,7 @@ RUN if [[ -n "${VARIANT}" ]]; then MANIFEST="manifest-${VARIANT}.yaml"; EXTENSIO
 FROM quay.io/fedora/fedora:40 as builder
 COPY --from=os /usr/share/rpm-ostree/extensions/ /usr/share/rpm-ostree/extensions/
 RUN rm -f /etc/yum.repos.d/*.repo \
-&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora.repo -o /etc/yum.repos.d/fedora.repo
+&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora-archive.repo -o /etc/yum.repos.d/fedora-archive.repo
 RUN dnf install -y createrepo_c
 RUN createrepo_c /usr/share/rpm-ostree/extensions/
 


### PR DESCRIPTION
A `fedora-archive.repo` file will now be used by older branches using EOL fedora container versions[1]. This now acts as our mechanism for handling the situation where the EOL Fedora content actually moves to a different location by pointing to the archived content directly. The `fedora-archive.repo` file in the testing-devel branch will be curled during the container setup instead of the `fedora.repo` file when the version goes EOL.

This does mean we'll still have to maintain this container setup by updating the curl command as the versions go EOL around each new release.

This reverts commit 94dfed82c7882276e4e7d07d94aa519a9a037988.

[1] https://github.com/coreos/fedora-coreos-config/pull/3128

EDIT: 

We can actually now use the `fedora-archive.repo` for both EOL and non-EOL fedora releases. We decided to use it for the extensions container so we dont have to swap out `fedora.repo` when versions go EOL. Make that change here too.