### PR TITLE
OCPBUGS-53384: [release-4.15] packages-openshift.yaml: bump OVS version to 3.3

### DIFF
--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -3,7 +3,7 @@ packages:
   # but are not present in CentOS Stream and RHEL.
   - cri-o cri-tools conmon-rs
   - openshift-clients openshift-hyperkube
-  - openvswitch3.1
+  - openvswitch3.3
   # The packages below are present in CentOS Stream/RHEL,
   # and depend on one or more of the above.
   - NetworkManager-ovs


### PR DESCRIPTION
Open vSwitch 3.1 is EoL upstream and so the support of this version in FDP is limited.  To ensure timely bug fix delivery for OCP 4.14+ we need to upgrade to the current LTS stream, which is Open vSwitch 3.3. It will be fully supported for much longer.

Consolidation of versions used across releases of OpenShift will also reduce pressure on QE teams allowing to drop older releases not used by any products.

ovn-kubernetes container image will follow the lead and move to this version as well in https://github.com/openshift/ovn-kubernetes/pull/2492.

The plan is to get this into 4.15 and then backport to 4.14.