### PR TITLE
OCPBUGS-63597: Remove kernel-rt from 4.12.z

### DIFF
--- a/extensions-rhel-8.6.yaml
+++ b/extensions-rhel-8.6.yaml
@@ -34,18 +34,6 @@ extensions:
       - kernel-modules
       - kernel-modules-extra
     match-base-evr: kernel
-  # GRPA-2822
-  # https://github.com/openshift/machine-config-operator/pull/1330
-  # https://github.com/openshift/enhancements/blob/master/enhancements/support-for-realtime-kernel.md
-  kernel-rt:
-    architectures:
-      - x86_64
-    packages:
-      - kernel-rt-core
-      - kernel-rt-kvm
-      - kernel-rt-modules
-      - kernel-rt-modules-extra
-      - kernel-rt-devel
   # https://github.com/openshift/machine-config-operator/pull/2456
   # https://github.com/openshift/enhancements/blob/master/enhancements/sandboxed-containers/sandboxed-containers-tech-preview.md
   # GRPA-3123

--- a/oscontainer.yaml
+++ b/oscontainer.yaml
@@ -2,7 +2,7 @@
 base: registry.access.redhat.com/ubi8/ubi:latest
 # These are the packages whose NEVRAs are included as labels on the image.
 labeled-packages:
-  - kernel kernel-rt-core
+  - kernel
   - ostree rpm-ostree
   - ignition
   - systemd


### PR DESCRIPTION
I suspect it's not this simple and there are probably tests somewhere that will get cranky about this