### PR TITLE
NO-JIRA: Add tpm2_getcap to the initrd for Clevis TPM2 functionality

### DIFF
--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fde/module-setup.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fde/module-setup.sh
@@ -62,6 +62,7 @@ install() {
         tpm2_create
         tpm2_createpolicy
         tpm2_createprimary
+        tpm2_getcap
         tpm2_load
         tpm2_pcrread
         tpm2_unseal


### PR DESCRIPTION
The tpm2_getcap binary is required for Clevis TPM2 operations but was missing from the initrd.

See: https://github.com/openshift/os/issues/1656