### PR TITLE
COS-3424: Revert ostree.remote snooze - 4.17

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -33,6 +33,3 @@
 #- pattern: iso-offline-install-iscsi.ibft.bios
 #  tracker: https://github.com/openshift/os/issues/1492
 
-- pattern: ostree.remote
-  tracker: https://github.com/coreos/rhel-coreos-config/issues/34
-  snooze: 2025-07-07


### PR DESCRIPTION
remove ostree.remote test as it is working again after fedora DC move completes

Ref: coreos/rhel-coreos-config#34