### PR TITLE
NO-JIRA: ci/get-ocp-repo.sh: add `--output-dir`

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -34,7 +34,7 @@ ARG OPENSHIFT_CI=0
 # any Python apps that run (e.g. dnf) will cause pyc creation.
 RUN --mount=type=bind,target=/run/src \
   find /usr -name '*.pyc' -exec mv {} {}.bak \; && \
-  if [ "${OPENSHIFT_CI}" != 0 ]; then /run/src/ci/get-ocp-repo.sh --ocp-layer /run/src/packages-openshift.yaml; fi && \
+  if [ "${OPENSHIFT_CI}" != 0 ]; then /run/src/ci/get-ocp-repo.sh --ocp-layer /run/src/packages-openshift.yaml --output-dir /run/yum.repos.d; fi && \
   /run/src/scripts/apply-manifest /run/src/packages-openshift.yaml && \
   find /usr -name '*.pyc.bak' -exec sh -c 'mv $1 ${1%.bak}' _ {} \; && \
   ostree container commit

--- a/ci/get-ocp-repo.sh
+++ b/ci/get-ocp-repo.sh
@@ -51,6 +51,8 @@ if [ -n "$ocp_manifest" ]; then
     info "Got OpenShift version $ocp_version from $ocp_manifest"
     # osname is used lower down, so set it
     osname=$(source /usr/lib/os-release; if [ $ID == centos ]; then echo scos; fi)
+
+    output_dir=$(dirname "$ocp_manifest")
 else
     [ -n "$cosa_workdir" ]
     # --cosa-workdir path
@@ -96,9 +98,12 @@ else
         rhel_version=${rhel_version//./}
     fi
     info "Got RHEL version $rhel_version from automatic-version-prefix value $version"
+
+    output_dir="$cosa_workdir/src/config"
 fi
 
-repo_path="$cosa_workdir/src/config/ocp.repo"
+mkdir -p "$output_dir"
+repo_path="$output_dir/ocp.repo"
 
 set -x
 curl --fail -L "http://base-${ocp_version}-rhel${rhel_version}.ocp.svc.cluster.local" -o "$repo_path"

--- a/ci/get-ocp-repo.sh
+++ b/ci/get-ocp-repo.sh
@@ -25,20 +25,22 @@ info() {
     echo "INFO:" "$@" >&2
 }
 
-if [ $# -eq 0 ]; then
-    print_usage_and_exit
-else
-    mode=$1; shift
-    cosa_workdir=
-    ocp_manifest=
-    if [ "$mode" = "--cosa-workdir" ]; then
-        cosa_workdir=$1; shift
-    elif [ "$mode" = "--ocp-layer" ]; then
-        ocp_manifest=$1; shift
-    else
-        print_usage_and_exit
-    fi
-fi
+cosa_workdir=
+ocp_manifest=
+rc=0
+options=$(getopt --options h --longoptions help,cosa-workdir:,ocp-layer: -- "$@") || rc=$?
+[ $rc -eq 0 ] || print_usage_and_exit
+eval set -- "$options"
+while [ $# -ne 0 ]; do
+    case "$1" in
+        -h | --help) print_usage_and_exit;;
+        --cosa-workdir) cosa_workdir=$2; shift;;
+        --ocp-layer) ocp_manifest=$2; shift;;
+        --) break;;
+        *) echo "$0: invalid argument: $1" >&2; exit 1;;
+    esac
+    shift
+done
 
 if [ -n "$ocp_manifest" ]; then
     # --ocp-layer path


### PR DESCRIPTION
In the node layering case, we're directly bind-mounting the build context dir. It's mounted read-only, so we can't write `ocp.repo` there. And even if we could, we shouldn't modify the build context if we don't need to.

Add a new `--output-dir` option to allow changing the directory to which to write `ocp.repo`. Use this in the node layering flow to output to `/run/yum.repos.d`, which is an already established API for transient repo definitions.