### PR TITLE
NO-JIRA: kola-denylist: add ext.config.shared.boot.bootupd-validate

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -39,5 +39,13 @@
     - c9s
     - rhel-9.6
 
+- pattern: ext.config.shared.boot.bootupd-validate
+  tracker: https://github.com/openshift/os/issues/1687
+  osversion:
+    - c9s
+    - rhel-9.6
+  arches:
+    - ppc64le
+
 - pattern: ext.config.shared.rpm-ostree.kernel-replace
   tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1849


### PR DESCRIPTION
This test is failing on el9.6/c9s. It needs investigation but let's denylist it for now to unblock things.