### PR TITLE
NO-JIRA: okd-scos: pin clevis to 20-200.el9

### DIFF
--- a/overrides-c9s.yaml
+++ b/overrides-c9s.yaml
@@ -3,8 +3,13 @@
 # we need in the `packages` section. When not needed. Empty or comment out this
 # file (except this comment).
 
-#repos:
-#  - c9s-baseos-mirror
-#  - c9s-appstream-mirror
+repos:
+# - c9s-baseos-mirror
+  - c9s-appstream-mirror
 
-#packages:
+packages:
+  # https://issues.redhat.com/browse/RHEL-61612
+  - clevis-20-200.el9
+  - clevis-dracut-20-200.el9
+  - clevis-luks-20-200.el9
+  - clevis-systemd-20-200.el9


### PR DESCRIPTION
Latest clevis pulls in opensc and pcsc-lite which gives this error on booting:

```
[    1.931395] dracut-initqueue[621]: pcscd: unrecognized option '--disable-polkit'
[    1.742582] dracut-initqueue[621]: pcscd: unrecognized option '--disable-polkit'
[    1.933525] dracut-initqueue[621]: Usage: pcscd options
[    1.933837] dracut-initqueue[621]: Options:
[[0;32m  OK  [[    1.934124] dracut-initqueue[621]:   -a, --apdu		log APDU commands and results
0m] Found device [0;1;39mAmazon Elastic Block Store root[0m.[    1.934449] dracut-initqueue[621]:   -c, --config		path to reader.conf
[    1.934737] dracut-initqueue[621]:   -f, --foreground	run in foreground (no daemon),

[    1.935028] dracut-initqueue[621]: 			send logs to stdout instead of syslog
[    1.935341] dracut-initqueue[621]:   -T, --color		force use of colored logs
[    1.935628] dracut-initqueue[621]:   -h, --help		display usage information
[    1.935912] dracut-initqueue[621]:   -H, --hotplug		ask the daemon to rescan the available readers
[[0;32m  OK  [0m] Reached target [0;1;39mInit[    1.936468] dracut-initqueue[621]:   -v, --version		display the program version number
rd Root Device[[    1.936748] dracut-initqueue[621]:   -d, --debug		display lower level debug messages
0m.
[    1.937028] dracut-initqueue[621]:   -i, --info		display info level debug messages
[    1.937316] dracut-initqueue[621]:   -e  --error		display error level debug messages (default level)
[    1.937834] dracut-initqueue[621]:   -C  --critical	display critical only level debug messages
[    1.938109] dracut-initqueue[621]:   --force-reader-polling ignore the IFD_GENERATE_HOTPLUG reader capability
[    1.938665] dracut-initqueue[621]:   -t, --max-thread	maximum number of threads (default 200)
[    1.938948] dracut-initqueue[621]:   -s, --max-card-handle-per-thread	maximum number of card handle per thread (default: 200)
[    1.939509] dracut-initqueue[621]:   -r, --max-card-handle-per-reader	maximum number of card handle per reader (default: 200)
[    1.940064] dracut-initqueue[621]:   -x, --auto-exit	pcscd will quit after 60 seconds of inactivity
[    1.940632] dracut-initqueue[621]:   -S, --reader-name-no-serial    do not include the USB serial number in the name
```
This addresses https://github.com/openshift/os/issues/1630 until https://issues.redhat.com/browse/RHEL-61612 has been fixed.