### PR TITLE
NO-JIRA: denylist: add ostree.remote to denylist for 4.18

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -48,3 +48,7 @@
   snooze: 2025-01-01
   osversion:
     - rhel-9.6
+
+- pattern: ostree.remote
+  tracker: https://github.com/coreos/rhel-coreos-config/issues/34
+  snooze: 2025-07-05


### PR DESCRIPTION
The ostree.remote test has been failing on 4.18 build, let us add this test to the denylist for now

Ref: https://github.com/coreos/rhel-coreos-config/issues/34