### PR TITLE
[release-4.16] OKD-228: use sig-cloud 4.16 repo

### DIFF
--- a/c9s.repo
+++ b/c9s.repo
@@ -55,8 +55,8 @@ enabled=1
 gpgkey=file:///usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-SIG-Virtualization
 
 [c9s-sig-cloud-okd]
-name=CentOS Stream 9 - SIG Cloud OKD 4.15
-baseurl=https://mirror.stream.centos.org/SIGs/9-stream/cloud/$basearch/okd-4.15/
+name=CentOS Stream 9 - SIG Cloud OKD 4.16
+baseurl=https://mirror.stream.centos.org/SIGs/9-stream/cloud/$basearch/okd-4.16/
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1

--- a/overrides-c9s.yaml
+++ b/overrides-c9s.yaml
@@ -4,9 +4,12 @@
 # file (except this comment).
 
 repos:
-  - c9s-baseos-mirror
+# - c9s-baseos-mirror
   - c9s-appstream-mirror
 
 packages:
-  # https://github.com/openshift/os/issues/1514
-  - selinux-policy-38.1.36-1.el9
+  # https://issues.redhat.com/browse/RHEL-61612
+  - clevis-20-200.el9
+  - clevis-dracut-20-200.el9
+  - clevis-luks-20-200.el9
+  - clevis-systemd-20-200.el9


### PR DESCRIPTION
Use the 4.16 sig-cloud repo to use the appropriate cri-o package. Also pin clevis to 20-200.el9 until
https://issues.redhat.com/browse/RHEL-61612 is fixed