### PR TITLE
Rename extensions/Dockerfile to Containerfile

### DIFF
--- a/extensions/Containerfile
+++ b/extensions/Containerfile
@@ -1,7 +1,7 @@
 ## Downloads the extensions given the extensions.yaml
 FROM registry.ci.openshift.org/rhcos-devel/rhel-coreos:latest as os
 # Expects os to be cloned and this build run from the top level dir like:
-# podman build -f extensions/Dockerfile .
+# podman build -f extensions/Containerfile .
 # also expects submodules to be initialized
 RUN mkdir /os
 WORKDIR /os


### PR DESCRIPTION
## Summary

- Rename `extensions/Dockerfile` to `extensions/Containerfile`
- Update internal comment referencing the file path

This makes it explicit that this is about containers, not Docker.

Fixes: https://github.com/openshift/os/issues/992

## Dependencies

This PR requires a corresponding change in the fedora-coreos-pipeline:
- https://github.com/coreos/fedora-coreos-pipeline/pull/1297

The pipeline PR should be merged **after** this PR to avoid build failures.