### PR TITLE
NO-JIRA: denylist: add removed context

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -28,5 +28,10 @@
 - pattern: ext.config.version.rhaos-pkgs-match-openshift
   tracker: https://issues.redhat.com/browse/OCPBUGS-42688
 
+# This test is failing only in prow, so it's skipped by prow
+# but not denylisted here so it can run on the rhcos pipeline
+#- pattern: iso-offline-install-iscsi.ibft.bios
+#  tracker: https://github.com/openshift/os/issues/1492
+
 - pattern: ext.config.shared.var-mount.luks
   tracker: https://github.com/openshift/os/issues/1656


### PR DESCRIPTION
In a previous PR to denylist some of the context was removed. This PR brings back what was deleted unintentionally.