### PR TITLE
OCPBUGS-47495: 40rhcos-fips: include fips.so in initrd

### DIFF
--- a/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/module-setup.sh
+++ b/overlay.d/05rhcos/usr/lib/dracut/modules.d/40rhcos-fips/module-setup.sh
@@ -28,6 +28,16 @@ install() {
     inst_simple "$moddir/rhcos-fips-dracut-boot-fix.service" \
         "$systemdsystemunitdir/rhcos-fips-dracut-boot-fix.service"
 
+    # Golang 1.22 requires the fips shared object in the initrd to determine
+    # whether the system is in FIPS mode and ignition will panic if its missing
+    local src="/usr/lib64/ossl-modules/fips.so"
+    local dest="/usr/lib64/ossl-modules/fips.so"
+    if [ -f "$src" ]; then
+        inst_simple "$src" "$dest"
+    else
+        echo "Warning: $src not found!"
+    fi
+
     # Unconditionally include /etc/system-fips in the initrd. This has no
     # practical effect if fips=1 isn't also enabled. OTOH, it is a *requirement*
     # for a true FIPS boot: https://bugzilla.redhat.com/show_bug.cgi?id=1778940


### PR DESCRIPTION
Ignition panics when fips is enabled with golang 1.22. Golang 1.21 trusts openssl exclusively to tell whether FIPS mode is on or off but golang 1.22 looks at the system FIPS configuration directly. If the system is in FIPS mode but the initrd doesn't include the openssl FIPS module, golang 1.21 would assume it is not in FIPS mode whereas golang 1.22 sees that the openssl configuration doesn't match the system configuration and panics.