### PR TITLE
COS-2959: Add rhel-9.6 and ocp-rhel-9.6 variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ supported:
 
 - `rhel-9.4`: RHEL 9.4-based CoreOS; without OpenShift components.
 - `ocp-rhel-9.4`: RHEL 9.4-based CoreOS; including OpenShift components.
+- `rhel-9.6`: RHEL 9.6-based CoreOS; without OpenShift components.
+- `ocp-rhel-9.6`: RHEL 9.6-based CoreOS; including OpenShift components.
 - `c9s`: CentOS Stream-based CoreOS, without OKD components.
 - `okd-c9s`: CentOS Stream-based CoreOS, including OpenShift components. This
   currently includes some packages from RHEL because not all packages required

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -73,6 +73,12 @@ prepare_repos() {
     # Figure out which version we're building
     rhelver=$(rpm-ostree compose tree --print-only "${manifest}" | jq -r '.["automatic-version-prefix"]' | cut -f2 -d.)
 
+    # XXX change to rhel 9.6 when beta is GA
+    # use 9.4 repos for 9.6
+    if [[ "${rhelver}" == "96" ]]; then
+        rhelver="94"
+    fi
+
     # Temporary workaround until we publish builds in the default path
     if [[ "${rhelver}" == "94" ]]; then
         prev_build_url="${REDIRECTOR_URL}/${ocpver}-9.4/builds/"

--- a/common.yaml
+++ b/common.yaml
@@ -38,10 +38,14 @@ conditional-include:
     include: zram-no-defaults.yaml
   - if: osversion == "rhel-9.4"
     include: zram-no-defaults.yaml
+  - if: osversion == "rhel-9.6"
+    include: zram-no-defaults.yaml
   # Packages specific to el9
   - if: osversion == "c9s"
     include: fedora-coreos-config/manifests/shared-el9.yaml
   - if: osversion == "rhel-9.4"
+    include: fedora-coreos-config/manifests/shared-el9.yaml
+  - if: osversion == "rhel-9.6"
     include: fedora-coreos-config/manifests/shared-el9.yaml
 
 

--- a/extensions-ocp-rhel-9.6.yaml
+++ b/extensions-ocp-rhel-9.6.yaml
@@ -1,0 +1,1 @@
+extensions-rhel-9.6.yaml

--- a/extensions-rhel-9.6.yaml
+++ b/extensions-rhel-9.6.yaml
@@ -1,0 +1,94 @@
+# RPMs as operating system extensions, distinct from the base ostree commit/image
+# https://github.com/openshift/enhancements/blob/master/enhancements/rhcos/extensions.md
+# and https://github.com/coreos/fedora-coreos-tracker/issues/401
+
+extensions:
+  # https://issues.redhat.com/browse/RFE-4177
+  wasm:
+    architectures:
+      - x86_64
+      - aarch64
+    repos:
+      # XXX todo: swap to rhel 9.6 repos when beta is GA
+      # Ideally we would use content from c9s as it's the same as rhel 9.6 for now
+      # but this particular package does not exist there
+      - rhel-9.4-server-ose-4.18
+    packages:
+      - crun-wasm
+  # https://github.com/coreos/fedora-coreos-tracker/issues/1504
+  ipsec:
+    packages:
+      - libreswan
+      - NetworkManager-libreswan
+  # https://github.com/coreos/fedora-coreos-tracker/issues/326
+  usbguard:
+    packages:
+      - usbguard
+  kerberos:
+    packages:
+      - krb5-workstation
+      - libkadm5
+  # https://github.com/kmods-via-containers/kmods-via-containers/issues/3
+  # https://gitlab.cee.redhat.com/coreos/redhat-coreos/merge_requests/866
+  # These are currently overlaid onto the host so that they can be bind-mounted
+  # into build containers... in the future they should be a `development`
+  # extension: https://github.com/openshift/machine-config-operator/pull/2143.
+  kernel-devel:
+    packages:
+      - kernel-devel
+      - kernel-headers
+    match-base-evr: kernel
+  # These are already in the base, so they're not OS extensions, but they're
+  # useful to have in RPM form to install in kmod build containers.
+  kernel:
+    kind: development
+    packages:
+      - kernel
+      - kernel-core
+      - kernel-modules
+      - kernel-modules-extra
+    match-base-evr: kernel
+  # GRPA-2822
+  # https://github.com/openshift/machine-config-operator/pull/1330
+  # https://github.com/openshift/enhancements/blob/master/enhancements/support-for-realtime-kernel.md
+  kernel-rt:
+    architectures:
+      - x86_64
+    repos:
+      # XXX todo: swap to rhel 9.6 repos when beta is GA
+      - c9s-nfv
+    packages:
+      - kernel-rt-core
+      - kernel-rt-kvm
+      - kernel-rt-modules
+      - kernel-rt-modules-extra
+      - kernel-rt-devel
+    match-base-evr: kernel
+  # https://github.com/openshift/machine-config-operator/pull/2456
+  # https://github.com/openshift/enhancements/blob/master/enhancements/sandboxed-containers/sandboxed-containers-tech-preview.md
+  # GRPA-3123
+  # - kata-containers
+  sandboxed-containers:
+    architectures:
+      - x86_64
+      - s390x
+    repos:
+      # XXX ideally we would pull that from c9s as it's identical to rhel 9.6 for now
+      # but c9s does not build this for s390x so we have to pull it from rhel 9.4
+      # todo: swap to rhel 9.6 repos when beta is GA
+      - rhel-9.4-server-ose-4.18
+    packages:
+      - kata-containers
+  # https://issues.redhat.com/browse/COS-2402
+  kernel-64k:
+    architectures:
+      - aarch64
+    packages:
+      - kernel-64k-core
+      - kernel-64k-modules
+      - kernel-64k-modules-core
+      - kernel-64k-modules-extra
+  # https://issues.redhat.com/browse/COS-2940
+  sysstat:
+    packages:
+      - sysstat

--- a/image-ocp-rhel-9.6.yaml
+++ b/image-ocp-rhel-9.6.yaml
@@ -1,0 +1,1 @@
+image-rhel-9.6.yaml

--- a/image-rhel-9.6.yaml
+++ b/image-rhel-9.6.yaml
@@ -1,0 +1,1 @@
+image-rhel-9.4.yaml

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -7,21 +7,25 @@
   tracker: https://github.com/openshift/os/issues/1237
   osversion:
     - c9s
+    - rhel-9.6
 
 - pattern: iso-live-login.uefi-secure
   tracker: https://github.com/openshift/os/issues/1237
   osversion:
     - c9s
+    - rhel-9.6
 
 - pattern: iso-as-disk.uefi-secure
   tracker: https://github.com/openshift/os/issues/1237
   osversion:
     - c9s
+    - rhel-9.6
 
 - pattern: fips.*
   tracker: https://github.com/openshift/os/issues/1540
   osversion:
     - c9s
+    - rhel-9.6
 
 # we're missing a cri-o rebuild for 4.17, which blocks on buildroot issues
 - pattern: ext.config.version.rhaos-pkgs-match-openshift
@@ -31,3 +35,15 @@
 # but not denylisted here so it can run on the rhcos pipeline
 #- pattern: iso-offline-install-iscsi.ibft.bios
 #  tracker: https://github.com/openshift/os/issues/1492
+
+# as it's a fake rhel build (from c9s) versions won't match
+- pattern: ext.config.version.rhel-major-version
+  tracker: https://github.com/openshift/os/issues/1635
+  snooze: 2025-01-01
+  osversion:
+    - rhel-9.6
+- pattern: ext.config.shared.content-origins
+  tracker: https://github.com/openshift/os/issues/1635
+  snooze: 2025-01-01
+  osversion:
+    - rhel-9.6

--- a/manifest-ocp-rhel-9.6.yaml
+++ b/manifest-ocp-rhel-9.6.yaml
@@ -1,0 +1,111 @@
+# Manifest for OCP node based on RHEL 9.6
+# Note: this manifest is temporary; in the future, OCP components will be layered instead.
+
+rojig:
+  license: MIT
+  name: rhcos
+  summary: OpenShift 4.18
+
+variables:
+  osversion: "rhel-9.6"
+
+# Include manifests common to all RHEL and CentOS Stream versions and manifest
+# common to RHEL 9 & C9S variants
+include:
+  - manifest-rhel-9.6.yaml
+  - packages-openshift.yaml
+
+# Additional repos we need for OCP components
+# right now we use rhel-9.4 OCP repos as RHEL 9.6 is not available yet
+repos:
+  - rhel-9.4-fast-datapath
+  - rhel-9.4-server-ose-4.18
+  - rhel-9.4-appstream
+  - c9s-extras-common
+  - c9s-sig-nfv
+  - c9s-nfv
+
+packages:
+ # RPM GPG keys for CentOS SIG repos
+  - centos-release-cloud-common
+  - centos-release-nfv-common
+  - centos-release-virt-common
+
+# We include hours/minutes to avoid version number reuse
+automatic-version-prefix: "418.96.<date:%Y%m%d%H%M>"
+# This ensures we're semver-compatible which OpenShift wants
+automatic-version-suffix: "-"
+# Keep this is sync with the version in postprocess
+mutate-os-release: "4.18"
+
+postprocess:
+  - |
+     #!/usr/bin/env bash
+     set -xeo pipefail
+
+     # Tweak /usr/lib/os-release
+     grep -v -e "OSTREE_VERSION" -e "OPENSHIFT_VERSION" /etc/os-release > /usr/lib/os-release.rhel
+     (
+     . /etc/os-release
+     cat > /usr/lib/os-release <<EOF
+     NAME="${NAME}"
+     ID="rhcos"
+     ID_LIKE="rhel fedora"
+     VERSION="${OSTREE_VERSION}"
+     VERSION_ID="${OPENSHIFT_VERSION}"
+     VARIANT="${VARIANT}"
+     VARIANT_ID=${VARIANT_ID}
+     PLATFORM_ID="${PLATFORM_ID}"
+     PRETTY_NAME="${NAME} ${OSTREE_VERSION}"
+     ANSI_COLOR="${ANSI_COLOR}"
+     CPE_NAME="${CPE_NAME}::coreos"
+     HOME_URL="${HOME_URL}"
+     DOCUMENTATION_URL="https://docs.okd.io/latest/welcome/index.html"
+     BUG_REPORT_URL="https://access.redhat.com/labs/rhir/"
+     REDHAT_BUGZILLA_PRODUCT="OpenShift Container Platform"
+     REDHAT_BUGZILLA_PRODUCT_VERSION="${OPENSHIFT_VERSION}"
+     REDHAT_SUPPORT_PRODUCT="OpenShift Container Platform"
+     REDHAT_SUPPORT_PRODUCT_VERSION="${OPENSHIFT_VERSION}"
+     OPENSHIFT_VERSION="${OPENSHIFT_VERSION}"
+     RHEL_VERSION=9.6
+     OSTREE_VERSION="${OSTREE_VERSION}"
+     EOF
+     )
+     rm -f /etc/os-release
+     ln -s ../usr/lib/os-release /etc/os-release
+
+     # Tweak /etc/system-release, /etc/system-release-cpe & /etc/redhat-release
+     (
+     . /etc/os-release
+     cat > /usr/lib/system-release-cpe <<EOF
+     ${CPE_NAME}
+     EOF
+     cat > /usr/lib/system-release <<EOF
+     ${NAME} release ${VERSION_ID}
+     EOF
+     rm -f /etc/system-release-cpe /etc/system-release /etc/redhat-release
+     ln -s /usr/lib/system-release-cpe /etc/system-release-cpe
+     ln -s /usr/lib/system-release /etc/system-release
+     ln -s /usr/lib/system-release /etc/redhat-release
+     )
+
+     # Tweak /usr/lib/issue
+     cat > /usr/lib/issue <<EOF
+     \S \S{VERSION_ID}
+     EOF
+     rm -f /etc/issue /etc/issue.net
+     ln -s /usr/lib/issue /etc/issue
+     ln -s /usr/lib/issue /etc/issue.net
+
+# Packages pinned to specific repos in RHCOS 9
+repo-packages:
+  - repo: c9s-appstream
+    packages:
+      - nss-altfiles
+  - repo: rhel-9.4-server-ose-4.18
+    packages:
+      - conmon-rs
+      - cri-o
+      - cri-tools
+      - openshift-clients
+      - openshift-kubelet

--- a/manifest-rhel-9.6.yaml
+++ b/manifest-rhel-9.6.yaml
@@ -1,0 +1,78 @@
+# Manifest for RHCOS based on RHEL 9.6
+
+rojig:
+  license: MIT
+  name: rhcos
+  summary: RHEL CoreOS 9.6
+
+variables:
+  osversion: "rhel-9.6"
+
+# Include manifests common to all RHEL and CentOS Stream versions
+include:
+  - common.yaml
+
+# XXX todo: swap to rhel 9.6 repos when beta is GA
+# CentOS Stream 9 repos for now
+repos:
+  - c9s-baseos
+  - c9s-appstream
+
+# Eventually we should try to build these images as part of the RHEL composes.
+# In that case, the versioning should instead be exactly the same as the pungi
+# compose ID.
+automatic-version-prefix: "9.6.<date:%Y%m%d%H%M>"
+# This ensures we're semver-compatible which OpenShift wants
+automatic-version-suffix: "-"
+
+mutate-os-release: "9.6"
+
+# XXX todo: swap to rhel 9.6 repos when beta is GA
+repo-packages:
+  - repo: c9s-baseos
+    packages:
+     # We include the generic centos release package and fake the red hat os-release
+     # info in a post-process script
+     # XXX todo: swap to redhat-release once 9.6 beta is GA
+     - centos-stream-release
+
+# XXX remove once swapping to rhel 9.6 beta content
+# Fake out RHEL version in the os-release while waiting for RHEL-9.6 release.
+postprocess:
+  - |
+     #!/usr/bin/env bash
+     set -xeo pipefail
+
+     (
+     . /etc/os-release
+     cat > /usr/lib/os-release <<EOF
+     NAME="Red Hat Enterprise Linux CoreOS"
+     VERSION="${OSTREE_VERSION} (Plow)"
+     ID="rhel"
+     ID_LIKE="fedora"
+     VERSION="${OSTREE_VERSION}"
+     VARIANT="CoreOS"
+     VARIANT_ID=coreos
+     VERSION_ID="9.6"
+     PLATFORM_ID="platform:el9"
+     PRETTY_NAME="Red Hat Enterprise Linux CoreOS ${OSTREE_VERSION} (Plow)"
+     ANSI_COLOR="0;31"
+     LOGO="fedora-logo-icon"
+     CPE_NAME="cpe:/o:redhat:enterprise_linux:9::baseos"
+     HOME_URL="https://www.redhat.com/"
+     DOCUMENTATION_URL="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9"
+     BUG_REPORT_URL="https://issues.redhat.com/"
+
+     REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 9"
+     REDHAT_BUGZILLA_PRODUCT_VERSION=9.6
+     REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
+     REDHAT_SUPPORT_PRODUCT_VERSION="9.6"
+     OSTREE_VERSION="${OSTREE_VERSION}"
+     EOF
+     )
+
+
+      rm -f /etc/system-release /etc/os-release /etc/redhat-release
+      ln -s /usr/lib/os-release /etc/os-release
+      ln -s /usr/lib/os-release /etc/system-release
+      ln -s /usr/lib/os-release /etc/redhat-release


### PR DESCRIPTION
Right now these are pure centOS Stream 9 builds with a spoofed `os-release` file.

For the ocp variant, pull the packages from the 9.4-4.18 repos.

https://issues.redhat.com/browse/COS-2959