### PR TITLE
SDN-5544: Unpin libreswan version

### DIFF
--- a/extensions-ocp-rhel-9.6.yaml
+++ b/extensions-ocp-rhel-9.6.yaml
@@ -20,9 +20,7 @@ extensions:
   # https://github.com/coreos/fedora-coreos-tracker/issues/1504
   ipsec:
     packages:
-      # pin to 4.6-3.el9_0.3 for now for https://issues.redhat.com/browse/OCPBUGS-43498
-      # we can revert once that's fixed in latest libreswan
-      - libreswan-4.6-3.el9_0.3
+      - libreswan
       - NetworkManager-libreswan
   # https://github.com/coreos/fedora-coreos-tracker/issues/326
   usbguard:


### PR DESCRIPTION
This would enable to consume libreswan 5 version from FDP repository.
https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=66972299