### PR TITLE
NO-JIRA: Various patches to build extensions container using `podman build` in production

### DIFF
--- a/ci/get-ocp-repo.sh
+++ b/ci/get-ocp-repo.sh
@@ -73,7 +73,7 @@ cosa_workdir=
 ocp_manifest=
 output_dir=
 rc=0
-options=$(getopt --options h --longoptions help,cosa-workdir:,ocp-layer:,output-dir:,cleanup,create-gpg-keys -- "$@") || rc=$?
+options=$(getopt --options h --longoptions help,cosa-workdir:,ocp-layer:,output-dir:,cleanup -- "$@") || rc=$?
 [ $rc -eq 0 ] || print_usage_and_exit
 eval set -- "$options"
 while [ $# -ne 0 ]; do
@@ -83,7 +83,6 @@ while [ $# -ne 0 ]; do
         --ocp-layer) ocp_manifest=$2; shift;;
         --output-dir) output_dir=$2; shift;;
         --cleanup) cleanup_repos; exit 0;;
-        --create-gpg-keys) create_gpg_keys; exit 0;;
         --) break;;
         *) echo "$0: invalid argument: $1" >&2; exit 1;;
     esac

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -81,7 +81,7 @@ cosa_build() {
 # Build QEMU image and run all kola tests
 kola_test_qemu() {
     cosa buildextend-qemu
-    cosa kola run --parallel 2 --output-dir ${ARTIFACT_DIR:-/tmp}/kola --rerun --allow-rerun-success tags=needs-internet
+    cosa kola run --parallel 2 --output-dir ${ARTIFACT_DIR:-/tmp}/kola --rerun --allow-rerun-success tags=needs-internet "$@"
 }
 
 # Build metal, metal4k & live images and run kola tests
@@ -301,13 +301,13 @@ main() {
             ;;
         "scos-9-build-test-qemu")
             setup_user
-            cosa_init "okd-c9s"
+            cosa_init "c9s"
             cosa_build
-            kola_test_qemu
+            kola_test_qemu --tag '!openshift'
             ;;
         "scos-9-build-test-metal")
             setup_user
-            cosa_init "okd-c9s"
+            cosa_init "c9s"
             cosa_build
             kola_test_metal
             ;;

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -270,10 +270,6 @@ main() {
             cosa_init "$2"
             prepare_repos
             ;;
-        "build" | "init-and-build-default")  # TODO: change prow job to use init-and-build-default
-            cosa_init "ocp-rhel-9.6"
-            cosa_build
-            ;;
         # this is called by cosa's CI
         "rhcos-cosa-prow-pr-ci")
             setup_user

--- a/ci/prow-entrypoint.sh
+++ b/ci/prow-entrypoint.sh
@@ -74,7 +74,9 @@ cosa_build() {
     cosa fetch
     # Only build the ostree image by default
     cosa build ostree
-    # Build extensions container
+}
+
+cosa_build_extensions() {
     cosa buildextend-extensions-container
 }
 
@@ -275,12 +277,14 @@ main() {
             setup_user
             cosa_init "ocp-rhel-9.6"
             cosa_build
+            cosa_build_extensions
             kola_test_qemu
             ;;
         "rhcos-9-build-test-qemu")
             setup_user
             cosa_init "ocp-rhel-9.6"
             cosa_build
+            cosa_build_extensions
             kola_test_qemu
             ;;
         "rhcos-9-build-test-metal")

--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -21,15 +21,18 @@ RUN rm -f /etc/yum.repos.d/*.repo \
 RUN dnf install -y createrepo_c
 RUN createrepo_c /usr/share/rpm-ostree/extensions/
 
-# Generate extensions.json for meta.json, written to a bind-mounted path during the build.
+# Generate extensions.json for meta.json.
 # Use dnf repoquery to print 'name: version,' for each RPM
 # sed to remove the comma from the last RPM
 RUN (echo "{" && \
 (dnf repoquery --repofrompath=extensions,/usr/share/rpm-ostree/extensions/ \
   --quiet --disablerepo=* --enablerepo=extensions \
   --queryformat "\"%{name}\": \"%{evr}.%{arch}\"," | \
-sed "$ s/,$//") && echo "}") >> /tmp/extensions.json
+sed "$ s/,$//") && echo "}") >> /usr/share/rpm-ostree/extensions.json
 
 ## Final container that has the extensions repo dir
 FROM registry.access.redhat.com/ubi9/ubi:latest
 COPY --from=builder /usr/share/rpm-ostree/extensions/ /usr/share/rpm-ostree/extensions/
+# Make this the last layer, this is similar to the metalayer trick in the node
+# image, but this one is specific to rpm-ostree extensions.
+COPY --from=builder /usr/share/rpm-ostree/extensions.json /usr/share/rpm-ostree/extensions.json

--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -7,7 +7,7 @@ RUN mkdir /os
 WORKDIR /os
 ADD . .
 ARG OPENSHIFT_CI=0
-ARG VARIANT
+ARG VARIANT=""
 RUN if [ "${OPENSHIFT_CI}" != 0 ]; then ci/get-ocp-repo.sh --ocp-layer packages-openshift.yaml; fi
 RUN if [[ -n "${VARIANT}" ]]; then MANIFEST="manifest-${VARIANT}.yaml"; EXTENSIONS="extensions-${VARIANT}.yaml"; else MANIFEST="manifest.yaml"; EXTENSIONS="extensions.yaml"; fi && rpm-ostree compose extensions --rootfs=/ --output-dir=/usr/share/rpm-ostree/extensions/ ./"${MANIFEST}" ./"${EXTENSIONS}"
 

--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -24,12 +24,11 @@ RUN createrepo_c /usr/share/rpm-ostree/extensions/
 # Generate extensions.json for meta.json, written to a bind-mounted path during the build.
 # Use dnf repoquery to print 'name: version,' for each RPM
 # sed to remove the comma from the last RPM
-RUN sh -c 'echo "{" > /tmp/extensions.json && \
-dnf repoquery --repofrompath=extensions,/usr/share/rpm-ostree/extensions/ \
+RUN (echo "{" && \
+(dnf repoquery --repofrompath=extensions,/usr/share/rpm-ostree/extensions/ \
   --quiet --disablerepo=* --enablerepo=extensions \
   --queryformat "\"%{name}\": \"%{evr}.%{arch}\"," | \
-sed "$ s/,$//" >> /tmp/extensions.json && \
-echo "}" >> /tmp/extensions.json'
+sed "$ s/,$//") && echo "}") >> /tmp/extensions.json
 
 ## Final container that has the extensions repo dir
 FROM registry.access.redhat.com/ubi9/ubi:latest

--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -9,7 +9,7 @@ ADD . .
 ARG OPENSHIFT_CI=0
 ARG VARIANT=""
 RUN if [ "${OPENSHIFT_CI}" != 0 ]; then ci/get-ocp-repo.sh --ocp-layer packages-openshift.yaml; fi
-RUN if [[ -n "${VARIANT}" ]]; then MANIFEST="manifest-${VARIANT}.yaml"; EXTENSIONS="extensions-${VARIANT}.yaml"; else MANIFEST="manifest.yaml"; EXTENSIONS="extensions.yaml"; fi && rpm-ostree compose extensions --rootfs=/ --output-dir=/usr/share/rpm-ostree/extensions/ ./"${MANIFEST}" ./"${EXTENSIONS}"
+RUN --mount=type=secret,id=yumrepos,target=/os/secret.repo if [[ -n "${VARIANT}" ]]; then MANIFEST="manifest-${VARIANT}.yaml"; EXTENSIONS="extensions-${VARIANT}.yaml"; else MANIFEST="manifest.yaml"; EXTENSIONS="extensions.yaml"; fi && rpm-ostree compose extensions --rootfs=/ --output-dir=/usr/share/rpm-ostree/extensions/ ./"${MANIFEST}" ./"${EXTENSIONS}"
 
 ## Creates the repo metadata for the extensions.
 ## This uses Fedora as a lowest-common-denominator because it will work on

--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -6,9 +6,9 @@ FROM registry.ci.openshift.org/rhcos-devel/rhel-coreos:latest as os
 RUN mkdir /os
 WORKDIR /os
 ADD . .
-ARG COSA
+ARG OPENSHIFT_CI=0
 ARG VARIANT
-RUN if [[ -z "$COSA" ]] ; then ci/get-ocp-repo.sh --ocp-layer packages-openshift.yaml; else ci/get-ocp-repo.sh --create-gpg-keys; fi
+RUN if [ "${OPENSHIFT_CI}" != 0 ]; then ci/get-ocp-repo.sh --ocp-layer packages-openshift.yaml; fi
 RUN if [[ -n "${VARIANT}" ]]; then MANIFEST="manifest-${VARIANT}.yaml"; EXTENSIONS="extensions-${VARIANT}.yaml"; else MANIFEST="manifest.yaml"; EXTENSIONS="extensions.yaml"; fi && rpm-ostree compose extensions --rootfs=/ --output-dir=/usr/share/rpm-ostree/extensions/ ./"${MANIFEST}" ./"${EXTENSIONS}"
 
 ## Creates the repo metadata for the extensions.

--- a/scripts/generate-metadata
+++ b/scripts/generate-metadata
@@ -42,6 +42,10 @@ def get_rpmdb_pkglist():
     rpmdb = []
     for line in out.splitlines():
         n, e, v, r, a = line.split()
+        if n == 'gpg-pubkey':
+            # those aren't real packages, it's just how rpm represents imported
+            # GPG keys
+            continue
         # canonicalize none to 0 to match rpm-ostree semantics
         if e == '(none)':
             e = '0'


### PR DESCRIPTION
We're getting ready to build the extensions container in production as part of the layered node image work. To be able to build it using `podman build` directly and not via `cosa build-extensions-container`, a few adjustments are needed.

See individual commit messages.