### PR TITLE
NO-JIRA: Bump fedora-coreos-config

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -27,9 +27,6 @@ ostree-layers:
   - overlay/30lvmdevices
 
 conditional-include:
-  - if: basearch != "s390x"
-    # And remove some cruft from grub2
-    include: fedora-coreos-config/manifests/grub2-removals.yaml
   # Packages specific to el9
   - if: osversion == "centos-9"
     include:

--- a/common.yaml
+++ b/common.yaml
@@ -24,7 +24,6 @@ ostree-layers:
   - overlay/30rhcos-nvme-compat-udev
   - overlay/30gcp-udev-rules
   - overlay/30lvmdevices
-  - overlay/40grub
 
 conditional-include:
   - if: basearch != "s390x"

--- a/common.yaml
+++ b/common.yaml
@@ -6,6 +6,7 @@ include:
   - fedora-coreos-config/manifests/file-transfer.yaml
   - fedora-coreos-config/manifests/networking-tools.yaml
   - fedora-coreos-config/manifests/user-experience.yaml
+  - fedora-coreos-config/manifests/tier-x.yaml
   # RHCOS owned packages
   - packages-rhcos.yaml
 
@@ -41,10 +42,6 @@ conditional-include:
   - if: osversion == "centos-10"
     include:
       - fedora-coreos-config/manifests/shared-el10.yaml
-  - if: inherit_tier_x == true
-    include: fedora-coreos-config/manifests/tier-x.yaml
-  - if: inherit_tier_x == false
-    include: fedora-coreos-config/manifests/tier-x-dupes.yaml
 
 documentation: false
 

--- a/common.yaml
+++ b/common.yaml
@@ -6,7 +6,6 @@ include:
   - fedora-coreos-config/manifests/file-transfer.yaml
   - fedora-coreos-config/manifests/networking-tools.yaml
   - fedora-coreos-config/manifests/user-experience.yaml
-  - fedora-coreos-config/manifests/shared-workarounds.yaml
   # RHCOS owned packages
   - packages-rhcos.yaml
 

--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -18,7 +18,6 @@ RUN rm -f /etc/yum.repos.d/*.repo \
 && curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora-archive.repo -o /etc/yum.repos.d/fedora-archive.repo
 RUN dnf install -y createrepo_c
 RUN createrepo_c /usr/share/rpm-ostree/extensions/
-
 # Generate extensions.json for meta.json.
 # Use dnf repoquery to print 'name: version,' for each RPM
 # sed to remove the comma from the last RPM

--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -10,12 +10,8 @@ ARG OPENSHIFT_CI=0
 RUN --mount=type=secret,id=yumrepos,target=/os/secret.repo extensions/build.sh
 
 ## Creates the repo metadata for the extensions.
-## This uses Fedora as a lowest-common-denominator because it will work on
-## current p8/s390x. See https://github.com/openshift/os/issues/1000
-FROM quay.io/fedora/fedora:41 as builder
+FROM quay.io/centos/centos:stream9 as builder
 COPY --from=os /usr/share/rpm-ostree/extensions/ /usr/share/rpm-ostree/extensions/
-RUN rm -f /etc/yum.repos.d/*.repo \
-&& curl -L https://raw.githubusercontent.com/coreos/fedora-coreos-config/testing-devel/fedora-archive.repo -o /etc/yum.repos.d/fedora-archive.repo
 RUN dnf install -y createrepo_c
 RUN createrepo_c /usr/share/rpm-ostree/extensions/
 # Generate extensions.json for meta.json.

--- a/fast-tracks.yaml
+++ b/fast-tracks.yaml
@@ -1,0 +1,13 @@
+c9s-appstream-back-tracks:
+  from: c9s-appstream
+  packages:
+    # While we wait we can pull this from c9s
+    # https://gitlab.com/redhat/centos-stream/release-engineering/pungi-centos/-/merge_requests/969
+    - ignition*
+rhel-9.6-server-ose-4.19-back-tracks:
+  from: rhel-9.6-server-ose-4.19
+  packages:
+    # While we wait we can pull this from rhel-9.6 openshift rhaos repos
+    # https://gitlab.com/redhat/centos-stream/release-engineering/pungi-centos/-/merge_requests/969
+    # which will then flow into RHEL 10.1.
+    - ignition*

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -117,11 +117,3 @@
   osversion:
     - centos-10
     - rhel-10.1
-
-# We are currently adding a dead symlink to allow MCO to install a pacemaker
-# resource agent in Two Node OpenShift with Fencing (TNF). This will be removed
-# once the underlying agent is shipped as part of the `two-node-ha` extension
-# and the TNF controller in etcd is updated to initialize pacemaker clusters
-# via the version shipped in the extension.
-- pattern: ext.config.shared.files.validate-symlinks
-  tracker: https://issues.redhat.com/browse/OCPEDGE-1706

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -96,3 +96,6 @@
   osversion:
     - centos-10
     - rhel-10.1
+
+- pattern: ext.config.shared.multipath.resilient
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1937

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -84,27 +84,6 @@
     - centos-10
     - rhel-10.1
 
-# Waiting for submodule bump
-- pattern: ext.config.shared.networking.nm-ifcfg-rh-plugin
-  tracker: https://github.com/openshift/os/pull/1759#issuecomment-2779700581
-  osversion:
-    - centos-10
-    - rhel-10.1
-
-# Waiting for submodule bump
-- pattern: ext.config.shared.networking.team-dhcp-via-ignition
-  tracker: https://github.com/openshift/os/pull/1759#issuecomment-2779700581
-  osversion:
-    - centos-10
-    - rhel-10.1
-
-# Waiting for submodule bump
-# https://github.com/coreos/fedora-coreos-config/pull/3439
-- pattern: ext.config.shared.networking.default-network-behavior-change
-  tracker: https://github.com/openshift/os/pull/1759#issuecomment-2779700581
-  osversion:
-    - rhel-10.1
-
 - pattern: ext.config.shared.content-origins
   tracker: https://issues.redhat.com/browse/RHEL-86436
   osversion:

--- a/manifest-c10s.yaml
+++ b/manifest-c10s.yaml
@@ -18,6 +18,9 @@ repos:
   - c10s-baseos
   - c10s-appstream
   - c10s-extras-common
+  # While we wait we can pull this from c9s
+  # https://gitlab.com/redhat/centos-stream/release-engineering/pungi-centos/-/merge_requests/969
+  - c9s-appstream-back-tracks
 
 automatic-version-prefix: "10.0.<date:%Y%m%d>"
 # This ensures we're semver-compatible which OpenShift wants

--- a/manifest-c10s.yaml
+++ b/manifest-c10s.yaml
@@ -8,7 +8,6 @@ metadata:
 variables:
   id: "centos"
   osversion: "centos-10"
-  inherit_tier_x: true
 
 # Include manifests common to all RHEL and CentOS Stream versions
 include:

--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -8,7 +8,6 @@ metadata:
 variables:
   id: "centos"
   osversion: "centos-9"
-  inherit_tier_x: true
 
 # Include manifests common to all RHEL and CentOS Stream versions
 include:

--- a/manifest-rhel-10.1.yaml
+++ b/manifest-rhel-10.1.yaml
@@ -20,6 +20,10 @@ repos:
   - rhel-10.1-appstream
   # Early kernel repo not available for now
   # - rhel-10.1-early-kernel
+  # While we wait we can pull this from rhel-9.6
+  # https://gitlab.com/redhat/centos-stream/release-engineering/pungi-centos/-/merge_requests/969
+  # which will then flow into RHEL 10.1.
+  - rhel-9.6-server-ose-4.19-back-tracks
 
 automatic-version-prefix: "10.1.<date:%Y%m%d>"
 # This ensures we're semver-compatible which OpenShift wants

--- a/manifest-rhel-10.1.yaml
+++ b/manifest-rhel-10.1.yaml
@@ -8,7 +8,6 @@ metadata:
 variables:
   id: "rhel"
   osversion: "rhel-10.1"
-  inherit_tier_x: true
 
 # Include manifests common to all RHEL and CentOS Stream versions
 include:

--- a/manifest-rhel-9.6.yaml
+++ b/manifest-rhel-9.6.yaml
@@ -8,7 +8,6 @@ metadata:
 variables:
   id: "rhel"
   osversion: "rhel-9.6"
-  inherit_tier_x: true
 
 # Include manifests common to all RHEL and CentOS Stream versions
 include:

--- a/overlay.d/07fix-selinux-labels
+++ b/overlay.d/07fix-selinux-labels
@@ -1,1 +1,0 @@
-../fedora-coreos-config/overlay.d/07fix-selinux-labels

--- a/overlay.d/40grub
+++ b/overlay.d/40grub
@@ -1,1 +1,0 @@
-../fedora-coreos-config/overlay.d/40grub


### PR DESCRIPTION
Created by [GitHub workflow](https://github.com/coreos/fedora-coreos-config/actions/workflows/openshift-os.yml) ([source](https://github.com/coreos/fedora-coreos-config/blob/testing-devel/.github/workflows/openshift-os.yml)).

```
Aashish Radhakrishnan (3):
      workflows/remove-graduated-overrides: Install python3-libdnf5
      denylist: add snooze for ext.config.kdump.crash & kdump.crash.ssh
      denylist: add snooze for kdump.crash.nfs

Adam Piasecki (3):
      tests/aws: Modify xen-assert to find xen entry in hypervisor string
      denylist: snooze root-reprovision on rawhide for ppc64le
      denylist: snooze coreos.boot-mirror for x86_64

Dusty Mabe (25):
      tests/manual: trim saved state in coreos-builds-bisect.py
      denylist: skip console warnings on ppc
      overlay.d: drop 40grub overlay
      overrides: fast-track ignition-2.21.0-2.fc41
      buildroot: workaround rpmbuild bug
      buildroot: better workaround for rpm-build bug
      denylist: add denial for toolbox on rawhide
      tests/upgrade: always wait for fix-selinux-labels
      tests/upgrade: rework booted deployment processing
      tests/upgrade: adjust for OCI based updates
      tests/upgrade: use a variable for architecture
      tests/upgrade: fix rebase to container image
      workflows/add-overrides: install python3-libdnf5
      tests: drop some cruft from the net behavior change test
      denylist: extend snooze for toolbox
      Move to Fedora Linux 42
      image.yaml: switch to EROFS; deploying via container
      drop as much dead code/manifests as possible
      overlay.d: Drop 07fix-selinux-labels overlay
      overlay/15fcos: drop cgroups and wifi checks
      overrides: fast-track moby-engine, containerd
      inline the 16disable-zincati overlay
      manifests/user-experience.yaml: include makedumpfile kdumpctl
      some riscv enablement
      denylist: deny ext.config.multipath.resilient on s390x

Etienne Champetier (1):
      overlay.d/40grub: remove 70_coreos-user.cfg

Fifo Phonics (1):
      Add docker swarm overlay network auto-bridge test

Huijing Hei (1):
      tests/networking: update `nm-ifcfg-rh-plugin` and `team-dhcp-via-ignition` working on el9

Jeremy Poulin (1):
      [TNF] Add podman-etcd resource agent to the expected broken symlinks in RHCOS

Jonathan Lebon (2):
      coreos-boot-mount-generator: honor `boot=` karg better in multipath case
      tests: add coverage for multipath + multiple `boot` labels + no `root` karg

Michael Armijo (3):
      manifests: include azure-vm-utils
      overrides: fast-track azure-vm-utils in f41
      denylist: add `skip-console-warnings` to openstack

Nikita Dubrovskii (6):
      ci/overrides.py: format code with autopep8
      ci/overrides.py: use libdnf5 instead of hawkey
      ci/overrides.py: use libdnf5 instead of python3-dnf
      Revert "workflows/add-overrides: install python3-dnf"
      ci/overrides.py: fix comparison of nevra
      ci/overrides.py: don't fail with KeyError when manifest has no 'repos'

jbtrystram (3):
      denylist: add pxe-offline-install.4k.ppcfw for PPC64le
      denylist: re-enable ppc64le pxe test
      overlay.d/15fcos: add a script to trigger zincati to rebase to OCI
```