### PR TITLE
NO-JIRA: drop use of rhel-9.6-appstream-containernetworking repo

### DIFF
--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -31,7 +31,6 @@ conditional-include:
         #- rhel-10.1-server-ose-4.21
         - rhel-9.6-fast-datapath
         - rhel-9.6-server-ose-4.21
-        - rhel-9.6-appstream-containernetworking
   - if: osversion == "centos-9"
     include:
       repos:


### PR DESCRIPTION
cri-o has been rebuilt for RHEL 10 and nothing from this repo is getting pulled in any longer in node-image el10 builds. Let's drop this definition from the config.