### PR TITLE
NO-JIRA: Move ose-aws-ecr-image-credential-provider to rhel-9.6 only

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -276,10 +276,6 @@ packages:
  - dnf
  # https://issues.redhat.com/browse/OCPBUGS-35247
  - subscription-manager
- # XXX: This should be in packages-openshift.yaml instead. For now,
- # it's in the base until the equivalent functionality lands in RHEL:
- # https://issues.redhat.com/browse/RHEL-82921
- - ose-aws-ecr-image-credential-provider
 
 packages-x86_64:
   # Temporary add of open-vm-tools. Should be removed when containerized

--- a/manifest-rhel-9.6.yaml
+++ b/manifest-rhel-9.6.yaml
@@ -31,3 +31,7 @@ packages:
  # We include the generic release package and tweak the os-release info in a
  # post-process script
  - redhat-release
+ # XXX: This should be in packages-openshift.yaml only. For now,
+ # it's in the base until the equivalent functionality lands in RHEL:
+ # https://issues.redhat.com/browse/RHEL-82921
+ - ose-aws-ecr-image-credential-provider

--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -13,8 +13,7 @@ packages:
   # The packages below are present in CentOS Stream/RHEL,
   # and depend on one or more of the above.
   - NetworkManager-ovs
-  # XXX: There should also be ose-aws-ecr-image-credential-provider here. See
-  # common.yaml.
+  - ose-aws-ecr-image-credential-provider
   - ose-azure-acr-image-credential-provider
   - ose-gcp-gcr-image-credential-provider
 


### PR DESCRIPTION
Limit the hack for this to RHEL 9.6 only for now by lifting it up to the 9.6-specific manifest. Otherwise, this breaks c9s builds which don't have access to the OCP plashets.

Also, just keep it listed in `packages-openshift.yaml`. In RHCOS node image builds, this is a no-op since it'll already be in the base. In SCOS node image builds, this will layer it.