### PR TITLE
NO-JIRA: packages-openshift: enable rhel-10.1-fast-datapath

### DIFF
--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -26,10 +26,9 @@ conditional-include:
         - rhel-10.1-baseos
         - rhel-10.1-appstream
         #- rhel-10.1-early-kernel
+        - rhel-10.1-fast-datapath
         # XXX Not built for rhel 10 yet
-        #- rhel-10.1-fast-datapath
         #- rhel-10.1-server-ose-4.21
-        - rhel-9.6-fast-datapath
         - rhel-9.6-server-ose-4.21
   - if: osversion == "centos-9"
     include:


### PR DESCRIPTION
The repo is now available for rhel-10 so we can start including packages from there and drop the `rhel-9.6-fast-datapath` workaround.

xref: https://github.com/openshift/os/pull/1878