### PR TITLE
No-JIRA: move the OKD SIG repo to 4.22

### DIFF
--- a/c10s.repo
+++ b/c10s.repo
@@ -67,8 +67,8 @@ gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Virtualization
 # Note: We can't find a composes.stream.centos.org URL for this repo
 # so we use the mirror.stream.centos.org URL here.
 [c10s-sig-cloud-okd]
-name=CentOS Stream 10 - SIG Cloud OKD 4.21
-baseurl=https://mirror.stream.centos.org/SIGs/10-stream/cloud/$basearch/okd-4.21/
+name=CentOS Stream 10 - SIG Cloud OKD 4.22
+baseurl=https://mirror.stream.centos.org/SIGs/10-stream/cloud/$basearch/okd-4.22/
 gpgcheck=1
 repo_gpgcheck=0
 enabled=1


### PR DESCRIPTION
We now have the OKD 4.22 SIG Repo with cri-o and cri-tools 1.35.0