### PR TITLE
[release-4.18] OCPBUGS-58135: packages-openshift.yaml: bump OVS version to 3.5.

### DIFF
--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -3,7 +3,7 @@ packages:
   # but are not present in CentOS Stream and RHEL.
   - cri-o cri-tools conmon-rs
   - openshift-clients openshift-kubelet
-  - openvswitch3.4
+  - openvswitch3.5
   # The packages below are present in CentOS Stream/RHEL,
   # and depend on one or more of the above.
   - NetworkManager-ovs


### PR DESCRIPTION
ovn-kubernetes container image moved to OVS 3.5 in: https://github.com/openshift/ovn-kubernetes/pull/2593 as part of 4.19 to 4.18 sync: https://issues.redhat.com//browse/OCPBUGS-48710

We should keep OVS versions between os and ovn-k in sync in order to decrease the number of variables in the system.

CC: @sdodson @tssurya @abhat 