### PR TITLE
[release-4.18] gitmodules: track rhcos-4.18 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "fedora-coreos-config"]
 	path = fedora-coreos-config
 	url = https://github.com/coreos/fedora-coreos-config
-	branch = testing-devel
+	branch = rhcos-4.18


### PR DESCRIPTION
Start tracking the rhcos-4.18 branch of fedora-coreos-config as a part of branching 4.18