### PR TITLE
NO-JIRA: Remove clevis overrides for OKD

### DIFF
--- a/overrides-c9s.yaml
+++ b/overrides-c9s.yaml
@@ -3,13 +3,8 @@
 # we need in the `packages` section. When not needed. Empty or comment out this
 # file (except this comment).
 
-repos:
+#repos:
 # - c9s-baseos-mirror
-  - c9s-appstream-mirror
+# - c9s-appstream-mirror
 
-packages:
-  # https://issues.redhat.com/browse/RHEL-61612
-  - clevis-20-200.el9
-  - clevis-dracut-20-200.el9
-  - clevis-luks-20-200.el9
-  - clevis-systemd-20-200.el9
+#packages:


### PR DESCRIPTION
Due to https://github.com/openshift/os/issues/1630, we had to pin clevis to an older version. This was fixed in clevis-21-203.el9, so removing it.