### PR TITLE
NO-JIRA: Drop oscontainer.yaml

### DIFF
--- a/oscontainer.yaml
+++ b/oscontainer.yaml
@@ -1,9 +1,0 @@
-# Configuration for oscontainer uploads; this is the base image.
-base: registry.access.redhat.com/ubi8/ubi:latest
-# These are the packages whose NEVRAs are included as labels on the image.
-labeled-packages:
-  - kernel kernel-rt-core
-  - ostree rpm-ostree
-  - ignition
-  - systemd
-  - runc cri-o


### PR DESCRIPTION
This haven't been used for a while, and the support was removed is COSA. See https://github.com/coreos/coreos-assembler/pull/3765