### PR TITLE
OCPEDGE-1752: [TNF] Remove broken symlink test skip once fedora-coreos-config is bumped.

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -118,10 +118,3 @@
     - centos-10
     - rhel-10.1
 
-# We are currently adding a dead symlink to allow MCO to install a pacemaker
-# resource agent in Two Node OpenShift with Fencing (TNF). This will be removed
-# once the underlying agent is shipped as part of the `two-node-ha` extension
-# and the TNF controller in etcd is updated to initialize pacemaker clusters
-# via the version shipped in the extension.
-- pattern: ext.config.shared.files.validate-symlinks
-  tracker: https://issues.redhat.com/browse/OCPEDGE-1706


### PR DESCRIPTION
This PR depends on https://github.com/coreos/fedora-coreos-config/pull/3461 to merge in before https://github.com/openshift/os/pull/1759 syncs the fixed test.

If both changes are present, this PR should pass all kola tests. The kola test was skipped in https://github.com/openshift/os/pull/1796 to allow a broken symbolic link to be setup so that Two Node OpenShift with Fencing (TNF) clusters could enable a custom resource agent for pacemaker via the MCO.

Depends on: https://github.com/coreos/fedora-coreos-config/pull/3461
Depends on: https://github.com/openshift/os/pull/1759