### PR TITLE
NO-JIRA: ci/get-ocp-repo.sh: pull in mirror repos when building scos

### DIFF
--- a/ci/get-ocp-repo.sh
+++ b/ci/get-ocp-repo.sh
@@ -194,7 +194,11 @@ if [ "$osname" = scos ]; then
     if [ -n "$ocp_manifest" ]; then
         workdir=$(dirname "$ocp_manifest")
     fi
+    # pull in the mirror repo as well in case there are newer versions in the composes
+    # and we require older versions - this happens because we build the node images async
+    # and the composes move fast.
     cat "$workdir/c9s.repo" >> "$repo_path.tmp"
+    cat "$workdir/c9s-mirror.repo" >> "$repo_path.tmp"
     mv "$repo_path.tmp" "$repo_path"
     create_gpg_keys
 fi

--- a/extensions-okd-c9s.yaml
+++ b/extensions-okd-c9s.yaml
@@ -56,6 +56,9 @@ extensions:
       - x86_64
     repos:
       - c9s-nfv
+      # nfv-mirror is needed while building scos node images through CI in case the composes have already moved kernel version
+      # this is true for any other package as well - so we will need to find a better solution for this [TODO]
+      - c9s-nfv-mirror
     packages:
       - kernel-rt-core
       - kernel-rt-kvm


### PR DESCRIPTION
Recently, building scos extensions hit this error:
```
error: Packages not found: kernel-rt-core-5.14.0-570.el9, kernel-rt-devel-5.14.0-570.el9, kernel-rt-kvm-5.14.0-570.el9, kernel-rt-modules-5.14.0-570.el9, kernel-rt-modules-extra-5.14.0-570.el9
```

This is because the baseos image was built with the 570 version of the kernel, but the composes had already moved on to the 571 version. While pulling the mirror repos fixes this for now, it would be ideal to always build from mirror repos as composes seem to have a faster cadence. We should probably also have the node image building be triggered at the same time the base images are being built to avoid these races.