### PR TITLE
NO-JIRA: bump version to 4.19

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -138,6 +138,7 @@ RHCOS/OCP version | RHEL version
 4.16 | 9.4 EUS
 4.17 | 9.4 EUS
 4.18 | 9.4 EUS
+4.19 | 9.6 EUS
 
 ## Q: How do I determine what version of an RPM is included in an RHCOS release?
 

--- a/extensions-rhel-9.4.yaml
+++ b/extensions-rhel-9.4.yaml
@@ -9,7 +9,7 @@ extensions:
       - x86_64
       - aarch64
     repos:
-      - rhel-9.4-server-ose-4.18
+      - rhel-9.4-server-ose-4.19
     packages:
       - crun-wasm
   # https://github.com/coreos/fedora-coreos-tracker/issues/1504
@@ -69,7 +69,7 @@ extensions:
       - x86_64
       - s390x
     repos:
-      - rhel-9.4-server-ose-4.18
+      - rhel-9.4-server-ose-4.19
     packages:
       - kata-containers
   # https://issues.redhat.com/browse/COS-2402

--- a/extensions-rhel-9.6.yaml
+++ b/extensions-rhel-9.6.yaml
@@ -12,7 +12,7 @@ extensions:
       # XXX todo: swap to rhel 9.6 repos when beta is GA
       # Ideally we would use content from c9s as it's the same as rhel 9.6 for now
       # but this particular package does not exist there
-      - rhel-9.4-server-ose-4.18
+      - rhel-9.6-server-ose-4.19
     packages:
       - crun-wasm
   # https://github.com/coreos/fedora-coreos-tracker/issues/1504
@@ -76,7 +76,7 @@ extensions:
       # XXX ideally we would pull that from c9s as it's identical to rhel 9.6 for now
       # but c9s does not build this for s390x so we have to pull it from rhel 9.4
       # todo: swap to rhel 9.6 repos when beta is GA
-      - rhel-9.4-server-ose-4.18
+      - rhel-9.6-server-ose-4.19
     packages:
       - kata-containers
   # https://issues.redhat.com/browse/COS-2402

--- a/manifest-ocp-rhel-9.4.yaml
+++ b/manifest-ocp-rhel-9.4.yaml
@@ -4,7 +4,7 @@
 metadata:
   license: MIT
   name: rhcos
-  summary: OpenShift 4.18
+  summary: OpenShift 4.19
 
 variables:
   osversion: "rhel-9.4"
@@ -18,14 +18,14 @@ include:
 # Additional repos we need for OCP components
 repos:
   - rhel-9.4-fast-datapath
-  - rhel-9.4-server-ose-4.18
+  - rhel-9.4-server-ose-4.19
 
 # We include hours/minutes to avoid version number reuse
-automatic-version-prefix: "418.94.<date:%Y%m%d%H%M>"
+automatic-version-prefix: "419.94.<date:%Y%m%d%H%M>"
 # This ensures we're semver-compatible which OpenShift wants
 automatic-version-suffix: "-"
 # Keep this is sync with the version in postprocess
-mutate-os-release: "4.18"
+mutate-os-release: "4.19"
 
 postprocess:
   - |
@@ -91,7 +91,7 @@ repo-packages:
   - repo: rhel-9.4-appstream
     packages:
       - nss-altfiles
-  - repo: rhel-9.4-server-ose-4.18
+  - repo: rhel-9.4-server-ose-4.19
     packages:
       - conmon-rs
       - cri-o

--- a/manifest-ocp-rhel-9.6.yaml
+++ b/manifest-ocp-rhel-9.6.yaml
@@ -4,7 +4,7 @@
 metadata:
   license: MIT
   name: rhcos
-  summary: OpenShift 4.18
+  summary: OpenShift 4.19
 
 variables:
   osversion: "rhel-9.6"
@@ -18,14 +18,14 @@ include:
 # Additional repos we need for OCP components
 repos:
   - rhel-9.6-fast-datapath
-  - rhel-9.6-server-ose-4.18
+  - rhel-9.6-server-ose-4.19
 
 # We include hours/minutes to avoid version number reuse
-automatic-version-prefix: "418.96.<date:%Y%m%d%H%M>"
+automatic-version-prefix: "419.96.<date:%Y%m%d%H%M>"
 # This ensures we're semver-compatible which OpenShift wants
 automatic-version-suffix: "-"
 # Keep this is sync with the version in postprocess
-mutate-os-release: "4.18"
+mutate-os-release: "4.19"
 
 postprocess:
   - |

--- a/manifest-okd-c9s.yaml
+++ b/manifest-okd-c9s.yaml
@@ -4,7 +4,7 @@
 metadata:
   license: MIT
   name: scos
-  summary: OKD 4.18
+  summary: OKD 4.19
 
 variables:
   osversion: "c9s"
@@ -22,14 +22,15 @@ repos:
   # CentOS Cloud SIG repo for cri-o, cri-tools and conmon-rs
   - c9s-sig-cloud-okd
   # Include RHCOS 9 repo for oc, hyperkube
-  - rhel-9.4-server-ose-4.18
+  # rhel-9.6-server-ose-4.19 is not mirrored in CI yet
+  - rhel-9.4-server-ose-4.19
 
 # We include hours/minutes to avoid version number reuse
-automatic-version-prefix: "418.9.<date:%Y%m%d%H%M>"
+automatic-version-prefix: "419.9.<date:%Y%m%d%H%M>"
 # This ensures we're semver-compatible which OpenShift wants
 automatic-version-suffix: "-"
 # Keep this is sync with the version in postprocess
-mutate-os-release: "4.18"
+mutate-os-release: "4.19"
 
 postprocess:
   - |

--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -2,7 +2,7 @@ metadata:
   # This should match the /etc/os-release manipulation we do below when
   # injecting `OPENSHIFT_VERSION`. It's used by CI to determine the repos to
   # inject when building the layered image.
-  ocp_version: "4.18"
+  ocp_version: "4.19"
 
 packages:
   # The packages below are required by OpenShift/OKD
@@ -97,7 +97,7 @@ postprocess:
     #!/usr/bin/env bash
     set -xeuo pipefail
     cat >> /usr/lib/os-release <<EOF
-    OPENSHIFT_VERSION="4.18"
+    OPENSHIFT_VERSION="4.19"
     EOF
 
   - |


### PR DESCRIPTION
4.18 branched so bump the versioni in main development to 4.19.

Note: CI hasn't been updated to use 9.6 repos yet.