### PR TITLE
NO-JIRA: extensions-rhel-9.4: Unpin `libreswan`

### DIFF
--- a/extensions-rhel-9.4.yaml
+++ b/extensions-rhel-9.4.yaml
@@ -15,9 +15,7 @@ extensions:
   # https://github.com/coreos/fedora-coreos-tracker/issues/1504
   ipsec:
     packages:
-      # pin to 4.6-3.el9_0.3 for now for https://issues.redhat.com/browse/OCPBUGS-43498
-      # we can revert once that's fixed in latest libreswan
-      - libreswan-4.6-3.el9_0.3
+      - libreswan
       - NetworkManager-libreswan
   # https://github.com/coreos/fedora-coreos-tracker/issues/326
   usbguard:

--- a/extensions-rhel-9.6.yaml
+++ b/extensions-rhel-9.6.yaml
@@ -18,9 +18,7 @@ extensions:
   # https://github.com/coreos/fedora-coreos-tracker/issues/1504
   ipsec:
     packages:
-      # pin to 4.6-3.el9_0.3 for now for https://issues.redhat.com/browse/OCPBUGS-43498
-      # we can revert once that's fixed in latest libreswan
-      - libreswan-4.6-3.el9_0.3
+      - libreswan
       - NetworkManager-libreswan
   # https://github.com/coreos/fedora-coreos-tracker/issues/326
   usbguard:


### PR DESCRIPTION
Removing the pin to use the latest version of libreswan.