### PR TITLE
[release-4.17] OKD-228: use sig-cloud 4.17 repo

### DIFF
--- a/c9s.repo
+++ b/c9s.repo
@@ -55,8 +55,8 @@ enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-Virtualization
 
 [c9s-sig-cloud-okd]
-name=CentOS Stream 9 - SIG Cloud OKD 4.16
-baseurl=https://mirror.stream.centos.org/SIGs/9-stream/cloud/$basearch/okd-4.16/
+name=CentOS Stream 9 - SIG Cloud OKD 4.17
+baseurl=https://mirror.stream.centos.org/SIGs/9-stream/cloud/$basearch/okd-4.17/
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1

--- a/overrides-c9s.yaml
+++ b/overrides-c9s.yaml
@@ -3,8 +3,13 @@
 # we need in the `packages` section. When not needed. Empty or comment out this
 # file (except this comment).
 
-#repos:
+repos:
 #  - c9s-baseos-mirror
-#  - c9s-appstream-mirror
+  - c9s-appstream-mirror
 
-#packages:
+packages:
+  # https://issues.redhat.com/browse/RHEL-61612
+  - clevis-20-200.el9
+  - clevis-dracut-20-200.el9
+  - clevis-luks-20-200.el9
+  - clevis-systemd-20-200.el9


### PR DESCRIPTION
Use the 4.17 sig-cloud repo to use the appropriate cri-o package. Also pin clevis to 20-200.el9 until
https://issues.redhat.com/browse/RHEL-61612 is fixed.