### PR TITLE
NO-JIRA: denylist: add ostree.remote to denylist for 4.12

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -91,3 +91,6 @@
   tracker: "Deny upgrades until we have a RHEL9 build for 4.12"
   osversion:
     - rhel-9.0
+- pattern: ostree.remote
+  tracker: https://github.com/coreos/rhel-coreos-config/issues/34
+  snooze: 2025-07-07


### PR DESCRIPTION
The ostree.remote test has been failing on 4.12 build

Ref: https://github.com/coreos/rhel-coreos-config/issues/34