### PR TITLE
NO-JIRA: extensions: include release and arch in extensions.json

### DIFF
--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -35,7 +35,7 @@ RUN createrepo_c /usr/share/rpm-ostree/extensions/
 RUN sh -c 'echo "{" > /tmp/extensions.json && \
 dnf repoquery --repofrompath=extensions,/usr/share/rpm-ostree/extensions/ \
   --quiet --disablerepo=* --enablerepo=extensions \
-  --queryformat "\"%{name}\": \"%{version}\"," | \
+  --queryformat "\"%{name}\": \"%{evr}.%{arch}\"," | \
 sed "$ s/,$//" >> /tmp/extensions.json && \
 echo "}" >> /tmp/extensions.json'
 


### PR DESCRIPTION
`%{version}` just prints the version field, but we want the epoch, release, and arch too. This matches what we previously would output before moving extensions building to a container.

There is code that will parse this metadata assuming that it's an EVRA:

https://github.com/openshift-eng/art-tools/blob/6a29949b2b2819afe00829646e6c7db9b784ff8a/doozer/doozerlib/rhcos.py#L248