### PR TITLE
NO-JIRA: Bump fedora-coreos-config

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -7,7 +7,6 @@ include:
   - fedora-coreos-config/manifests/networking-tools.yaml
   - fedora-coreos-config/manifests/user-experience.yaml
   - fedora-coreos-config/manifests/shared-workarounds.yaml
-  - fedora-coreos-config/manifests/bootupd.yaml
   # RHCOS owned packages
   - packages-rhcos.yaml
 
@@ -47,9 +46,15 @@ conditional-include:
     include: fedora-coreos-config/manifests/shared-el9.yaml
   - if: osversion == "rhel-9.6"
     include: fedora-coreos-config/manifests/shared-el9.yaml
-
+  - if: inherit_tier_x == true
+    include: fedora-coreos-config/manifests/tier-x.yaml
+  - if: inherit_tier_x == false
+    include: fedora-coreos-config/manifests/tier-x-dupes.yaml
 
 documentation: false
+
+# historical default
+recommends: true
 
 postprocess:
   # Mark the OS as of the CoreOS variant.

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -35,9 +35,15 @@
 
 - pattern: ext.config.shared.var-mount.luks
   tracker: https://github.com/openshift/os/issues/1656
+  osversion:
+    - c9s
+    - rhel-9.6
 
 - pattern: ext.config.shared.root-reprovision.luks.autosave-xfs
   tracker: https://github.com/openshift/os/issues/1656
+  osversion:
+    - c9s
+    - rhel-9.6
 
 - pattern: "*kdump*"
   tracker: https://gitlab.com/redhat/centos-stream/containers/bootc/-/issues/1169

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -38,3 +38,9 @@
 
 - pattern: ext.config.shared.root-reprovision.luks.autosave-xfs
   tracker: https://github.com/openshift/os/issues/1656
+
+- pattern: "*kdump*"
+  tracker: https://gitlab.com/redhat/centos-stream/containers/bootc/-/issues/1169
+  osversion:
+    - c9s
+    - rhel-9.6

--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -7,6 +7,7 @@ metadata:
 
 variables:
   osversion: "c9s"
+  inherit_tier_x: true
 
 # Include manifests common to all RHEL and CentOS Stream versions
 include:

--- a/manifest-rhel-9.4.yaml
+++ b/manifest-rhel-9.4.yaml
@@ -7,6 +7,7 @@ metadata:
 
 variables:
   osversion: "rhel-9.4"
+  inherit_tier_x: false
 
 # Include manifests common to all RHEL and CentOS Stream versions
 include:

--- a/manifest-rhel-9.6.yaml
+++ b/manifest-rhel-9.6.yaml
@@ -7,6 +7,7 @@ metadata:
 
 variables:
   osversion: "rhel-9.6"
+  inherit_tier_x: true
 
 # Include manifests common to all RHEL and CentOS Stream versions
 include:


### PR DESCRIPTION
This is basically https://github.com/openshift/os/pull/1644 but with a commit added. Doing it this way instead of pushing to that PR directly because the bot will just nuke my changes if new commits land in f-c-c.

```
Adam Piasecki (1):
      denylist: add multipath.partition

Dusty Mabe (7):
      tests/kola: add SELinux systemd /var/cache exceptions in upgrade test
      Move to Fedora Linux 41
      denylist: drop kdump.crash.nfs and ext.config.boot.bootupd-validate
      overrides: drop graduated grub2-2.12-10.fc41 override
      07fix-selinux-labels: fix service ordering
      tests/kola: fix potential unbound variable error
      ci: use OSbuild to build metal/metal4k in one shot

HuijingHei (5):
      test: extend bootupd test to include testing adoption and updates
      denylist: deny `ext.config.boot.bootupd-validate` until we rollout F41
      tests/kola: remove dtb exceptions in upgrade test SELinux checks
      tests/upgrade: drop the rollback deployment on aarch64
      tests/bootupd-validate: skip checking BIOS on older bootupd

Jonathan Lebon (17):
      workflows/add-overrides: install python3-dnf
      Inherit from fedora-bootc's tier-x on Fedora 42+
      manifests: conditionalize duplicate manifests
      manifests: split system-configuration.yaml
      manifests: split networking-tools.yaml
      manifests: split user-experience.yaml
      manifests: hoist up bootable-rpm-ostree.yaml include
      manifests: move veritysetup request to ignition-and-ostree.yaml
      manifests: move bootc to bootable-rpm-ostree.yaml
      manifests: conditionalize bootable-rpm-ostree.yaml
      manifests: just disable systemd-firstboot, don't nuke
      manifests: split ignition-and-ostree.yaml
      manifests: split tier-x dupes into separate manifest
      workflows: add `bump-fedora-bootc` workflow
      manifests/tier-x: use readonly in repo config only
      workflows/remove-graduated-overrides: clone with submodule
      manifests/fedora-coreos: move from `rojig` to `metadata`

Joseph Marrero Corchado (1):
      manifest: Add bootc

Michael Armijo (1):
      denylist: remove fcos.internet and podman.workflow

Nikita Dubrovskii (3):
      dnf5: use 'setopt' to enable 'updates-testing' repo
      dnf5 builddep: drop '--spec' as it no longer exists
      coreos-secex-ignition-prepare: remount /usr rw if needed
```