### PR TITLE
DNM: test PR with clevis-pin + fixed setuid test + revert c9s selinux patches

### DIFF
--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -26,23 +26,3 @@ mutate-os-release: "9"
 
 packages:
  - centos-stream-release
-
-postprocess:
-  - |
-    #!/usr/bin/env bash
-    set -xeuo pipefail
-    cat > /tmp/scos-workarounds.cil << EOF
-    ; https://issues.redhat.com/browse/RHEL-49735
-    (typeattributeset cil_gen_require afterburn_t)
-    (typepermissive afterburn_t)
-
-    ; https://issues.redhat.com/browse/RHEL-38614
-    (typeattributeset cil_gen_require coreos_installer_t)
-    (typepermissive coreos_installer_t)
-
-    ; https://issues.redhat.com/browse/RHEL-47033
-    (typeattributeset cil_gen_require systemd_network_generator_t)
-    (typepermissive systemd_network_generator_t)
-    EOF
-    /usr/sbin/semodule -i /tmp/scos-workarounds.cil
-    rm /tmp/scos-workarounds.cil

--- a/overrides-c9s.yaml
+++ b/overrides-c9s.yaml
@@ -3,8 +3,14 @@
 # we need in the `packages` section. When not needed. Empty or comment out this
 # file (except this comment).
 
-#repos:
-#  - c9s-baseos-mirror
-#  - c9s-appstream-mirror
+repos:
+# - c9s-baseos-mirror
+  - c9s-appstream-mirror
 
-#packages:
+packages:
+  # https://issues.redhat.com/browse/RHEL-61612
+  - clevis-20-200.el9
+  - clevis-dracut-20-200.el9
+  - clevis-luks-20-200.el9
+  - clevis-systemd-20-200.el9
+  - clevis-udisks2-20-200.el9


### PR DESCRIPTION
This PR combines the following: 


 

https://github.com/openshift/os/pull/1568 ( revert c9s selinux patches, failing due to https://issues.redhat.com/browse/RHEL-61612 )

https://github.com/openshift/os/pull/1631 - fixing the issue with clevis - [RHEL-61612](https://issues.redhat.com//browse/RHEL-61612) 

https://github.com/coreos/fedora-coreos-config/pull/3202 - Fixing the setuid test failure in #1631 

