### PR TITLE
OCPBUGS-48614: Move ose-aws-ecr-image-credential-provider to CoreOS base

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -276,6 +276,10 @@ packages:
  - dnf
  # https://issues.redhat.com/browse/OCPBUGS-35247
  - subscription-manager
+ # XXX: This should be in packages-openshift.yaml instead. For now,
+ # it's in the base until the equivalent functionality lands in RHEL:
+ # https://issues.redhat.com/browse/RHEL-82921
+ - ose-aws-ecr-image-credential-provider
 
 packages-x86_64:
   # Temporary add of open-vm-tools. Should be removed when containerized

--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -13,7 +13,8 @@ packages:
   # The packages below are present in CentOS Stream/RHEL,
   # and depend on one or more of the above.
   - NetworkManager-ovs
-  - ose-aws-ecr-image-credential-provider
+  # XXX: There should also be ose-aws-ecr-image-credential-provider here. See
+  # common.yaml.
   - ose-azure-acr-image-credential-provider
   - ose-gcp-gcr-image-credential-provider
 


### PR DESCRIPTION
The ose-aws-ecr-image-credential-provider package is used in AWS by the kubelet to get ECR credentials, as described by:

https://kubernetes.io/docs/tasks/administer-cluster/kubelet-credential-provider/

However, it's also currently used at least by ROSA to provide a pull secret to podman during provisioning. This use case then broke when we switched to el-only bootimages and stopped including it.

The long-term goal is to have that functionality in RHEL proper, but at least for 4.19 let's work around this by lowering the package down to the CoreOS layer.

See also: https://issues.redhat.com/browse/RHEL-82921