### PR TITLE
OCPEDGE-1706: [TNF] OCP Two Node with Fencing symlink begone!

### DIFF
--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -189,15 +189,6 @@ postprocess:
     ---
     EOF
 
-  # Inject symlink for Two Node OpenShift with Fencing (TNF)
-  # This is a workaround to allow pacemaker to use a pre-release resource agent for etcd
-  # This should be removed after https://issues.redhat.com/browse/OCPEDGE-1706 is completed
-  - |
-    #!/usr/bin/env bash
-    set -xeuo pipefail
-    mkdir -p /usr/lib/ocf/resource.d/ocp-tnf
-    ln -s /usr/local/lib/ocf/resource.d/ocp-tnf/podman-etcd /usr/lib/ocf/resource.d/ocp-tnf/podman-etcd
-
   - |
     #!/usr/bin/env bash
     set -xeo pipefail


### PR DESCRIPTION
The latest builds of OCP 4.20 now come with an updated resource-agents RPM that includes the podman-etcd agent.

This means that the symlink now conflicts with the resource agent specified in the default path.