### PR TITLE
NO-JIRA: c10s.repo: use x86_64 extras-common URL for all arch

### DIFF
--- a/c10s.repo
+++ b/c10s.repo
@@ -36,11 +36,14 @@ repo_gpgcheck=0
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial-SHA256
 
+# Note: the hardcoded x86_64 is not a mistake. Extras just has noarch RPMs that
+# contain GPG keys and repo files but for some reason only the x86_64 repo has
+# them... Drop hardcoded arch once https://pagure.io/centos-infra/issue/1635 is fixed
 # Note: We can't find a composes.stream.centos.org URL for this repo
 # so we use the mirror.stream.centos.org URL here.
 [c10s-extras-common]
 name=CentOS Stream 10 - Extras packages
-baseurl=https://mirror.stream.centos.org/SIGs/10-stream/extras/$basearch/extras-common
+baseurl=https://mirror.stream.centos.org/SIGs/10-stream/extras/x86_64/extras-common
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1


### PR DESCRIPTION
Currently, CentOS Stream does not ship extras-common repo for s390x [1]. 
This prevents us to build c10s against this arch. I basically replicate the same hack config as we do for c9s. 
Note that this extras-common repo only provides noarch RPMs, at least the one we pull (i.e centos-release-cloud-common, centos-release-nfv-common and centos-release-virt-common) are noarch.

[1] https://pagure.io/centos-infra/issue/1635