### PR TITLE
NO-JIRA: ci/prow: test on RHEL 9.6

### DIFF
--- a/ci/get-ocp-repo.sh
+++ b/ci/get-ocp-repo.sh
@@ -119,6 +119,14 @@ set -x
 curl --fail -L "http://base-${ocp_version}-rhel${rhel_version}.ocp.svc.cluster.local" -o "$repo_path"
 set +x
 
+if [ "${rhel_version}" = 96 ]; then
+    # XXX: also currently also add 9.4 repos for crun-wasm when building extensions
+    # https://github.com/openshift/os/issues/1680
+    # https://github.com/openshift/os/pull/1682
+    # https://issues.redhat.com/browse/COS-3075
+    curl --fail -L http://base-4-19-rhel94.ocp.svc.cluster.local >> "$repo_path"
+fi
+
 # If we're building the SCOS OKD variant, then strip away all the RHEL repos and just keep the plashet.
 # Temporary workaround until we have all packages for SCOS in CentOS Stream.
 if [ "$osname" = scos ]; then

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -274,6 +274,7 @@ main() {
             cosa_init "ocp-rhel-9.4"
             cosa_build
             ;;
+        # this is called by cosa's CI
         "rhcos-cosa-prow-pr-ci")
             setup_user
             cosa_init "ocp-rhel-9.4"
@@ -293,10 +294,16 @@ main() {
             kola_test_metal
             ;;
         "rhcos-96-build-test-qemu")
-            exit 0
+            setup_user
+            cosa_init "ocp-rhel-9.6"
+            cosa_build
+            kola_test_qemu
             ;;
         "rhcos-96-build-test-metal")
-            exit 0
+            setup_user
+            cosa_init "ocp-rhel-9.6"
+            cosa_build
+            kola_test_metal
             ;;
         "scos-9-build-test-qemu")
             setup_user

--- a/extensions-ocp-rhel-9.6.yaml
+++ b/extensions-ocp-rhel-9.6.yaml
@@ -10,8 +10,10 @@ extensions:
       - aarch64
     repos:
       - rhel-9.6-server-ose-4.19
-      # temporarily add rhel-9.4-appstream for crun-wasm
+      # XXX: temporarily add rhel-9.4-appstream for crun-wasm
       # https://github.com/openshift/os/issues/1680
+      # https://issues.redhat.com/browse/COS-3075
+      # NOTE: when reverting this, also revert the associated hack in get-ocp-repo.sh
       - rhel-9.4-appstream
     packages:
       - crun-wasm


### PR DESCRIPTION
We now have RHEL 9.6 content in the CI mirror so we can run tests.