### PR TITLE
NO-JIRA: Remove kernel-rt-kvm for cs9 and cs10

### DIFF
--- a/extensions-okd-c10s.yaml
+++ b/extensions-okd-c10s.yaml
@@ -69,7 +69,6 @@ extensions:
       - c10s-nfv
     packages:
       - kernel-rt-core
-      - kernel-rt-kvm
       - kernel-rt-modules
       - kernel-rt-modules-extra
       - kernel-rt-devel

--- a/extensions-okd-c9s.yaml
+++ b/extensions-okd-c9s.yaml
@@ -69,7 +69,6 @@ extensions:
       - c9s-nfv
     packages:
       - kernel-rt-core
-      - kernel-rt-kvm
       - kernel-rt-modules
       - kernel-rt-modules-extra
       - kernel-rt-devel


### PR DESCRIPTION
Based on https://kojihub.stream.centos.org/koji/buildinfo?buildID=77362 and looking at [RHEL-76757](https://issues.redhat.com/browse/RHEL-76757), the decision is to stop building rt-kvm, so we will have to remove it for Centos (and eventually RHEL).

This would need to be tracked for RHEL as well so we can mak the change in the rhel extensions files.