### PR TITLE
[4.17] denylist: update the tracker issue for rhaos-pkgs-match-openshift

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -23,9 +23,10 @@
   osversion:
     - c9s
 
-# we're missing a cri-o rebuild for 4.17, which blocks on buildroot issues
+# The 4.17 and 4.18 build of Ignition encounters a FIPS panic so
+# we are using the 4.16 build for now while that is under investigation.
 - pattern: ext.config.version.rhaos-pkgs-match-openshift
-  tracker: https://issues.redhat.com/browse/RHEL-35883
+  tracker: https://issues.redhat.com/browse/OCPBUGS-42688
 
 # This test is failing only in prow, so it's skipped by prow
 # but not denylisted here so it can run on the rhcos pipeline


### PR DESCRIPTION
The rhaos4.x didn't match the OCP version for both 4.17 and 4.18, hence an ignition rebuild was done but that resulted in FIPS panic. This issue is now tracked using a new JIRA card, therefore, we are updating the tracker for rhaos-pkgs-match-openshift.