### PR TITLE
[COS-3018] Add a small test to validate OCP packages are present

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -248,6 +248,13 @@ validate() {
     exit 0
 }
 
+validate_ocp_image() {
+    ocp_packages=$(rpm-ostree compose tree --print-only packages-openshift.yaml | jq -r '.packages[]')
+    for package in $ocp_packages; do
+        rpm -q "$package"
+    done
+}
+
 main() {
     if [[ "${#}" -lt 1 ]]; then
         echo "This script is expected to be called by Prow with the name of the build phase or test to run"
@@ -273,6 +280,10 @@ main() {
         "build" | "init-and-build-default")  # TODO: change prow job to use init-and-build-default
             cosa_init "ocp-rhel-9.6"
             cosa_build
+            ;;
+        # Check for if the OCP RPMs are properly installed
+        "validate-node-image")
+            validate_ocp_image
             ;;
         # this is called by cosa's CI
         "rhcos-cosa-prow-pr-ci")


### PR DESCRIPTION
Add a prow entrypoint to validate the OCP packages are installed. This is a trick to get prow to trigget a build of the node image without running all the metal and qemu tests.

See https://issues.redhat.com/browse/COS-3018