### PR TITLE
[release-4.20] COS-3912: denylist: drop rhcos.network.init-interfaces-test

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -4,8 +4,3 @@
 
 - pattern: ext.config.version.rhaos-pkgs-match-openshift
   tracker: https://github.com/openshift/os/issues/1847
-
-- pattern: rhcos.network.init-interfaces-test
-  tracker: https://github.com/openshift/os/issues/1852
-  arches:
-    - s390x


### PR DESCRIPTION
This is a backport of https://github.com/openshift/os/pull/1900

Issue: https://github.com/openshift/os/issues/1852