### PR TITLE
OCPNODE-4010: package: add ose-crio-credential-provider

### DIFF
--- a/build-node-image.sh
+++ b/build-node-image.sh
@@ -25,7 +25,7 @@ if [ $ID = centos ]; then
     # this says: "if the line starts with [.*], turn off printing. if the line starts with [our-repo], turn it on."
     awk "/\[.*\]/{p=0} /\[rhel-9.6-server-ose-4.21\]/{p=1} p" /etc/yum.repos.d/*.repo > /etc/yum.repos.d/okd.repo.tmp
     sed -i -e 's,\[rhel-9.6-server-ose-4.21\],\[rhel-9.6-server-ose-4.21-okd\],' /etc/yum.repos.d/okd.repo.tmp
-    echo 'includepkgs=openshift-*,ose-aws-ecr-*,ose-azure-acr-*,ose-gcp-gcr-*' >> /etc/yum.repos.d/okd.repo.tmp
+    echo 'includepkgs=openshift-*,ose-aws-ecr-*,ose-azure-acr-*,ose-gcp-gcr-*,ose-crio-*' >> /etc/yum.repos.d/okd.repo.tmp
     mv /etc/yum.repos.d/okd.repo{.tmp,}
 fi
 

--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -64,6 +64,7 @@ packages:
   - ose-aws-ecr-image-credential-provider
   - ose-azure-acr-image-credential-provider
   - ose-gcp-gcr-image-credential-provider
+  - ose-crio-credential-provider
 
 postprocess:
   # This is part of e.g. fedora-repos in Fedora; we now want to include it by default


### PR DESCRIPTION
which is used to allow pull secrets to  be used for mirrored registries