### PR TITLE
[release-4.14] OCPBUGS-52577: pin libreswan version to 4.6 in rhcos extension

### DIFF
--- a/extensions-c9s.yaml
+++ b/extensions-c9s.yaml
@@ -18,7 +18,7 @@ extensions:
   # https://github.com/coreos/fedora-coreos-tracker/issues/1504
   ipsec:
     packages:
-      - libreswan
+      - libreswan-4.6-3.el9_0.3
       - NetworkManager-libreswan
   # https://github.com/coreos/fedora-coreos-tracker/issues/326
   usbguard:

--- a/extensions-rhel-9.2.yaml
+++ b/extensions-rhel-9.2.yaml
@@ -13,7 +13,7 @@ extensions:
   # https://github.com/coreos/fedora-coreos-tracker/issues/1504
   ipsec:
     packages:
-      - libreswan
+      - libreswan-4.6-3.el9_0.3
       - NetworkManager-libreswan
   # https://github.com/coreos/fedora-coreos-tracker/issues/326
   usbguard:


### PR DESCRIPTION
When OCP is upgraded from 4.14 to 4.15 on a IPsec enabled cluster with a machine config pool in paused state, cluster is still blocked on 4.14 machine-config network operator and uses 4.14 os extension for the rollout, so this is going to install `libreswan-4.9-5.el9_2.4.x86_64 ` version for ipsec extension. But at the same time network cluster operator is already upgraded to 4.15 version as implemented with PR openshift/cluster-network-operator#2454 (which is going to be merged eventually), the ovn-ipsec-host pod container is installed with `libreswan-4.6-3.el9_0.3` as per change [here](https://github.com/openshift/ovn-kubernetes/blob/release-4.15/Dockerfile#L44).

Due to mismatch on libreswan versions between node and ipsec pod container, the ipsec container fails to configure ipsec connections on the node with peer nodes and in fact it crashes pluto daemon on the host. To fix this problem. This PR makes the 4.14 ipsec os extension plugin to be pinned with `libreswan-4.6-3.el9_0.3.x86_64` version so that both host and container can have the same libreswan version for interoperability.

/assign @huiran0826 