### PR TITLE
NO-JIRA: packages-openshift: fix bash conditional syntax

### DIFF
--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -122,8 +122,8 @@ postprocess:
     fi
     # in the el-only variants, we already have CoreOS in the NAME, so don't
     # re-add it when building the node image
-    if [ $NAME != *CoreOS* ]; then
-      NAME=$NAME CoreOS
+    if [[ $NAME != *CoreOS* ]]; then
+      NAME="$NAME CoreOS"
     fi
     cat > /etc/motd <<EOF
     $NAME $OSTREE_VERSION


### PR DESCRIPTION
packages-openshift: fix bash conditional syntax

When using the globby checks, we need to use the bash-specific double
brackets, not single. Also fix the appending of "CoreOS" to the `NAME`
variable.

Fixes 621ac80 ("packages-openshift: fix duplicate "CoreOS" in motd").

