### PR TITLE
NO-JIRA: tests/replace-rt-kernel: ensure we always pick a different EVR

### DIFF
--- a/tests/kola/rpm-ostree/replace-rt-kernel/test.sh
+++ b/tests/kola/rpm-ostree/replace-rt-kernel/test.sh
@@ -42,12 +42,7 @@ case "${AUTOPKGTEST_REBOOT_MARK:-}" in
     runv sed -i '/\[baseos\]/,/^ *\[/ s/enabled=0/enabled=1/' /etc/yum.repos.d/cs.repo
     runv sed -i '/\[appstream\]/,/^ *\[/ s/enabled=0/enabled=1/' /etc/yum.repos.d/cs.repo
 
-    evr=
-    if rpm -q centos-stream-release; then
-        # we're already on CentOS and probably running the latest kernel. so
-        # here we need to instead pick whatever the latest that's *not* the same
-        evr=-$(dnf repoquery kernel --qf '%{EVR}' | grep -v "$(rpm -q kernel --qf %{EVR})" | tail -n1)
-    fi
+    evr=-$(dnf repoquery kernel --qf '%{EVR}' | grep -v "$(rpm -q kernel --qf %{EVR})" | tail -n1)
 
     echo "Testing overriding with CentOS Stream kernel"
     runv rpm-ostree override replace --experimental --from repo=baseos kernel{,-core,-modules,-modules-extra,-modules-core}"${evr}"


### PR DESCRIPTION
Right now, only on c9s-based systems, we have logic to ensure we pick a different EVR. But even in the RHEL case, we need this logic because we might be in the period where c9s and RHEL are in sync and so the kernel builds have the same EVRs in both RHEL and c9s.

Work around this by just always doing the repoquery and filtering.

This is technically an rpm-ostree bug I think, but highly unlikely to happen in the wild because you normally replace with a kernel from the same vendor.