### PR TITLE
[release-4.16] OCPBUGS-49835: Backport extensions/Dockerfile: Get extensions rpm list

### DIFF
--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -27,6 +27,16 @@ RUN rm -f /etc/yum.repos.d/*.repo \
 RUN dnf install -y createrepo_c
 RUN createrepo_c /usr/share/rpm-ostree/extensions/
 
+# Generate extensions.json for meta.json, written to a bind-mounted path during the build.
+# Use dnf repoquery to print 'name: version,' for each RPM
+# sed to remove the comma from the last RPM
+RUN sh -c 'echo "{" > /tmp/extensions.json && \
+dnf repoquery --repofrompath=extensions,/usr/share/rpm-ostree/extensions/ \
+  --quiet --disablerepo=* --enablerepo=extensions \
+  --queryformat "\"%{name}\": \"%{version}\"," | \
+sed "$ s/,$//" >> /tmp/extensions.json && \
+echo "}" >> /tmp/extensions.json'
+
 ## Final container that has the extensions repo dir
 FROM registry.access.redhat.com/ubi9/ubi:latest
 COPY --from=builder /usr/share/rpm-ostree/extensions/ /usr/share/rpm-ostree/extensions/

--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -33,7 +33,7 @@ RUN createrepo_c /usr/share/rpm-ostree/extensions/
 RUN sh -c 'echo "{" > /tmp/extensions.json && \
 dnf repoquery --repofrompath=extensions,/usr/share/rpm-ostree/extensions/ \
   --quiet --disablerepo=* --enablerepo=extensions \
-  --queryformat "\"%{name}\": \"%{version}\"," | \
+  --queryformat "\"%{name}\": \"%{evr}.%{arch}\"," | \
 sed "$ s/,$//" >> /tmp/extensions.json && \
 echo "}" >> /tmp/extensions.json'
 


### PR DESCRIPTION
 - Generate JSON file listing installed extension packages;
 - Use dnf repoquery to list 'name: version,' for each RPM and generates a JSON file at `/tmp/extensions.json`. Where the build volume is mounted;
 - It is needed to generated the extensions package list in meta.json.

Signed-off-by: Renata Ravanelli <rravanel@redhat.com>
(cherry picked from commit 128a6b95d2ae0910073aae0dd6a309ab9b8f319d)