### PR TITLE
[release-4.18] OCPBUGS-46012: pin libreswan version to 4.6 in rhcos extension

### DIFF
--- a/extensions-rhel-9.4.yaml
+++ b/extensions-rhel-9.4.yaml
@@ -15,9 +15,9 @@ extensions:
   # https://github.com/coreos/fedora-coreos-tracker/issues/1504
   ipsec:
     packages:
-      # pin to 4.6 for now for https://issues.redhat.com/browse/OCPBUGS-43498
+      # pin to 4.6-3.el9_0.3 for now for https://issues.redhat.com/browse/OCPBUGS-43498
       # we can revert once that's fixed in latest libreswan
-      - libreswan-4.6
+      - libreswan-4.6-3.el9_0.3
       - NetworkManager-libreswan
   # https://github.com/coreos/fedora-coreos-tracker/issues/326
   usbguard:

--- a/extensions-rhel-9.6.yaml
+++ b/extensions-rhel-9.6.yaml
@@ -18,9 +18,9 @@ extensions:
   # https://github.com/coreos/fedora-coreos-tracker/issues/1504
   ipsec:
     packages:
-      # pin to 4.6 for now for https://issues.redhat.com/browse/OCPBUGS-43498
+      # pin to 4.6-3.el9_0.3 for now for https://issues.redhat.com/browse/OCPBUGS-43498
       # we can revert once that's fixed in latest libreswan
-      - libreswan-4.6
+      - libreswan-4.6-3.el9_0.3
       - NetworkManager-libreswan
   # https://github.com/coreos/fedora-coreos-tracker/issues/326
   usbguard:


### PR DESCRIPTION
Pin to full NEVR because otherwise we'd pick up the older 9.1 package