### PR TITLE
NO-JIRA: ci/prow-entrypoint: skip pxe-offline-install.rootfs-appended.bios for…

### DIFF
--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -96,7 +96,7 @@ kola_test_metal() {
     cosa compress --artifact=metal --artifact=metal4k
 
     # Run all testiso scenarios on metal artifact
-    kola testiso -S --output-dir ${ARTIFACT_DIR:-/tmp}/kola-testiso  --denylist-test iso-offline-install-iscsi*
+    kola testiso -S --output-dir ${ARTIFACT_DIR:-/tmp}/kola-testiso  --denylist-test iso-offline-install-iscsi* --denylist-test pxe-offline-install.rootfs-appended.bios
 }
 
 # Ensure that we can create all platform images for COSA CI

--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -28,6 +28,11 @@
 #- pattern: iso-offline-install-iscsi.ibft.bios
 #  tracker: https://github.com/openshift/os/issues/1492
 
+# This test is failing only in prow, so it's skipped by prow
+# but not denylisted here so it can run on the rhcos pipeline
+#- pattern: pxe-offline-install.rootfs-appended.bios
+#  tracker: https://github.com/openshift/os/issues/1768
+
 - pattern: "*kdump*"
   tracker: https://gitlab.com/redhat/centos-stream/containers/bootc/-/issues/1169
   osversion:


### PR DESCRIPTION
… now

This is perma-failing in Prow right now, so just skip over it for now.

See: https://github.com/openshift/os/issues/1768