### PR TITLE
NO-JIRA: Bump fedora-coreos-config

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -38,6 +38,11 @@ conditional-include:
     include: zram-no-defaults.yaml
   - if: osversion == "rhel-9.4"
     include: zram-no-defaults.yaml
+  # Packages specific to el9
+  - if: osversion == "c9s"
+    include: fedora-coreos-config/manifests/shared-el9.yaml
+  - if: osversion == "rhel-9.4"
+    include: fedora-coreos-config/manifests/shared-el9.yaml
 
 
 documentation: false

--- a/overlay.d/07fix-selinux-labels
+++ b/overlay.d/07fix-selinux-labels
@@ -1,0 +1,1 @@
+../fedora-coreos-config/overlay.d/07fix-selinux-labels


### PR DESCRIPTION
Created by [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/openshift-os.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/openshift-os.yml)).

```
Dusty Mabe (3):
      denylist: drop denials for yum repo errors
      tests/kola: rename selinux.default test to selinux.unmodified-policy
      tests/kola: catch SELinux unlabeled and mislabeled files

Jonathan Lebon (1):
      tests/kola: add more context on weird /var/mnt directory

Michael Armijo (2):
      tests/update-ca-trust: validate new ca-bundle.crt location
      denylist: extend snooze for `kdump.crash`

Timothée Ravier (3):
      manifests: Move NetworkManager-team/teamd to EL9 shared manifest
      manifests: Move runc to EL9 shared manifest
      manifests: Move GPU firmwares & kdump tools to EL10 shared manifest

gursewak1997 (1):
      denylist: drop denial for ignition.ssh.key

jbtrystram (1):
      overlay.d: add 07fix-selinux-labels overlay
```