### PR TITLE
NO-JIRA: kola-denylist: drop clevis-related entries

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -33,18 +33,6 @@
 #- pattern: iso-offline-install-iscsi.ibft.bios
 #  tracker: https://github.com/openshift/os/issues/1492
 
-- pattern: ext.config.shared.var-mount.luks
-  tracker: https://github.com/openshift/os/issues/1656
-  osversion:
-    - c9s
-    - rhel-9.6
-
-- pattern: ext.config.shared.root-reprovision.luks.autosave-xfs
-  tracker: https://github.com/openshift/os/issues/1656
-  osversion:
-    - c9s
-    - rhel-9.6
-
 - pattern: "*kdump*"
   tracker: https://gitlab.com/redhat/centos-stream/containers/bootc/-/issues/1169
   osversion:


### PR DESCRIPTION
We have new enough clevis now in RHEL and CentOS Stream.