### PR TITLE
[release-4.14] NO-JIRA: Revert "denylist: add dhcp-propagation and podman.rootless-systemd"

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -28,9 +28,3 @@
   tracker: https://github.com/openshift/os/issues/1237
   osversion:
   - c9s
-
-- pattern: ext.config.shared.podman.rootless-systemd
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1760
-
-- pattern: ext.config.shared.ntp.chrony.dhcp-propagation
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1761


### PR DESCRIPTION
The Fedora 38 content is available using the metalinks again and these two kola tests are passing again in 4.14.

ref: https://pagure.io/releng/issue/12204

This reverts commit 65d0b71dfc75dc37eef1cfac504b6c52cdefc63e.

see: https://github.com/openshift/os/pull/1550