### PR TITLE
NO-JIRA: ci: re-run failed tests and allow for success on flaky connections

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -115,7 +115,7 @@ cosa_build() {
 # Build QEMU image and run all kola tests
 kola_test_qemu() {
     cosa buildextend-qemu
-    cosa kola run --parallel 2 --output-dir ${ARTIFACT_DIR:-/tmp}/kola
+    cosa kola run --parallel 2 --output-dir ${ARTIFACT_DIR:-/tmp}/kola --allow-rerun-success tags=needs-internet
 }
 
 # Build metal, metal4k & live images and run kola tests


### PR DESCRIPTION
kola has a flag to re-run tests and allow for it to pass on re-run. This is useful when there are intermittent network failures that happen that is out of our control.