### PR TITLE
NO-JIRA: Containerfile: add metadata in last layer of node image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -27,7 +27,7 @@
 #   --security-opt label=disable -t localhost/openshift-node-c9s \
 #   src/config
 
-FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev:c9s-coreos
+FROM quay.io/openshift-release-dev/ocp-v4.0-art-dev:c9s-coreos as build
 ARG OPENSHIFT_CI=0
 # Avoid shipping modified .pyc files. Due to https://github.com/ostreedev/ostree/issues/1469,
 # any Python apps that run (e.g. dnf) will cause pyc creation.
@@ -37,3 +37,10 @@ RUN --mount=type=bind,target=/run/src --mount=type=secret,id=yumrepos,target=/et
   /run/src/scripts/apply-manifest /run/src/packages-openshift.yaml && \
   find /usr -name '*.pyc.bak' -exec sh -c 'mv $1 ${1%.bak}' _ {} \; && \
   ostree container commit
+
+FROM build as metadata
+RUN --mount=type=bind,target=/run/src /run/src/scripts/generate-metadata
+
+FROM build
+COPY --from=metadata /usr/share/openshift /usr/share/openshift
+LABEL io.openshift.metalayer=true

--- a/scripts/generate-metadata
+++ b/scripts/generate-metadata
@@ -1,0 +1,56 @@
+#!/usr/bin/python3 -u
+
+"""
+This script generates metadata intended to be stored as a separate layer.
+For now, only the RPM listing is generated. It follows the same schema as the
+`rpmostree.rpmdb.pkglist` commit metadata key in a base rpm-ostree compose.
+This is because it's intended to be consumed by code previously adapted for
+that purpose.
+
+Also, for now only a single `meta.json` file is generated. Obviously more
+metadata of interest can be generated in the future.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+# The "base" here denotes the fact that this describes the base node image and
+# will inherently not be valid if another layering operation is done on top of
+# this image to install packages. The source of truth for package lists will
+# always be the rpmdb.
+METADATA_FILE = "/usr/share/openshift/base/meta.json"
+
+
+def main():
+    metadata = {
+        # this follows the same schema as rpmostree.rpmdb.pkglist but let's
+        # not actually name it the same because it's not actually rpm-ostree
+        # generating this
+        'rpmdb.pkglist': get_rpmdb_pkglist()
+    }
+    os.makedirs(os.path.dirname(METADATA_FILE), exist_ok=True)
+    with open(METADATA_FILE, encoding='utf-8', mode='w') as f:
+        json.dump(metadata, f)
+
+
+def get_rpmdb_pkglist():
+    QUERYFORMAT = '%{NAME}\t%{EPOCH}\t%{VERSION}\t%{RELEASE}\t%{ARCH}\n'
+    out = subprocess.check_output(['rpm', '-qa', '--queryformat', QUERYFORMAT],
+                                  encoding='utf-8')
+    rpmdb = []
+    for line in out.splitlines():
+        n, e, v, r, a = line.split()
+        # canonicalize none to 0 to match rpm-ostree semantics
+        if e == '(none)':
+            e = 0
+        rpmdb.append([n, e, v, r, a])
+
+    # sort it by package name to be nice to humans who like JSON
+    rpmdb = sorted(rpmdb, key=lambda p: p[0])
+    return rpmdb
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
Prior to the layered RHCOS enhancement[[1]], there was tooling in ART and in the RHCOS release browser (notably linked from the release controller) that relied on the commit metadata JSON file published separately to be able to inspect the RPM contents of a build.

With the move to a layered node image, we lose this. The more container-native analogue would be SBOMs, which we should get for free once we move to Konflux. However, until then, let's provide an easy-to- generate alternative that still allows avoiding to download the whole image.

We add a new semantic where the last layer of the node image is actually a metadata-only layer. Then, tooling like `oc image extract` capable of extracting only specific layers from an image can be used to pull it down. E.g.

```
$ oc image extract quay.io/jlebon/rhcos:latest[-1] --file /usr/share/openshift/base/meta.json
$ jq . meta.json
```

Add a label to signal that this image implements this semantic.

Compared to SBOMs, this has the _major_ advantage that it's in-band and implicitly gets preserved as the image is slung around (whereas an attached SBOM may not until the tooling is careful to do so).

But like SBOMs, it has the pitfall that the metadata is only valid for the original node image, and obviously skews once more layering is done. The source of truth for the package list is always the rpmdb.

That said, a client implicitly knows if the metadata no longer matches the node content simply by the fact that it wouldn't be in the last layer.

[1]: https://github.com/openshift/enhancements/blob/master/enhancements/rhcos/split-rhcos-into-layers.md