### PR TITLE
[release-4.14] NO-JIRA: bump fedora-coreos-config and update extensions container

### DIFF
--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -20,10 +20,10 @@ RUN if [[ -n "${VARIANT}" ]]; then MANIFEST="manifest-${VARIANT}.yaml"; EXTENSIO
 ## Creates the repo metadata for the extensions.
 ## This uses Fedora as a lowest-common-denominator because it will work on
 ## current p8/s390x. See https://github.com/openshift/os/issues/1000
-FROM quay.io/fedora/fedora:latest as builder
+FROM quay.io/fedora/fedora:38 as builder
 COPY --from=os /usr/share/rpm-ostree/extensions/ /usr/share/rpm-ostree/extensions/
 RUN rm -f /etc/yum.repos.d/*.repo \
-&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora.repo -o /etc/yum.repos.d/fedora.repo
+&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora-archive.repo -o /etc/yum.repos.d/fedora-archive.repo
 RUN dnf install -y createrepo_c
 RUN createrepo_c /usr/share/rpm-ostree/extensions/
 


### PR DESCRIPTION
#### bump fedora-coreos-config
This submodule bump is required for the RHCOS pipeline migration to the ITUP cluster.
```
Michael Armijo (1):
      tests/kola: use fedora-archive.repo for EOL Fedora containers
```
xref: https://github.com/coreos/fedora-coreos-config/pull/3136

---
#### extensions/Dockerfile: use fedora:38 and fedora-archive.repo
A fedora-archive.repo file will now be used by older branches using EOL fedora container versions[1]. This now acts as our mechanism for handling the situation where the EOL Fedora content actually moves to a different location by pointing to the archived content directly. The fedora-archive.repo file in the testing-devel branch will be curled during the container setup instead of the fedora.repo file when the version goes EOL.

This does mean we'll still have to maintain this container setup by updating the curl command as the versions go EOL around each new release. In this case the version is already EOL, so update the curl command now.

This essentially reverts these two commits:
- https://github.com/openshift/os/commit/83ad41625296e12122a649ba27dc9f47ef67ba54
- https://github.com/openshift/os/commit/18921dd80a7a28a89baee320f50c8f99bd18aea8

[1] https://github.com/coreos/fedora-coreos-config/pull/3128