### PR TITLE
NO-JIRA: denylist: add  ext.config.shared.var-mount.luks

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -28,7 +28,5 @@
 - pattern: ext.config.version.rhaos-pkgs-match-openshift
   tracker: https://issues.redhat.com/browse/OCPBUGS-42688
 
-# This test is failing only in prow, so it's skipped by prow
-# but not denylisted here so it can run on the rhcos pipeline
-#- pattern: iso-offline-install-iscsi.ibft.bios
-#  tracker: https://github.com/openshift/os/issues/1492
+- pattern: ext.config.shared.var-mount.luks
+  tracker: https://github.com/openshift/os/issues/1656


### PR DESCRIPTION
rhel-9.4 and rhel-9.6 builds are now failing with the above. Let's denylist it until resolution is found.

See: https://github.com/openshift/os/issues/1656