### PR TITLE
NO-JIRA: c9s/c10s repos: use basearch var for extras repo

### DIFF
--- a/c10s.repo
+++ b/c10s.repo
@@ -36,14 +36,9 @@ repo_gpgcheck=0
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial-SHA256
 
-# Note: the hardcoded x86_64 is not a mistake. Extras just has noarch RPMs that
-# contain GPG keys and repo files but for some reason only the x86_64 repo has
-# them... Drop hardcoded arch once https://pagure.io/centos-infra/issue/1635 is fixed
-# Note: We can't find a composes.stream.centos.org URL for this repo
-# so we use the mirror.stream.centos.org URL here.
 [c10s-extras-common]
 name=CentOS Stream 10 - Extras packages
-baseurl=https://mirror.stream.centos.org/SIGs/10-stream/extras/x86_64/extras-common
+baseurl=https://mirror.stream.centos.org/SIGs/10-stream/extras/$basearch/extras-common
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1

--- a/c9s.repo
+++ b/c9s.repo
@@ -36,14 +36,9 @@ repo_gpgcheck=0
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-centosofficial
 
-# Note: the hardcoded x86_64 is not a mistake. Extras just has noarch RPMs that
-# contain GPG keys and repo files but for some reason only the x86_64 repo has
-# them... Drop hardcoded arch once https://pagure.io/centos-infra/issue/1635 is fixed
-# Note: We can't find a composes.stream.centos.org URL for this repo
-# so we use the mirror.stream.centos.org URL here.
 [c9s-extras-common]
 name=CentOS Stream 9 - Extras packages
-baseurl=https://mirror.stream.centos.org/SIGs/9-stream/extras/x86_64/extras-common
+baseurl=https://mirror.stream.centos.org/SIGs/9-stream/extras/$basearch/extras-common
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1


### PR DESCRIPTION
estras-common repo was missing for s390x arch [1], but it's now fixed.

[1] https://pagure.io/centos-infra/issue/1635