### PR TITLE
NO-JIRA: denylist: snooze `ostree.sync` on `s390x`

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -56,3 +56,10 @@
     - c9s
     - rhel-9.6
     - rhel-9.4
+
+- pattern: ostree.sync
+  tracker: https://github.com/openshift/os/issues/1720
+  snooze: 2025-02-11
+  warn: true
+  arches:
+    - s390x


### PR DESCRIPTION
This test is failing intermittently on s390x. Let's snooze it for now to unblock the pipeline while we investigate:
https://github.com/openshift/os/issues/1720