### PR TITLE
Add openvswitch-ipsec package for ipsec plugin

### DIFF
--- a/extensions-ocp-rhel-9.4.yaml
+++ b/extensions-ocp-rhel-9.4.yaml
@@ -19,6 +19,7 @@ extensions:
       # we can revert once that's fixed in latest libreswan
       - libreswan-4.6-3.el9_0.3
       - NetworkManager-libreswan
+      - openvswitch-ipsec
   # https://github.com/coreos/fedora-coreos-tracker/issues/326
   usbguard:
     packages:

--- a/extensions-ocp-rhel-9.6.yaml
+++ b/extensions-ocp-rhel-9.6.yaml
@@ -24,6 +24,7 @@ extensions:
       # we can revert once that's fixed in latest libreswan
       - libreswan-4.6-3.el9_0.3
       - NetworkManager-libreswan
+      - openvswitch-ipsec
   # https://github.com/coreos/fedora-coreos-tracker/issues/326
   usbguard:
     packages:


### PR DESCRIPTION
The FDP story (https://issues.redhat.com/browse/FDP-1051) gets openvswitch-ipsec systemd service with required configurable parameters for OCP. It's time for OCP to use this service running on the host for configuring IPsec for east west traffic. It also helps to bring up existing IPsec connections before kubelet upon node reboot scenarios. Hence this PR includes openvswitch-ipsec package to be part of the ipsec extension.