### PR TITLE
OKD-228: pin sig-cloud to release 4.18 in c9s repo

### DIFF
--- a/c9s.repo
+++ b/c9s.repo
@@ -55,8 +55,8 @@ enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-Virtualization
 
 [c9s-sig-cloud-okd]
-name=CentOS Stream 9 - SIG Cloud OKD 4.16
-baseurl=https://mirror.stream.centos.org/SIGs/9-stream/cloud/$basearch/okd-4.16/
+name=CentOS Stream 9 - SIG Cloud OKD 4.18
+baseurl=https://mirror.stream.centos.org/SIGs/9-stream/cloud/$basearch/okd-4.18/
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1


### PR DESCRIPTION
To pick up the appropriate version of cri-o