### PR TITLE
OCPBUGS-34629: Clean-up NVME-related IDs

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -31,14 +31,12 @@ conditional-include:
   - if: basearch != "s390x"
     # And remove some cruft from grub2
     include: fedora-coreos-config/manifests/grub2-removals.yaml
-    #zram default config is in a subpackage in c10s
-    # Meanwhile, remove the default config from the package
   - if: osversion == "c9s"
-    include: zram-no-defaults.yaml
+    include: manifest-el9-shared.yaml
   - if: osversion == "rhel-9.4"
-    include: zram-no-defaults.yaml
+    include: manifest-el9-shared.yaml
   - if: osversion == "rhel-9.6"
-    include: zram-no-defaults.yaml
+    include: manifest-el9-shared.yaml
   # Packages specific to el9
   - if: osversion == "c9s"
     include: fedora-coreos-config/manifests/shared-el9.yaml
@@ -57,16 +55,6 @@ documentation: false
 recommends: true
 
 postprocess:
-  - |
-    #!/usr/bin/bash
-    set -xeuo pipefail
-    # Disable composefs for now on el9 due to ppc64le/kernel-64k bugs:
-    # https://issues.redhat.com/browse/RHEL-63985
-    if [ -f /usr/lib/ostree/prepare-root.conf ] && [[ $(rpm -q kernel) = *.el9.* ]]; then
-      grep -q 'enabled = true' /usr/lib/ostree/prepare-root.conf
-      sed -i -e 's,enabled = true,enabled = no,' /usr/lib/ostree/prepare-root.conf
-    fi
-
   # Mark the OS as of the CoreOS variant.
   # XXX: should be part of a centos/redhat-release subpackage instead
   - |

--- a/manifest-el9-shared.yaml
+++ b/manifest-el9-shared.yaml
@@ -18,3 +18,21 @@ postprocess:
       grep -q 'enabled = true' /usr/lib/ostree/prepare-root.conf
       sed -i -e 's,enabled = true,enabled = no,' /usr/lib/ostree/prepare-root.conf
     fi
+
+  - |
+    #!/usr/bin/env bash
+    set -xeo pipefail
+    # Clean-up NVME-related IDs. Right now they are getting generated
+    # at build time and because we create a "golden image" everyone is
+    # getting the same IDs, but they are supposed to be unique.
+    # In Fedora and EL10 the %post that generates this was removed
+    # - https://src.fedoraproject.org/rpms/nvme-cli/c/629f632c97ab888f2ae3a8bc3eb2bacf0959dd2d
+    # - https://gitlab.com/redhat/centos-stream/rpms/nvme-cli/-/commit/762906d9286ed3d83af70ff6d620ba32b5addd3e
+    # - https://issues.redhat.com/browse/RHEL-68495
+    # Related:
+    # - https://github.com/openshift/os/issues/1519
+    # - https://issues.redhat.com/browse/OCPBUGS-34629
+    #
+    # In EL9, when https://issues.redhat.com/browse/RHEL-8041 gets fixed we
+    # can drop this workaround.
+    rm -fv /etc/nvme/hostid /etc/nvme/hostnqn

--- a/manifest-el9-shared.yaml
+++ b/manifest-el9-shared.yaml
@@ -1,0 +1,20 @@
+# Place here configuration that should happen on all el9* builds
+
+#zram default config is in a subpackage in c10s
+# Meanwhile, remove the default config from the package
+remove-from-packages:
+  # zram-generator-0.3.2 (shipped in centOS 9) provides a default
+  # zram-generator config, we want to disable it
+  - - zram-generator
+    - "/usr/lib/systemd/zram-generator.conf"
+
+postprocess:
+  - |
+    #!/usr/bin/bash
+    set -xeuo pipefail
+    # Disable composefs for now on el9 due to ppc64le/kernel-64k bugs:
+    # https://issues.redhat.com/browse/RHEL-63985
+    if [ -f /usr/lib/ostree/prepare-root.conf ]; then
+      grep -q 'enabled = true' /usr/lib/ostree/prepare-root.conf
+      sed -i -e 's,enabled = true,enabled = no,' /usr/lib/ostree/prepare-root.conf
+    fi

--- a/zram-no-defaults.yaml
+++ b/zram-no-defaults.yaml
@@ -1,5 +1,0 @@
-remove-from-packages:
-  # zram-generator-0.3.2 (shipped in centOS 9) provides a default
-  # zram-generator config, we want to disable it
-  - - zram-generator
-    - "/usr/lib/systemd/zram-generator.conf"


### PR DESCRIPTION
## manifest-el9-shared: Clean-up NVME-related IDs

> See https://github.com/openshift/os/issues/1519
> and https://issues.redhat.com/browse/OCPBUGS-34629

## create new manifest-el9-shared.yaml manifest

> This makes a manifest to be shared amongst rhel-9.4 rhel-9.6 and c9s
>  and moves some initial configuration into it, including the disabling
>  of composefs and the dropping of the zram-generator configuration.
