### PR TITLE
NO-JIRA: denylist: remove c9s fips.* entry

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -18,11 +18,6 @@
   osversion:
     - c9s
 
-- pattern: fips.*
-  tracker: https://github.com/openshift/os/issues/1540
-  osversion:
-    - c9s
-
 # The 4.17 and 4.18 build of Ignition encounters a FIPS panic so
 # we are using the 4.16 build for now while that is under investigation.
 - pattern: ext.config.version.rhaos-pkgs-match-openshift


### PR DESCRIPTION
The fips.* tests are passing now in c9s. Tested in: https://github.com/openshift/os/pull/1748.