### PR TITLE
NO-JIRA: denylist: enable `ostree.sync` and disable on c10s

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -41,10 +41,10 @@
 
 - pattern: ostree.sync
   tracker: https://github.com/openshift/os/issues/1720
-  snooze: 2025-02-11
-  warn: true
   arches:
     - s390x
 
 - pattern: ostree.sync
-  tracker: https://github.com/openshift/os/issues/1744
+  tracker: https://github.com/openshift/os/issues/1751
+  osversion:
+    - c10s


### PR DESCRIPTION
As https://github.com/coreos/coreos-assembler/pull/4026 fixes the issue on c9s & rhcos9.6