### PR TITLE
OCPBUGS-42649: [release-4.16] Bump fedora-coreos-config to include 07fix-selinux-labels overlay

### DIFF
--- a/overlay.d/07fix-selinux-labels
+++ b/overlay.d/07fix-selinux-labels
@@ -1,0 +1,1 @@
+../fedora-coreos-config/overlay.d/07fix-selinux-labels


### PR DESCRIPTION
Essentially a backport of https://github.com/coreos/fedora-coreos-config/pull/3150