### PR TITLE
NO-JIRA: manifest-ocp-rhel-9.6: get toolbox from ART plashet

### DIFF
--- a/manifest-ocp-rhel-9.4.yaml
+++ b/manifest-ocp-rhel-9.4.yaml
@@ -98,3 +98,4 @@ repo-packages:
       - cri-tools
       - openshift-clients
       - openshift-kubelet
+      - toolbox

--- a/manifest-ocp-rhel-9.6.yaml
+++ b/manifest-ocp-rhel-9.6.yaml
@@ -97,7 +97,9 @@ repo-packages:
       - podman
       - runc
       - skopeo
-      - toolbox
   - repo: rhel-9.6-appstream
     packages:
       - ignition
+  - repo: rhel-9.6-server-ose-4.19
+    packages:
+      - toolbox

--- a/packages-rhcos.yaml
+++ b/packages-rhcos.yaml
@@ -15,7 +15,6 @@ packages:
   - nss-altfiles
   - ostree
   - rpm-ostree
-  - toolbox
   # for kdump:
   # https://github.com/coreos/fedora-coreos-tracker/issues/622
   - kexec-tools


### PR DESCRIPTION
RHCOS is trying to move to a point where all container tool packages come from RHEL instead of the ART plashet[0]. This is part of the effort to have a RHEL only bootstrap image and a layered container image for the node. Unfortunately there is already a package in RHEL called toolbox which conflicts with the RHCOS toolbox.

Ensure that RHCOS gets the RHCOS toolbox by only getting the package from the ART plashet.

[0] https://issues.redhat.com/browse/RHELPLAN-170883