### PR TITLE
denylist: add ext.config.rpm-ostree.replace-rt-kernel

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -48,3 +48,8 @@
   snooze: 2025-01-01
   osversion:
     - rhel-9.6
+
+- pattern: ext.config.rpm-ostree.replace-rt-kernel
+  tracker: https://github.com/openshift/os/issues/1640
+  osversion:
+    - rhel-9.4


### PR DESCRIPTION
In 4.16, 4.17 and 4.18 [rhel-9.4] this test is failing after kernel being upgraded in the Build OSTree stage.

See: https://github.com/openshift/os/issues/1640