### PR TITLE
NO-JIRA: bump version to 4.21

### DIFF
--- a/build-node-image.sh
+++ b/build-node-image.sh
@@ -23,8 +23,8 @@ source /etc/os-release
 # should come from CentOS. We should eventually sever this.
 if [ $ID = centos ]; then
     # this says: "if the line starts with [.*], turn off printing. if the line starts with [our-repo], turn it on."
-    awk "/\[.*\]/{p=0} /\[rhel-9.6-server-ose-4.20\]/{p=1} p" /etc/yum.repos.d/*.repo > /etc/yum.repos.d/okd.repo.tmp
-    sed -i -e 's,\[rhel-9.6-server-ose-4.20\],\[rhel-9.6-server-ose-4.20-okd\],' /etc/yum.repos.d/okd.repo.tmp
+    awk "/\[.*\]/{p=0} /\[rhel-9.6-server-ose-4.21\]/{p=1} p" /etc/yum.repos.d/*.repo > /etc/yum.repos.d/okd.repo.tmp
+    sed -i -e 's,\[rhel-9.6-server-ose-4.21\],\[rhel-9.6-server-ose-4.21-okd\],' /etc/yum.repos.d/okd.repo.tmp
     echo 'includepkgs=openshift-*,ose-aws-ecr-*,ose-azure-acr-*,ose-gcp-gcr-*' >> /etc/yum.repos.d/okd.repo.tmp
     mv /etc/yum.repos.d/okd.repo{.tmp,}
 fi

--- a/c10s.repo
+++ b/c10s.repo
@@ -66,6 +66,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Virtualization
 
 # Note: We can't find a composes.stream.centos.org URL for this repo
 # so we use the mirror.stream.centos.org URL here.
+# This needs to be updated to okd-4.21 once it becomes available
 [c10s-sig-cloud-okd]
 name=CentOS Stream 10 - SIG Cloud OKD 4.20
 baseurl=https://mirror.stream.centos.org/SIGs/10-stream/cloud/$basearch/okd-4.20/

--- a/c9s.repo
+++ b/c9s.repo
@@ -66,6 +66,7 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Virtualization
 
 # Note: We can't find a composes.stream.centos.org URL for this repo
 # so we use the mirror.stream.centos.org URL here.
+# This needs to be updated to okd-4.21 once it becomes available
 [c9s-sig-cloud-okd]
 name=CentOS Stream 9 - SIG Cloud OKD 4.20 
 baseurl=https://mirror.stream.centos.org/SIGs/9-stream/cloud/$basearch/okd-4.20/

--- a/ci/get-ocp-repo.sh
+++ b/ci/get-ocp-repo.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 urls=(
     # theoretically that's the only one we need
-    "http://base-4-20-rhel96.ocp.svc.cluster.local"
+    "http://base-4-21-rhel96.ocp.svc.cluster.local"
 )
 
 dest=$1; shift

--- a/docs/building.md
+++ b/docs/building.md
@@ -36,7 +36,7 @@ To build SCOS:
 ```
 podman build . --secret id=yumrepos,src=/path/to/all.repo \
   -v /etc/pki/ca-trust:/etc/pki/ca-trust:ro \
-  --security-opt label=disable -t localhost/stream-coreos:4.20
+  --security-opt label=disable -t localhost/stream-coreos:4.21
 ```
 
 To build RHCOS, the command is identical, but you must pass in the RHCOS base

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -140,6 +140,7 @@ RHCOS/OCP version | RHEL version
 4.18 | 9.4 EUS
 4.19 | 9.6 EUS
 4.20 | 9.6 EUS
+4.21 | 9.6 EUS
 
 ## Q: How do I determine what version of an RPM is included in an RHCOS release?
 

--- a/extensions/rhel-10.1.yaml
+++ b/extensions/rhel-10.1.yaml
@@ -13,7 +13,7 @@ repos:
   # For crun-wasm (wasm) and kata-containers (sandboxed-containers).
   # Repo placed here to respect the rule above.
   # XXX Move to 10.1 plashets when available
-  - rhel-9.6-server-ose-4.20
+  - rhel-9.6-server-ose-4.21
   # For two-node-ha extension.
   # Repo placed here to respect the rule above.
   - rhel-10.1-highavailability
@@ -23,7 +23,7 @@ repos:
   # - rhel-10.1-fast-datapath
 
 extensions:
-  # Uncomment when the server-ose-4.20 repo exists for RHEL 10
+  # Uncomment when the server-ose-4.21 repo exists for RHEL 10
   # # https://issues.redhat.com/browse/RFE-4177
   # wasm:
   #   architectures:

--- a/extensions/rhel-9.6.yaml
+++ b/extensions/rhel-9.6.yaml
@@ -12,7 +12,7 @@ repos:
   - rhel-9.6-appstream
   # For crun-wasm (wasm) and kata-containers (sandboxed-containers).
   # Repo placed here to respect the rule above.
-  - rhel-9.6-server-ose-4.20
+  - rhel-9.6-server-ose-4.21
   # For two-node-ha extension.
   # Repo placed here to respect the rule above.
   - rhel-9.6-highavailability

--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -2,7 +2,7 @@ metadata:
   # This should match the /etc/os-release manipulation we do below when
   # injecting `OPENSHIFT_VERSION`. It's used by CI to determine the repos to
   # inject when building the layered image.
-  ocp_version: "4.20"
+  ocp_version: "4.21"
 
 conditional-include:
   - if:
@@ -19,7 +19,7 @@ conditional-include:
         - rhel-9.6-appstream
         - rhel-9.6-early-kernel
         - rhel-9.6-fast-datapath
-        - rhel-9.6-server-ose-4.20
+        - rhel-9.6-server-ose-4.21
   - if: osversion == "rhel-10.1"
     include:
       repos:
@@ -28,9 +28,9 @@ conditional-include:
         #- rhel-10.1-early-kernel
         # XXX Not built for rhel 10 yet
         #- rhel-10.1-fast-datapath
-        #- rhel-10.1-server-ose-4.20
+        #- rhel-10.1-server-ose-4.21
         - rhel-9.6-fast-datapath
-        - rhel-9.6-server-ose-4.20
+        - rhel-9.6-server-ose-4.21
         - rhel-9.6-appstream-containernetworking
   - if: osversion == "centos-9"
     include:
@@ -40,7 +40,7 @@ conditional-include:
         - c9s-sig-nfv
         - c9s-sig-cloud-okd
         # XXX: this shouldn't be here; see related XXX in build-node-image.sh
-        - rhel-9.6-server-ose-4.20-okd
+        - rhel-9.6-server-ose-4.21-okd
   - if: osversion == "centos-10"
     include:
       repos:
@@ -50,8 +50,8 @@ conditional-include:
         - c10s-sig-cloud-okd
         # XXX: this shouldn't be here; see related XXX in build-node-image.sh
         # XXX: using 9.6 repo for now until 10.1 plashets exist
-        # - rhel-10.1-server-ose-4.20-okd
-        - rhel-9.6-server-ose-4.20-okd
+        # - rhel-10.1-server-ose-4.21-okd
+        - rhel-9.6-server-ose-4.21-okd
 
 packages:
   # The packages below are required by OpenShift/OKD
@@ -149,7 +149,7 @@ postprocess:
     #!/usr/bin/env bash
     set -xeuo pipefail
     cat >> /usr/lib/os-release <<EOF
-    OPENSHIFT_VERSION="4.20"
+    OPENSHIFT_VERSION="4.21"
     EOF
 
   - |


### PR DESCRIPTION
Note: c9s.repo and c10s.repo do not have an okd-4.21 repo yet so it will remain untouched.