### PR TITLE
extensions/rhel-10.1: Add perl-interpreter

### DIFF
--- a/extensions/rhel-10.1.yaml
+++ b/extensions/rhel-10.1.yaml
@@ -55,6 +55,7 @@ extensions:
     packages:
       - kernel-devel
       - kernel-headers
+      - perl-interpreter
     match-base-evr: kernel
   # These are already in the base, so they're not OS extensions, but they're
   # useful to have in RPM form to install in kmod build containers.


### PR DESCRIPTION
Perl will be removed from RHCOS 10. Explicitely include it in the kernel-devel extension.

See: https://github.com/coreos/rhel-coreos-config/issues/109