### PR TITLE
NO-JIRA: denylist: skip `bootupd-validate` on rhel-9.4

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -44,6 +44,7 @@
   osversion:
     - c9s
     - rhel-9.6
+    - rhel-9.4
   arches:
     - ppc64le
 


### PR DESCRIPTION
This test is also failing on the rhel-9.4 variant with the same symptoms as: https://github.com/openshift/os/issues/1687. 
Denylist the test on the rhel-9.4 variant to unblock the pipeline until we can investigate.