### PR TITLE
[release-4.17] OCPBUGS-46013: pin libreswan version to 4.6 in rhcos extension

### DIFF
--- a/extensions-rhel-9.4.yaml
+++ b/extensions-rhel-9.4.yaml
@@ -15,9 +15,9 @@ extensions:
   # https://github.com/coreos/fedora-coreos-tracker/issues/1504
   ipsec:
     packages:
-      # pin to 4.6 for now for https://issues.redhat.com/browse/OCPBUGS-43498
+      # pin to 4.6-3.el9_0.3 for now for https://issues.redhat.com/browse/OCPBUGS-43498
       # we can revert once that's fixed in latest libreswan
-      - libreswan-4.6
+      - libreswan-4.6-3.el9_0.3
       - NetworkManager-libreswan
   # https://github.com/coreos/fedora-coreos-tracker/issues/326
   usbguard:

--- a/extensions-rhel-9.4.yaml
+++ b/extensions-rhel-9.4.yaml
@@ -15,7 +15,9 @@ extensions:
   # https://github.com/coreos/fedora-coreos-tracker/issues/1504
   ipsec:
     packages:
-      - libreswan
+      # pin to 4.6 for now for https://issues.redhat.com/browse/OCPBUGS-43498
+      # we can revert once that's fixed in latest libreswan
+      - libreswan-4.6
       - NetworkManager-libreswan
   # https://github.com/coreos/fedora-coreos-tracker/issues/326
   usbguard:


### PR DESCRIPTION
This change installes libreswan-4.6-3.el9_0.3 via ipsec extension as a mitigation step to address the ipsec connection issue tracked in https://issues.redhat.com/browse/OCPBUGS-41823. This change can be reverted once a final fix in libreswan is ready to be consumed by openshift

JIRA: https://issues.redhat.com/browse/OCPBUGS-43498