### PR TITLE
NO-JIRA: overrides-c9s: add s390utils-base override for CentOS too

### DIFF
--- a/c9s-mirror.repo
+++ b/c9s-mirror.repo
@@ -1,6 +1,7 @@
 # These are the official c9s repos. They are slower to update, but contain older
 # versions of packages, which is useful when pinning for lack of a "coreos-pool"
-# equivalent. They are unused when no pinning is needed.
+# equivalent. When no pinning is needed you may find the compose repo URLs
+# defined in c9s.repo are quicker to get new content.
 
 [c9s-baseos-mirror]
 name=CentOS Stream 9 - BaseOS

--- a/c9s.repo
+++ b/c9s.repo
@@ -1,3 +1,9 @@
+# These are compose repo URLs that represent the latest composes in
+# CentOS Stream 9. Sometimes these repos get content a little faster
+# than the mirror repos defined in c9s-mirror.repo, but they won't
+# have multiple versions of packages, which make them not ideal when
+# needing to pin on older package versions.
+
 [c9s-baseos]
 name=CentOS Stream 9 - BaseOS
 baseurl=https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/BaseOS/$basearch/os

--- a/common.yaml
+++ b/common.yaml
@@ -298,9 +298,8 @@ packages-aarch64:
   - irqbalance
 
 packages-s390x:
-  # Required for IBM Secure Execution
-  # Pinned due to https://github.com/openshift/os/issues/1731
-  - s390utils-base-2.33.1-2.el9
+  # Required genprotimg for IBM Secure Execution
+  - s390utils-base
 
 remove-from-packages:
   - - filesystem

--- a/manifest-rhel-9.6.yaml
+++ b/manifest-rhel-9.6.yaml
@@ -12,6 +12,7 @@ variables:
 # Include manifests common to all RHEL and CentOS Stream versions
 include:
   - common.yaml
+  - overrides-rhel-9.6.yaml
 
 repos:
   - rhel-9.6-baseos

--- a/overrides-c9s.yaml
+++ b/overrides-c9s.yaml
@@ -3,8 +3,12 @@
 # we need in the `packages` section. When not needed. Empty or comment out this
 # file (except this comment).
 
-#repos:
-# - c9s-baseos-mirror
-# - c9s-appstream-mirror
+repos:
+ - c9s-baseos-mirror
+ - c9s-appstream-mirror
 
 #packages:
+
+packages-s390x:
+  # https://github.com/openshift/os/issues/1731
+  - s390utils-base-2.33.1-2.el9

--- a/overrides-rhel-9.6.yaml
+++ b/overrides-rhel-9.6.yaml
@@ -1,0 +1,9 @@
+# This is a poor man's version of an override lockfile for rhel-9.6. When needed
+# we gather any overrides NEVRs here to keep them in one place. When not needed,
+# empty or comment out this file (except this comment).
+
+#packages:
+
+packages-s390x:
+  # https://github.com/openshift/os/issues/1731
+  - s390utils-base-2.33.1-2.el9


### PR DESCRIPTION
~~As mentioned in [1] the mirrors have older versions and we're currently pinning an older version of s390utils-base [2] so we need to use these for now. I'm not sure of the reason to use the compose repos but if we change it back to that we should include the rationale in the commit and maybe a comment in the code.~~

~~[1] https://github.com/openshift/os/commit/88e41a0fef0dbe8e0b2d103cadd37217c8cd0933~~
~~[2] https://github.com/openshift/os/commit/71313d82c43d27fa26201f9ecd987b1716f31749~~

EDIT: See https://github.com/openshift/os/pull/1750#issuecomment-2669436000


Let's move the override added in [1] to a new file dedicated to
overrides. This will make it easier for us to identify and focus
on overcoming the issues related to the override.

[1] https://github.com/openshift/os/commit/71313d82c43d27fa26201f9ecd987b1716f31749

----

This adds the override from [1] and also enables the *mirror repos
since those are the repos that have older versiosn of packages in
CentOS Stream.

[1] https://github.com/openshift/os/commit/71313d82c43d27fa26201f9ecd987b1716f31749

