### PR TITLE
COS-3424: Revert ostree.remote snooze - 4.15

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -39,6 +39,3 @@
   arches:
     - ppc64le
 
-- pattern: ostree.remote
-  tracker: https://github.com/coreos/rhel-coreos-config/issues/34
-  snooze: 2025-07-05


### PR DESCRIPTION
remove ostree.remote test as it is working again after fedora DC move completes

Ref: coreos/rhel-coreos-config#34