### PR TITLE
NO-JIRA: manifests: move from `rojig` to `metadata`

### DIFF
--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -1,6 +1,6 @@
 # Manifest for CentOS Stream CoreOS 9
 
-rojig:
+metadata:
   license: MIT
   name: scos
   summary: CentOS Stream CoreOS 9

--- a/manifest-ocp-rhel-9.4.yaml
+++ b/manifest-ocp-rhel-9.4.yaml
@@ -1,7 +1,7 @@
 # Manifest for OCP node based on RHEL 9.4
 # Note: this manifest is temporary; in the future, OCP components will be layered instead.
 
-rojig:
+metadata:
   license: MIT
   name: rhcos
   summary: OpenShift 4.18

--- a/manifest-ocp-rhel-9.6.yaml
+++ b/manifest-ocp-rhel-9.6.yaml
@@ -1,7 +1,7 @@
 # Manifest for OCP node based on RHEL 9.6
 # Note: this manifest is temporary; in the future, OCP components will be layered instead.
 
-rojig:
+metadata:
   license: MIT
   name: rhcos
   summary: OpenShift 4.18

--- a/manifest-okd-c9s.yaml
+++ b/manifest-okd-c9s.yaml
@@ -1,7 +1,7 @@
 # Manifest for OKD node based on CentOS Stream CoreOS 9
 # Note: this manifest is temporary; in the future, OKD components will be layered instead.
 
-rojig:
+metadata:
   license: MIT
   name: scos
   summary: OKD 4.18

--- a/manifest-rhel-9.4.yaml
+++ b/manifest-rhel-9.4.yaml
@@ -1,6 +1,6 @@
 # Manifest for RHCOS based on RHEL 9.4
 
-rojig:
+metadata:
   license: MIT
   name: rhcos
   summary: RHEL CoreOS 9.4

--- a/manifest-rhel-9.6.yaml
+++ b/manifest-rhel-9.6.yaml
@@ -1,6 +1,6 @@
 # Manifest for RHCOS based on RHEL 9.6
 
-rojig:
+metadata:
   license: MIT
   name: rhcos
   summary: RHEL CoreOS 9.6

--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -106,7 +106,7 @@ postprocess:
     # This works around the fact that we can't currently access manifest
     # variables from postprocess scripts, though we just use the name, since
     # it's easier.
-    variant=$(jq -r .rojig.name /usr/share/rpm-ostree/treefile.json)
+    variant=$(jq -r .metadata.name /usr/share/rpm-ostree/treefile.json)
     if [ $variant = "scos" ]; then
       colloquial_name=SCOS
       project_name=OKD


### PR DESCRIPTION
Now that cosa supports looking at the `metadata` key, let's finally stop abusing the `rojig` key.