### PR TITLE
NO-JIRA: Prep patches for #1780

### DIFF
--- a/common.yaml
+++ b/common.yaml
@@ -274,6 +274,9 @@ packages:
  - policycoreutils-python-utils
  # https://github.com/coreos/fedora-coreos-tracker/issues/1687
  - dnf
+ # This is used by rpm-ostree treefile-apply to deal with
+ # https://gitlab.com/fedora/bootc/tracker/-/issues/59
+ - 'dnf-command(versionlock)'
  # https://issues.redhat.com/browse/OCPBUGS-35247
  - subscription-manager
 

--- a/manifest-c9s.yaml
+++ b/manifest-c9s.yaml
@@ -17,6 +17,7 @@ include:
 repos:
   - c9s-baseos
   - c9s-appstream
+  - c9s-extras-common
 
 automatic-version-prefix: "9.0.<date:%Y%m%d>"
 # This ensures we're semver-compatible which OpenShift wants
@@ -26,3 +27,6 @@ mutate-os-release: "9"
 
 packages:
  - centos-stream-release
+ - centos-release-cloud-common
+ - centos-release-nfv-common
+ - centos-release-virt-common


### PR DESCRIPTION
These are split out of #1780 because they need to land first and be in the base images.