### PR TITLE
NO-JIRA: extensions-ocp-rhel-9.6: add rhel-9.4-appstream for crun-wasm

### DIFF
--- a/extensions-ocp-rhel-9.6.yaml
+++ b/extensions-ocp-rhel-9.6.yaml
@@ -10,6 +10,9 @@ extensions:
       - aarch64
     repos:
       - rhel-9.6-server-ose-4.19
+      # temporarily add rhel-9.4-appstream for crun-wasm
+      # https://github.com/openshift/os/issues/1680
+      - rhel-9.4-appstream
     packages:
       - crun-wasm
   # https://github.com/coreos/fedora-coreos-tracker/issues/1504


### PR DESCRIPTION
Temporarily add the rhel-9.4-appstream repo for crun-wasm dependencies. The version of crun-wasm explicity requires version 15 of lldd and llvm which are not in the current rhel-9.6-appstream repo. We can remove rhel-9.4-appstream when a 9.6 compatible version of crun-wasm is built.

See: https://github.com/openshift/os/issues/1680