### PR TITLE
OCPBUGS-43079: [release-4.17] overlay.d/05rhcos: Neuter coreos-luks-open for remote kdump

### DIFF
--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fde/coreos-luks-generator
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fde/coreos-luks-generator
@@ -17,6 +17,14 @@ add_requires() {
     ln -sf "../${name}" "${requires_dir}/${name}"
 }
 
+# We don't need to mount the local disk if we are in the kdump initramfs
+# and kdump is configured to export the logs to a remote target
+# See https://issues.redhat.com/browse/OCPBUGS-42351
+# Also see https://github.com/coreos/fedora-coreos-config/commit/8ced0db61f23a9b59ef096317fb6fc225bfba133
+if getargbool 0 'kdump_remote_ip'; then
+   exit 0
+fi
+
 # In 4.4+, we only activate if rhcos.root=crypt_rootfs as set on the
 # kernel cmdline by image.yaml.  This will allow us to go back
 # to matching FCOS and supporting full rootfs reprovisioning.


### PR DESCRIPTION
In cases where kdump is configured to export logs to a remote machine, mounting the local disk is pointless. Furthermore, we can't even do it. This bug was hidden by kdump truncating the arguments but it surfaced in 4.16 with https://github.com/rhkdump/kdump-utils/commit/0f6ad91be85d5aec983a00ca54adb1b130889bc2

See https://issues.redhat.com/browse/OCPBUGS-42351 See https://github.com/coreos/fedora-coreos-config/commit/8ced0db61f23a9b59ef096317fb6fc225bfba133#diff-c55c07c8d9cee0242ef457bc2d5cc254a1c1c1d53f2957378736efe1a98218c1R19

This is a backport of https://github.com/openshift/os/pull/1632