### PR TITLE
[release-4.19] NO-JIRA: gitmodules: track rhcos-4.19 branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "fedora-coreos-config"]
 	path = fedora-coreos-config
 	url = https://github.com/coreos/fedora-coreos-config
-	branch = testing-devel
+	branch = rhcos-4.19 


### PR DESCRIPTION
Start tracking the rhcos-4.19 branch of fedora-coreos-config as a part of branching 4.19