### PR TITLE
NO-JIRA: common.yaml: re-enable composefs on el9

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -45,3 +45,6 @@
   warn: true
   arches:
     - s390x
+
+- pattern: ostree.sync
+  tracker: https://github.com/openshift/os/issues/1744

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -45,15 +45,6 @@
   osversion:
     - rhel-9.4
 
-# There are issues currently on ppc64le and kernel-64k in el9 that break
-# with composefs.
-- pattern: ext.config.shared.composefs.enabled
-  tracker: https://issues.redhat.com/browse/RHEL-70199
-  osversion:
-    - c9s
-    - rhel-9.6
-    - rhel-9.4
-
 - pattern: ostree.sync
   tracker: https://github.com/openshift/os/issues/1720
   snooze: 2025-02-11

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -39,12 +39,6 @@
     - c9s
     - rhel-9.6
 
-# Remove this when we stop using rhel-9.4
-- pattern: ext.config.shared.boot.bootupd-validate
-  tracker: https://github.com/openshift/os/issues/1687
-  osversion:
-    - rhel-9.4
-
 - pattern: ostree.sync
   tracker: https://github.com/openshift/os/issues/1720
   snooze: 2025-02-11

--- a/manifest-el9-shared.yaml
+++ b/manifest-el9-shared.yaml
@@ -16,5 +16,5 @@ postprocess:
     # https://issues.redhat.com/browse/RHEL-63985
     if [ -f /usr/lib/ostree/prepare-root.conf ]; then
       grep -q 'enabled = true' /usr/lib/ostree/prepare-root.conf
-      sed -i -e 's,enabled = true,enabled = no,' /usr/lib/ostree/prepare-root.conf
+      sed -i -e 's,enabled = true,enabled = maybe,' /usr/lib/ostree/prepare-root.conf
     fi

--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -32,7 +32,7 @@ postprocess:
     # kernel overrides today for e.g. kernel-rt.
     for x in $(find /etc/yum.repos.d/ -name '*.repo'); do
       # ignore repo files that are mountpoints since they're likely secrets
-      if ! findmnt "$x" &>/dev/null; then
+      if ! mountpoint "$x"; then
         sed -i -e s,enabled=1,enabled=0, $x
       fi
     done


### PR DESCRIPTION
The composefs issue (https://issues.redhat.com/browse/RHEL-63985)
should now be fixed in the latest el9 kernel. So let's optimistically
re-enable it. Now that we have tests for now, CI will validate this for
us as well.