### PR TITLE
NO-JIRA: [ocp-]rhel-9.6: consume from RHEL 9.6 repos

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -7,25 +7,21 @@
   tracker: https://github.com/openshift/os/issues/1237
   osversion:
     - c9s
-    - rhel-9.6
 
 - pattern: iso-live-login.uefi-secure
   tracker: https://github.com/openshift/os/issues/1237
   osversion:
     - c9s
-    - rhel-9.6
 
 - pattern: iso-as-disk.uefi-secure
   tracker: https://github.com/openshift/os/issues/1237
   osversion:
     - c9s
-    - rhel-9.6
 
 - pattern: fips.*
   tracker: https://github.com/openshift/os/issues/1540
   osversion:
     - c9s
-    - rhel-9.6
 
 # The 4.17 and 4.18 build of Ignition encounters a FIPS panic so
 # we are using the 4.16 build for now while that is under investigation.
@@ -36,15 +32,3 @@
 # but not denylisted here so it can run on the rhcos pipeline
 #- pattern: iso-offline-install-iscsi.ibft.bios
 #  tracker: https://github.com/openshift/os/issues/1492
-
-# as it's a fake rhel build (from c9s) versions won't match
-- pattern: ext.config.version.rhel-major-version
-  tracker: https://github.com/openshift/os/issues/1635
-  snooze: 2025-01-01
-  osversion:
-    - rhel-9.6
-- pattern: ext.config.shared.content-origins
-  tracker: https://github.com/openshift/os/issues/1635
-  snooze: 2025-01-01
-  osversion:
-    - rhel-9.6

--- a/manifest-ocp-rhel-9.6.yaml
+++ b/manifest-ocp-rhel-9.6.yaml
@@ -16,20 +16,9 @@ include:
   - packages-openshift.yaml
 
 # Additional repos we need for OCP components
-# right now we use rhel-9.4 OCP repos as RHEL 9.6 is not available yet
 repos:
-  - rhel-9.4-fast-datapath
-  - rhel-9.4-server-ose-4.18
-  - rhel-9.4-appstream
-  - c9s-extras-common
-  - c9s-sig-nfv
-  - c9s-nfv
-
-packages:
- # RPM GPG keys for CentOS SIG repos
-  - centos-release-cloud-common
-  - centos-release-nfv-common
-  - centos-release-virt-common
+  - rhel-9.6-fast-datapath
+  - rhel-9.6-server-ose-4.18
 
 # We include hours/minutes to avoid version number reuse
 automatic-version-prefix: "418.96.<date:%Y%m%d%H%M>"
@@ -97,15 +86,15 @@ postprocess:
      ln -s /usr/lib/issue /etc/issue
      ln -s /usr/lib/issue /etc/issue.net
 
-# Packages pinned to specific repos in RHCOS 9
 repo-packages:
-  - repo: c9s-appstream
+  # https://issues.redhat.com/browse/RHELPLAN-170883
+  - repo: rhel-9.6-appstream
     packages:
-      - nss-altfiles
-  - repo: rhel-9.4-server-ose-4.18
-    packages:
-      - conmon-rs
-      - cri-o
-      - cri-tools
-      - openshift-clients
-      - openshift-kubelet
+      - conmon
+      - containers-common
+      - container-selinux
+      - crun
+      - podman
+      - runc
+      - skopeo
+      - toolbox

--- a/manifest-rhel-9.6.yaml
+++ b/manifest-rhel-9.6.yaml
@@ -12,11 +12,9 @@ variables:
 include:
   - common.yaml
 
-# XXX todo: swap to rhel 9.6 repos when beta is GA
-# CentOS Stream 9 repos for now
 repos:
-  - c9s-baseos
-  - c9s-appstream
+  - rhel-9.6-baseos
+  - rhel-9.6-appstream
 
 # Eventually we should try to build these images as part of the RHEL composes.
 # In that case, the versioning should instead be exactly the same as the pungi
@@ -27,52 +25,9 @@ automatic-version-suffix: "-"
 
 mutate-os-release: "9.6"
 
-# XXX todo: swap to rhel 9.6 repos when beta is GA
-repo-packages:
-  - repo: c9s-baseos
-    packages:
-     # We include the generic centos release package and fake the red hat os-release
-     # info in a post-process script
-     # XXX todo: swap to redhat-release once 9.6 beta is GA
-     - centos-stream-release
-
-# XXX remove once swapping to rhel 9.6 beta content
-# Fake out RHEL version in the os-release while waiting for RHEL-9.6 release.
-postprocess:
-  - |
-     #!/usr/bin/env bash
-     set -xeo pipefail
-
-     (
-     . /etc/os-release
-     cat > /usr/lib/os-release <<EOF
-     NAME="Red Hat Enterprise Linux CoreOS"
-     VERSION="${OSTREE_VERSION} (Plow)"
-     ID="rhel"
-     ID_LIKE="fedora"
-     VERSION="${OSTREE_VERSION}"
-     VARIANT="CoreOS"
-     VARIANT_ID=coreos
-     VERSION_ID="9.6"
-     PLATFORM_ID="platform:el9"
-     PRETTY_NAME="Red Hat Enterprise Linux CoreOS ${OSTREE_VERSION} (Plow)"
-     ANSI_COLOR="0;31"
-     LOGO="fedora-logo-icon"
-     CPE_NAME="cpe:/o:redhat:enterprise_linux:9::baseos"
-     HOME_URL="https://www.redhat.com/"
-     DOCUMENTATION_URL="https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9"
-     BUG_REPORT_URL="https://issues.redhat.com/"
-
-     REDHAT_BUGZILLA_PRODUCT="Red Hat Enterprise Linux 9"
-     REDHAT_BUGZILLA_PRODUCT_VERSION=9.6
-     REDHAT_SUPPORT_PRODUCT="Red Hat Enterprise Linux"
-     REDHAT_SUPPORT_PRODUCT_VERSION="9.6"
-     OSTREE_VERSION="${OSTREE_VERSION}"
-     EOF
-     )
-
-
-      rm -f /etc/system-release /etc/os-release /etc/redhat-release
-      ln -s /usr/lib/os-release /etc/os-release
-      ln -s /usr/lib/os-release /etc/system-release
-      ln -s /usr/lib/os-release /etc/redhat-release
+# Packages that are only in RHCOS and not in SCOS or that have special
+# constraints that do not apply to SCOS
+packages:
+ # We include the generic release package and tweak the os-release info in a
+ # post-process script
+ - redhat-release


### PR DESCRIPTION
RHEL 9.6 nightly content is already available to use so let's start tracking that instead for the 9.6 variants.

Note that OCP is approved to use that content.

While we're here, enact https://issues.redhat.com/browse/RHELPLAN-170883 where there was agreement that all container-related RPMs starting from 4.19+ will come from RHEL. This is prep for
https://github.com/openshift/enhancements/pull/1637.