### PR TITLE
NO-JIRA: extensions: add a label for extensions image discovery

### DIFF
--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -25,6 +25,9 @@ sed "$ s/,$//") && echo "}") >> /usr/share/rpm-ostree/extensions.json
 
 ## Final container that has the extensions repo dir
 FROM registry.access.redhat.com/ubi9/ubi:latest
+# Add a label so the extensions image can be identified
+LABEL io.openshift.os.extensions=true
+# Copy in the extensions repo
 COPY --from=builder /usr/share/rpm-ostree/extensions/ /usr/share/rpm-ostree/extensions/
 # Make this the last layer, this is similar to the metalayer trick in the node
 # image, but this one is specific to rpm-ostree extensions.


### PR DESCRIPTION
The MCO team was using the absence of the `ostree.linux` label to distinguish an extensions image from a node image in the release payload [1]. Let's make it easier to distinguish an extensions image by adding a label here.

[1] https://github.com/openshift/machine-config-operator/blob/6d48b64d76ed56318fbfdfc6a61c57ab93d96f9b/pkg/osimagestream/image_data.go#L15