### PR TITLE
[release-4.15] NO-JIRA: denylist: remove obsolete entries

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -39,14 +39,3 @@
   arches:
     - ppc64le
 
-- pattern: coreos.unique.boot.failure
-  tracker: https://github.com/coreos/coreos-assembler/issues/3669
-  snooze: 2023-12-13
-  warn: true
-  arches:
-    - aarch64
-
-- pattern: coreos.ignition.failure
-  tracker: https://github.com/coreos/coreos-assembler/issues/3670
-  snooze: 2023-12-13
-  warn: true


### PR DESCRIPTION
The snoozes for the `coreos.unique.boot.failure` and `coreos.ignition.failure` entries expired a while
ago and the tests have been passing. The associated tracker issues have also been closed.