### PR TITLE
OCPBUGS-52363: ci/get-ocp-repo.sh: Fixes for scos to accomodate building images in CI

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -35,5 +35,6 @@ RUN --mount=type=bind,target=/run/src --mount=type=secret,id=yumrepos,target=/et
   find /usr -name '*.pyc' -exec mv {} {}.bak \; && \
   if [ "${OPENSHIFT_CI}" != 0 ]; then /run/src/ci/get-ocp-repo.sh --ocp-layer /run/src/packages-openshift.yaml --output-dir /etc/yum.repos.d; fi && \
   /run/src/scripts/apply-manifest /run/src/packages-openshift.yaml && \
+  if [ "${OPENSHIFT_CI}" != 0 ]; then /run/src/ci/get-ocp-repo.sh --output-dir /etc/yum.repos.d --cleanup; fi && \
   find /usr -name '*.pyc.bak' -exec sh -c 'mv $1 ${1%.bak}' _ {} \; && \
   ostree container commit

--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -8,15 +8,7 @@ WORKDIR /os
 ADD . .
 ARG COSA
 ARG VARIANT
-RUN if [[ -z "$COSA" ]] ; then ci/get-ocp-repo.sh --ocp-layer packages-openshift.yaml; fi
-# on SCOS, we need to add the GPG keys of the various SIGs we need
-RUN if rpm -q centos-stream-release && ! rpm -q centos-release-cloud; then dnf install -y centos-release-{cloud,nfv,virt}-common; fi
-RUN mkdir -p /usr/share/distribution-gpg-keys/centos
-RUN ln -s /etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial /usr/share/distribution-gpg-keys/centos/RPM-GPG-KEY-CentOS-Official
-RUN ln -s {/etc/pki/rpm-gpg,/usr/share/distribution-gpg-keys/centos}/RPM-GPG-KEY-CentOS-SIG-Cloud
-RUN ln -s {/etc/pki/rpm-gpg,/usr/share/distribution-gpg-keys/centos}/RPM-GPG-KEY-CentOS-SIG-Extras-SHA512
-RUN ln -s {/etc/pki/rpm-gpg,/usr/share/distribution-gpg-keys/centos}/RPM-GPG-KEY-CentOS-SIG-NFV
-RUN ln -s {/etc/pki/rpm-gpg,/usr/share/distribution-gpg-keys/centos}/RPM-GPG-KEY-CentOS-SIG-Virtualization
+RUN if [[ -z "$COSA" ]] ; then ci/get-ocp-repo.sh --ocp-layer packages-openshift.yaml; else ci/get-ocp-repo.sh --create-gpg-keys; fi
 RUN if [[ -n "${VARIANT}" ]]; then MANIFEST="manifest-${VARIANT}.yaml"; EXTENSIONS="extensions-${VARIANT}.yaml"; else MANIFEST="manifest.yaml"; EXTENSIONS="extensions.yaml"; fi && rpm-ostree compose extensions --rootfs=/ --output-dir=/usr/share/rpm-ostree/extensions/ ./"${MANIFEST}" ./"${EXTENSIONS}"
 
 ## Creates the repo metadata for the extensions.

--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -33,7 +33,7 @@ postprocess:
     for x in $(find /etc/yum.repos.d/ -name '*.repo'); do
       # ignore repo files that are mountpoints since they're likely secrets
       if ! mountpoint "$x"; then
-        sed -i -e s,enabled=1,enabled=0, $x
+        sed -i -e 's/enabled\s*=\s*1/enabled=0/g' $x
       fi
     done
 


### PR DESCRIPTION
- For scos, we need the rhel-9.x-server-ose repo to get the Openshift releated binaries (kubelet, oc..)
- Append the c9s.repo so the packages for the rest comes from the CentOS Stream repos.
- Install centos stream packages so GPG keys are available when accessing the CentOS Stream repos

Once we have this merged, I am going to try to have config changes similar to the rhel-coreos [config](https://github.com/openshift/release/blob/master/ci-operator/config/openshift/os/openshift-os-master.yaml) to build and promote scos images. This will be the substitute for the mass open cloud pipeline through which we build our images today and will eliminate having us maintain and run it.