### PR TITLE
NO-JIRA: common.yaml: disable composefs on all arches on el9

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -60,10 +60,11 @@ postprocess:
   - |
     #!/usr/bin/bash
     set -xeuo pipefail
-    # Disable composefs for now on c9s/9.6 ppc64le due to
-    # https://issues.redhat.com/browse/RHEL-70199, which needs kernel backports.
-    if [ "$(uname -m)" = "ppc64le" ] && [[ $(rpm -q kernel) = *.el9.ppc64le ]]; then
-      rm -vf /usr/lib/ostree/prepare-root.conf
+    # Disable composefs for now on el9 due to ppc64le/kernel-64k bugs:
+    # https://issues.redhat.com/browse/RHEL-63985
+    if [ -f /usr/lib/ostree/prepare-root.conf ] && [[ $(rpm -q kernel) = *.el9.* ]]; then
+      grep -q 'enabled = true' /usr/lib/ostree/prepare-root.conf
+      sed -i -e 's,enabled = true,enabled = no,' /usr/lib/ostree/prepare-root.conf
     fi
 
   # Mark the OS as of the CoreOS variant.


### PR DESCRIPTION
There are issues currently on ppc64le and kernel-64k in el9 that break
with composefs. So it's not sufficient to do an architecture check
anyway. See: https://issues.redhat.com/browse/RHEL-63985.

The upcoming release of libostree will turn on composefs by default, so
it's not sufficient to delete `prepare-root.conf`; we need to explicitly
turn it off. See: https://github.com/ostreedev/ostree/pull/3353.