### PR TITLE
COS-2940: extensions: add sysstat as RHCOS extension

### DIFF
--- a/extensions-c9s.yaml
+++ b/extensions-c9s.yaml
@@ -83,3 +83,7 @@ extensions:
       - kernel-64k-modules
       - kernel-64k-modules-core
       - kernel-64k-modules-extra
+  # https://issues.redhat.com/browse/COS-2940
+  sysstat:
+    packages:
+      - sysstat

--- a/extensions-rhel-9.4.yaml
+++ b/extensions-rhel-9.4.yaml
@@ -81,3 +81,7 @@ extensions:
       - kernel-64k-modules
       - kernel-64k-modules-core
       - kernel-64k-modules-extra
+  # https://issues.redhat.com/browse/COS-2940
+  sysstat:
+    packages:
+      - sysstat


### PR DESCRIPTION
This package enables sysstat workloads in OCP

Ref: https://issues.redhat.com/browse/COS-2940