### PR TITLE
NO-JIRA: manifest-rhel-9.6: add early kernel repo

### DIFF
--- a/manifest-rhel-9.6.yaml
+++ b/manifest-rhel-9.6.yaml
@@ -16,6 +16,7 @@ include:
 repos:
   - rhel-9.6-baseos
   - rhel-9.6-appstream
+  - rhel-9.6-early-kernel
 
 automatic-version-prefix: "9.6.<date:%Y%m%d>"
 # This ensures we're semver-compatible which OpenShift wants


### PR DESCRIPTION
We need to enable the `rhel-9.6-early-kernel` repo to ensure that we still get access to the early kernels. Non-el-only variants (like `ocp-rhel-9.6`) get this already through their plashets.

(In fact, the `rhel-9.6-early-kernel` repo is just an OCP plashet in disguise; there are excludes added so that only the kernel is permitted. This doesn't break the "el-only" concept because those kernels _are_ RHEL-versioned. It's just that historically we've consumed them through OCP plashets, but ideally in the future we'd have a separate, clearly RHEL-versioned, repo for them... But ideally ideally, when we rebase to rhel-bootc, we have a rhel-bootc stream that uses those kernels that we would derive from.)