### PR TITLE
NO-JIRA: denylist: update iso mpath denials

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -55,31 +55,31 @@
     - rhel-10.1
 
 - pattern: multipath.day1
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1894
+  tracker: https://issues.redhat.com/browse/RHEL-86153
   osversion:
     - centos-10
     - rhel-10.1
 
 - pattern: multipath.day2
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1894
+  tracker: https://issues.redhat.com/browse/RHEL-86153
   osversion:
     - centos-10
     - rhel-10.1
 
 - pattern: multipath.partition
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1894
+  tracker: https://issues.redhat.com/browse/RHEL-86153
   osversion:
     - centos-10
     - rhel-10.1
 
-- pattern: iso-offline-install*mpath.bios
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1894
+- pattern: iso-offline-install*mpath.*
+  tracker: https://issues.redhat.com/browse/RHEL-86153
   osversion:
     - centos-10
     - rhel-10.1
 
 - pattern: ext.config.shared.root-reprovision.luks.multipath
-  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1894
+  tracker: https://issues.redhat.com/browse/RHEL-86153
   osversion:
     - centos-10
     - rhel-10.1


### PR DESCRIPTION
The iso-offline-install.mpath.uefi test is failing. We weren't covering that case with the regex before.

Also update the links for the mpath denials to the RHEL bug.

See https://issues.redhat.com/browse/RHEL-86153