### PR TITLE
[release-4.13] NO-JIRA: bump fedora-coreos-config and update extensions container

### DIFF
--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -19,10 +19,10 @@ RUN if [[ -n "${VARIANT}" ]]; then MANIFEST="manifest-${VARIANT}.yaml"; EXTENSIO
 ## Creates the repo metadata for the extensions.
 ## This uses Fedora as a lowest-common-denominator because it will work on
 ## current p8/s390x. See https://github.com/openshift/os/issues/1000
-FROM quay.io/fedora/fedora:latest as builder
+FROM quay.io/fedora/fedora:37 as builder
 COPY --from=os /usr/share/rpm-ostree/extensions/ /usr/share/rpm-ostree/extensions/
 RUN rm -f /etc/yum.repos.d/*.repo \
-&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora.repo -o /etc/yum.repos.d/fedora.repo
+&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora-archive.repo -o /etc/yum.repos.d/fedora-archive.repo
 RUN dnf install -y createrepo_c
 RUN createrepo_c /usr/share/rpm-ostree/extensions/
 


### PR DESCRIPTION
#### bump fedora-coreos-config
The submodule bump is required for the RHCOS pipeline migration to the ITUP cluster.
```
Michael Armijo (1):
      tests/kola: use fedora-archive.repo for EOL Fedora containers
```

xref: https://github.com/coreos/fedora-coreos-config/pull/3137

---
#### extensions/Dockerfile: use fedora:37 and fedora-archive.repo
A fedora-archive.repo file will now be used by older branches using EOL fedora container versions[1]. This now acts as our mechanism for handling the situation where the EOL Fedora content actually moves to a different location by pointing to the archived content directly. The fedora-archive.repo file in the testing-devel branch will be curled during the container setup instead of the fedora.repo file when the version goes EOL.

This does mean we'll still have to maintain this container setup by updating the curl command as the versions go EOL around each new release. In this case the version is already EOL, so update the curl command now.

This essentially reverts these two commits:
- https://github.com/openshift/os/commit/b56bcd8e00e737213a965d3300ce18d7c068977d
- https://github.com/openshift/os/commit/7487bccb911f19971a7fb8fdaacb82ea36a7e430

[1] https://github.com/coreos/fedora-coreos-config/pull/3128