### PR TITLE
NO-JIRA: Containerfile: use secrets API for yum repo injection

### DIFF
--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -31,7 +31,10 @@ postprocess:
     # repos will be attempted to be fetched by rpm-ostree when doing node-local
     # kernel overrides today for e.g. kernel-rt.
     for x in $(find /etc/yum.repos.d/ -name '*.repo'); do
-      sed -i -e s,enabled=1,enabled=0, $x
+      # ignore repo files that are mountpoints since they're likely secrets
+      if ! findmnt "$x" &>/dev/null; then
+        sed -i -e s,enabled=1,enabled=0, $x
+      fi
     done
 
   # These enable librhsm which enables host subscriptions to work in containers

--- a/scripts/apply-manifest
+++ b/scripts/apply-manifest
@@ -41,28 +41,7 @@ if len(manifest.get('packages', [])):
     if 'cri-o' in packages:
         os.makedirs("/var/opt", exist_ok=True)
 
-    # inject mounted-in repo files
-    extra_repos_dir = '/run/yum.repos.d'
-    copied_repo_files = []
-    if os.path.isdir(extra_repos_dir):
-        for file in os.listdir(extra_repos_dir):
-            src_path = os.path.join(extra_repos_dir, file)
-            if not os.path.isfile(src_path):
-                continue
-            if not file.endswith(".repo"):
-                continue
-            dest_path = os.path.join('/etc/yum.repos.d', file)
-            if os.path.exists(dest_path):
-                raise Exception(f"Repo file {dest_path} already exists")
-            print(f"Copying repo file {file} to /etc/yum.repos.d/")
-            shutil.copy(src_path, dest_path)
-            copied_repo_files += [dest_path]
-
     runcmd(dnf_install)
-
-    # delete the repo files we injected
-    for repo in copied_repo_files:
-        os.unlink(repo)
 
 
 if len(manifest.get('postprocess', [])):


### PR DESCRIPTION
Instead of the `/run/yum.repos.d` mechanism, use the secrets API which is already well-known and does what we want here, which is to avoid having to copy repo files into the image.

The `RUN --mount` option gracefully ignores the case where no secret was provided, which is also the semantic we want for this.