### PR TITLE
NO-JIRA: el-only variants: drop hours and minutes from version timestamp

### DIFF
--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -21,7 +21,7 @@ repos:
 # Eventually we should try to build these images as part of the c9s composes.
 # In that case, the versioning should instead be exactly the same as the pungi
 # compose ID.
-automatic-version-prefix: "9.<date:%Y%m%d>"
+automatic-version-prefix: "9.0.<date:%Y%m%d>"
 # This ensures we're semver-compatible which OpenShift wants
 automatic-version-suffix: "-"
 

--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -18,9 +18,6 @@ repos:
   - c9s-baseos
   - c9s-appstream
 
-# Eventually we should try to build these images as part of the c9s composes.
-# In that case, the versioning should instead be exactly the same as the pungi
-# compose ID.
 automatic-version-prefix: "9.0.<date:%Y%m%d>"
 # This ensures we're semver-compatible which OpenShift wants
 automatic-version-suffix: "-"

--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -21,7 +21,7 @@ repos:
 # Eventually we should try to build these images as part of the c9s composes.
 # In that case, the versioning should instead be exactly the same as the pungi
 # compose ID.
-automatic-version-prefix: "9.<date:%Y%m%d%H%M>"
+automatic-version-prefix: "9.<date:%Y%m%d>"
 # This ensures we're semver-compatible which OpenShift wants
 automatic-version-suffix: "-"
 

--- a/manifest-rhel-9.4.yaml
+++ b/manifest-rhel-9.4.yaml
@@ -20,7 +20,7 @@ repos:
 # Eventually we should try to build these images as part of the RHEL composes.
 # In that case, the versioning should instead be exactly the same as the pungi
 # compose ID.
-automatic-version-prefix: "9.4.<date:%Y%m%d%H%M>"
+automatic-version-prefix: "9.4.<date:%Y%m%d>"
 # This ensures we're semver-compatible which OpenShift wants
 automatic-version-suffix: "-"
 

--- a/manifest-rhel-9.4.yaml
+++ b/manifest-rhel-9.4.yaml
@@ -17,9 +17,6 @@ repos:
   - rhel-9.4-baseos
   - rhel-9.4-appstream
 
-# Eventually we should try to build these images as part of the RHEL composes.
-# In that case, the versioning should instead be exactly the same as the pungi
-# compose ID.
 automatic-version-prefix: "9.4.<date:%Y%m%d>"
 # This ensures we're semver-compatible which OpenShift wants
 automatic-version-suffix: "-"

--- a/manifest-rhel-9.6.yaml
+++ b/manifest-rhel-9.6.yaml
@@ -20,7 +20,7 @@ repos:
 # Eventually we should try to build these images as part of the RHEL composes.
 # In that case, the versioning should instead be exactly the same as the pungi
 # compose ID.
-automatic-version-prefix: "9.6.<date:%Y%m%d%H%M>"
+automatic-version-prefix: "9.6.<date:%Y%m%d>"
 # This ensures we're semver-compatible which OpenShift wants
 automatic-version-suffix: "-"
 

--- a/manifest-rhel-9.6.yaml
+++ b/manifest-rhel-9.6.yaml
@@ -17,9 +17,6 @@ repos:
   - rhel-9.6-baseos
   - rhel-9.6-appstream
 
-# Eventually we should try to build these images as part of the RHEL composes.
-# In that case, the versioning should instead be exactly the same as the pungi
-# compose ID.
 automatic-version-prefix: "9.6.<date:%Y%m%d>"
 # This ensures we're semver-compatible which OpenShift wants
 automatic-version-suffix: "-"


### PR DESCRIPTION
As part of the layered node image work, I was initially thinking we'd still keep the e.g. `419.96...` format there, but I'm now thinking we _don't_ override the versioning info from the base RHCOS layer anymore. So e.g. `bootc status` on an OCP node would still show `9.6...`. This is potentially breaking; I'm ready to help fix any issues that occur from this change in any OCP code that parses the version string today.

So then, it becomes much more enticing to also bundle with this change the suggestion in #1617 since any consumers  will have to adapt to the new version string anyway.

So let's do that.

Closes: #1617