### PR TITLE
[release-4.21] NO-JIRA: Remove (commented) WASM mentions

### DIFF
--- a/extensions/centos-10.yaml
+++ b/extensions/centos-10.yaml
@@ -17,13 +17,6 @@ repos:
   - c10s-rt-mirror
 
 extensions:
-  # https://issues.redhat.com/browse/RFE-4177
-  # wasm:
-  #   architectures:
-  #     - x86_64
-  #     - aarch64
-  #   packages:
-  #     - crun-wasm
   # https://github.com/coreos/fedora-coreos-tracker/issues/1504
   ipsec:
     packages:

--- a/extensions/rhel-10.1.yaml
+++ b/extensions/rhel-10.1.yaml
@@ -10,7 +10,7 @@ repos:
   # Generically used for various extensions.
   # Repo placed here to respect the rule above.
   - rhel-10.1-appstream
-  # For crun-wasm (wasm) and kata-containers (sandboxed-containers).
+  # For kata-containers (sandboxed-containers).
   # Repo placed here to respect the rule above.
   # XXX Move to 10.1 plashets when available
   - rhel-9.6-server-ose-4.21
@@ -23,14 +23,6 @@ repos:
   # - rhel-10.1-fast-datapath
 
 extensions:
-  # Uncomment when the server-ose-4.21 repo exists for RHEL 10
-  # # https://issues.redhat.com/browse/RFE-4177
-  # wasm:
-  #   architectures:
-  #     - x86_64
-  #     - aarch64
-  #   packages:
-  #     - crun-wasm
  # Uncomment once fast-datapath repo exists for RHEL 10
  ## https://github.com/coreos/fedora-coreos-tracker/issues/1504
  #ipsec:


### PR DESCRIPTION
- WASM support is no longer available in RHEL 9.8 and RHEL 10.0/10.1/10.2. Remove the corresponding extension mentions from RHCOS.