### PR TITLE
OCPEDGE-1704: [TNF] Added symlink to allow for custom pacemaker resource agent in two-node OCP variant

### DIFF
--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -189,6 +189,15 @@ postprocess:
     ---
     EOF
 
+  # Inject symlink for Two Node OpenShift with Fencing (TNF)
+  # This is a workaround to allow pacemaker to use a pre-release resource agent for etcd
+  # This should be removed after https://issues.redhat.com/browse/OCPEDGE-1706 is completed
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    mkdir -p /usr/lib/ocf/resource.d/ocp-tnf
+    ln -s /usr/local/lib/ocf/resource.d/ocp-tnf/podman-etcd /usr/lib/ocf/resource.d/ocp-tnf/podman-etcd
+
   - |
     #!/usr/bin/env bash
     set -xeo pipefail


### PR DESCRIPTION
Two-Node OpenShift with fencing is a variant of OpenShift that will be DevPreview in 4.19.
It adds a special executable to /usr/lib/ocf/resource.d/ocp-tnf/ that is not yet in the CoreOS extension for `two-node-ha`.

We are working to address this missing component ASAP, but in the meantime, this symlink allows us to enable this component via a MachineConfig.