### PR TITLE
NO-JIRA: denylist: add ext.config.shared.root-reprovision.luks.autosave-xfs

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -35,3 +35,6 @@
 
 - pattern: ext.config.shared.var-mount.luks
   tracker: https://github.com/openshift/os/issues/1656
+
+- pattern: ext.config.shared.root-reprovision.luks.autosave-xfs
+  tracker: https://github.com/openshift/os/issues/1656


### PR DESCRIPTION
rhel-9.6 builds are now failing with the above. Let's denylist it until a new version of clevis lands.

See: https://github.com/openshift/os/issues/1662