### PR TITLE
COS-3074: ci/prow: add stubs for rhel 10

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -316,6 +316,12 @@ main() {
         "scos-10-build-test-metal")
             exit 0
             ;;
+        "rhcos-10-build-test-qemu")
+            exit 0
+            ;;
+        "rhcos-10-build-test-metal")
+            exit 0
+            ;;
         *)
             # This case ensures that we exhaustively list the tests that should
             # pass for a PR. To add a new test in openshift/os:


### PR DESCRIPTION
Preparation work to update openshift/release jobs to build rhel 10. Now that we can build rhcos using RHEL nightly content we can start building RHCOS based on rhel 10 in CI.

See https://issues.redhat.com/browse/COS-2901