### PR TITLE
OCPEDGE-1704: [TNF] Added symlink to allow for custom pacemaker resource agent in two-node OCP variant

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -117,3 +117,11 @@
   osversion:
     - centos-10
     - rhel-10.1
+
+# We are currently adding a dead symlink to allow MCO to install a pacemaker
+# resource agent in Two Node OpenShift with Fencing (TNF). This will be removed
+# once the underlying agent is shipped as part of the `two-node-ha` extension
+# and the TNF controller in etcd is updated to initialize pacemaker clusters
+# via the version shipped in the extension.
+- pattern: ext.config.shared.files.validate-symlinks
+  tracker: https://issues.redhat.com/browse/OCPEDGE-1706

--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -189,6 +189,32 @@ postprocess:
     ---
     EOF
 
+  # Inject symlink for Two Node OpenShift with Fencing (TNF)
+  # This is a workaround to allow pacemaker to use a pre-release resource agent for etcd
+  # This should be removed after https://issues.redhat.com/browse/OCPEDGE-1706 is completed
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    rpm-ostree install --apply-live dnf-utils -y
+    set +e
+    python -m dnf.cli.main > /dev/null
+    if [ $? -ne 0 ]; then
+      exit 1
+    fi
+    python -m dnf.cli.main repoquery -l resource-agents | grep /usr/lib/ocf/resource.d/heartbeat/podman-etcd
+    if [ $? -eq 0 ]; then
+      rpm-ostree apply-live remove dnf-utils || dnf remove dnf-utils -y
+      dnf clean all
+      rpm-ostree cleanup -bpm
+      exit 0
+    fi
+    rpm-ostree apply-live remove dnf-utils || dnf remove dnf-utils -y
+    dnf clean all
+    rpm-ostree cleanup -bpm
+    set -e
+    mkdir -p /usr/lib/ocf/resource.d/ocp-tnf
+    ln -s /usr/local/lib/ocf/resource.d/ocp-tnf/podman-etcd /usr/lib/ocf/resource.d/ocp-tnf/podman-etcd
+
   - |
     #!/usr/bin/env bash
     set -xeo pipefail


### PR DESCRIPTION
Two-Node OpenShift with fencing is a variant of OpenShift that will be DevPreview in 4.19.
It adds a special executable to /usr/lib/ocf/resource.d/ocp-tnf/ that is not yet in the CoreOS extension for two-node-ha.

We are working to address this missing component ASAP, but in the meantime, this symlink allows us to enable this component via a MachineConfig.


--
This PR is an alternative to https://github.com/openshift/os/pull/1796 that ensures the symlink is not present once desired file is in resource-agents.

