### PR TITLE
NO-JIRA: denylist: add ostree.remote to denylist for 4.16

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -22,3 +22,7 @@
 # but not denylisted here so it can run on the rhcos pipeline
 #- pattern: iso-offline-install-iscsi.ibft.bios
 #  tracker: https://github.com/openshift/os/issues/1492
+
+- pattern: ostree.remote
+  tracker: https://github.com/coreos/rhel-coreos-config/issues/34
+  snooze: 2025-07-05


### PR DESCRIPTION
The ostree.remote test has been failing on 4.16 build, let us add this test to the denylist for now

Ref: https://github.com/coreos/rhel-coreos-config/issues/34