### PR TITLE
COS-3418: add kola-denylist for skipping kola tests

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -1,0 +1,5 @@
+- pattern: ext.config.version.rhaos-pkgs-match-openshift
+  tracker: https://github.com/openshift/os/issues/1847
+  streams:
+    - 4.19-9.6
+    - 4.20-9.6


### PR DESCRIPTION
This adds the initial `kola-denylist.yaml` and manifest files enabling us to run kola and OpenShift-specific tests in the pipeline. The denylist includes `ext.config.version.rhaos-pkgs-match-openshift` which is currently failing.

Note: the tracker link included is a placeholder and will be updated once the issue is properly tracked.