### PR TITLE
OCPBUGS-43498: use the full NEVRA name when specifying libreswan version

### DIFF
--- a/extensions-ocp-rhel-9.4.yaml
+++ b/extensions-ocp-rhel-9.4.yaml
@@ -15,9 +15,9 @@ extensions:
   # https://github.com/coreos/fedora-coreos-tracker/issues/1504
   ipsec:
     packages:
-      # pin to 4.6 for now for https://issues.redhat.com/browse/OCPBUGS-43498
+      # pin to 4.6-3.el9_0.3 for now for https://issues.redhat.com/browse/OCPBUGS-43498
       # we can revert once that's fixed in latest libreswan
-      - libreswan-4.6
+      - libreswan-4.6-3.el9_0.3
       - NetworkManager-libreswan
   # https://github.com/coreos/fedora-coreos-tracker/issues/326
   usbguard:

--- a/extensions-ocp-rhel-9.6.yaml
+++ b/extensions-ocp-rhel-9.6.yaml
@@ -18,9 +18,9 @@ extensions:
   # https://github.com/coreos/fedora-coreos-tracker/issues/1504
   ipsec:
     packages:
-      # pin to 4.6 for now for https://issues.redhat.com/browse/OCPBUGS-43498
+      # pin to 4.6-3.el9_0.3 for now for https://issues.redhat.com/browse/OCPBUGS-43498
       # we can revert once that's fixed in latest libreswan
-      - libreswan-4.6
+      - libreswan-4.6-3.el9_0.3
       - NetworkManager-libreswan
   # https://github.com/coreos/fedora-coreos-tracker/issues/326
   usbguard:


### PR DESCRIPTION
libreswan-4.6-3.el9_1.1.x86_64 will be installed if not specified with full NEVRA name. The version we'd like to pin in rhcos extension is libreswan-4.6-3.el9_0.3