### PR TITLE
NO-JIRA: denylist: add `rhcos.network.init-interfaces-test` entry

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -1,5 +1,11 @@
+# This file documents currently known-to-fail kola tests. It is consumed by
+# coreos-assembler to automatically skip some tests. For more information,
+# see: https://github.com/coreos/coreos-assembler/pull/866.
+
 - pattern: ext.config.version.rhaos-pkgs-match-openshift
   tracker: https://github.com/openshift/os/issues/1847
-  streams:
-    - 4.19-9.6
-    - 4.20-9.6
+
+- pattern: rhcos.network.init-interfaces-test
+  tracker: https://github.com/openshift/os/issues/1852
+  arches:
+    - s390x


### PR DESCRIPTION
This test has been failing since we started running openshift-specific kola tests in the `build-node-image` job. Let's denylist it for now so we can unblock the pipeline while we investigate
https://github.com/openshift/os/issues/1852

Also remove the stream definitions from the `ext.config.version.rhaos-pkgs-match-openshift` entry. An entry has been added to the `release-4.19` branch to properly denylist the test for 4.19-9.6. See: https://github.com/openshift/os/pull/1853