### PR TITLE
NO-JIRA: denylist: ext.config.rpm-ostree.replace-rt-kernel for c10s on ppc64le

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -109,3 +109,11 @@
   tracker: https://issues.redhat.com/browse/RHEL-86436
   osversion:
     - rhel-10.1
+
+- pattern: ext.config.rpm-ostree.replace-rt-kernel
+  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/1923
+  arches:
+    - ppc64le
+  osversion:
+    - centos-10
+    - rhel-10.1


### PR DESCRIPTION
The `ext.config.rpm-ostree.replace-rt-kernel` test is failing [1] when downgrading to previous kernel. 
In order to have the first `c10s` build produced by the pipeline, we can ignore this failure for now.

[1] https://github.com/coreos/fedora-coreos-tracker/issues/1923