### PR TITLE
OCPBUGS-59303: Revert "extensions-rhel-9.{4,6}: unpin libreswan"

### DIFF
--- a/extensions-rhel-9.4.yaml
+++ b/extensions-rhel-9.4.yaml
@@ -15,7 +15,9 @@ extensions:
   # https://github.com/coreos/fedora-coreos-tracker/issues/1504
   ipsec:
     packages:
-      - libreswan
+      # pin to 4.6-3.el9_0.3 for now for https://issues.redhat.com/browse/OCPBUGS-43498
+      # we can revert once that's fixed in latest libreswan
+      - libreswan-4.6-3.el9_0.3
       - NetworkManager-libreswan
   # https://github.com/coreos/fedora-coreos-tracker/issues/326
   usbguard:

--- a/extensions-rhel-9.6.yaml
+++ b/extensions-rhel-9.6.yaml
@@ -18,7 +18,9 @@ extensions:
   # https://github.com/coreos/fedora-coreos-tracker/issues/1504
   ipsec:
     packages:
-      - libreswan
+      # pin to 4.6-3.el9_0.3 for now for https://issues.redhat.com/browse/OCPBUGS-43498
+      # we can revert once that's fixed in latest libreswan
+      - libreswan-4.6-3.el9_0.3
       - NetworkManager-libreswan
   # https://github.com/coreos/fedora-coreos-tracker/issues/326
   usbguard:


### PR DESCRIPTION
This reverts commit f0a5e7a4f15a8a05489bf2cda6524eae6af247d5. The unpinning was not intentional and it will be reverted in [1][2]. Let's revert here as well to match.

[1] https://github.com/openshift/ovn-kubernetes/pull/2663
[2] https://github.com/openshift/ovn-kubernetes/pull/2663/commits/7427c9822295e70889466d7d50835bc1086c13a2