### PR TITLE
NO-JIRA: common.yaml: disable composefs on ppc64le for now

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -57,6 +57,15 @@ documentation: false
 recommends: true
 
 postprocess:
+  - |
+    #!/usr/bin/bash
+    set -xeuo pipefail
+    # Disable composefs for now on c9s/9.6 ppc64le due to
+    # https://issues.redhat.com/browse/RHEL-70199, which needs kernel backports.
+    if [ "$(uname -m)" = "ppc64le" ] && [[ $(rpm -q kernel) = *.el9.ppc64le ]]; then
+      rm -vf /usr/lib/ostree/prepare-root.conf
+    fi
+
   # Mark the OS as of the CoreOS variant.
   # XXX: should be part of a centos/redhat-release subpackage instead
   - |


### PR DESCRIPTION
There are issues with composefs on ppc64le right now: https://issues.redhat.com/browse/RHEL-70199

Work around this for now by disabling composefs on ppc64le only.

We don't want to ship to production with this kind of delta across arches, but at least for now this allows us to keep running tests on arches where it does work.

Note this will also run on 9.4 variants, but it's harmless there since `prepare-root.conf` doesn't exist.