### PR TITLE
[release-4.15] NO-JIRA: bump fedora-coreos-config and update extensions container

### DIFF
--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -20,10 +20,10 @@ RUN if [[ -n "${VARIANT}" ]]; then MANIFEST="manifest-${VARIANT}.yaml"; EXTENSIO
 ## Creates the repo metadata for the extensions.
 ## This uses Fedora as a lowest-common-denominator because it will work on
 ## current p8/s390x. See https://github.com/openshift/os/issues/1000
-FROM quay.io/fedora/fedora:latest as builder
+FROM quay.io/fedora/fedora:38 as builder
 COPY --from=os /usr/share/rpm-ostree/extensions/ /usr/share/rpm-ostree/extensions/
 RUN rm -f /etc/yum.repos.d/*.repo \
-&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora.repo -o /etc/yum.repos.d/fedora.repo
+&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora-archive.repo -o /etc/yum.repos.d/fedora-archive.repo
 RUN dnf install -y createrepo_c
 RUN createrepo_c /usr/share/rpm-ostree/extensions/
 


### PR DESCRIPTION
A `fedora-archive.repo` file will now be used by older branches using EOL fedora container versions[1]. This now acts as our mechanism for handling the situation where the EOL Fedora content actually moves to a different location by pointing to the archived content directly. The `fedora-archive.repo` file in the testing-devel branch will be curled during the container setup instead of the `fedora.repo` file when the version goes EOL.

This does mean we'll still have to maintain this container setup by updating the curl command as the versions go EOL around each new release. In this case the version is already EOL, so update the curl command now.

This essentially reverts two commits:
- 307f36015cf32f4b0fadb5405d3528a08edf3192
- 3f34c8730da9ad43f23142cbe6ae8c830b6b88db

[1] https://github.com/coreos/fedora-coreos-config/pull/3128

---

This also includes a submodule bump for `[release-4.15]`

```
Michael Armijo (3):
      tests/ntp: use the FCOS defined fedora.repo to set up container
      tests/podman/rootless-systemd: use the FCOS defined fedora.repo to set up container
      tests/kola: use fedora-archive.repo when setting up fedora container
```