### PR TITLE
COS-3294: extensions/rhel-10.1: drop kernel-rt-kvm package from RHEL 10 builds

### DIFF
--- a/extensions/rhel-10.1.yaml
+++ b/extensions/rhel-10.1.yaml
@@ -76,7 +76,6 @@ extensions:
       - rhel-10.1-nfv
     packages:
       - kernel-rt-core
-      - kernel-rt-kvm
       - kernel-rt-modules
       - kernel-rt-modules-extra
       - kernel-rt-devel


### PR DESCRIPTION
The kernel-rt-kvm package is removed in RHEL 10. Going forward, KVM modules will no longer be shipped in a separate package for RT kernels.

See: https://gitlab.com/cki-project/kernel-ark/-/merge_requests/3837