### PR TITLE
COS-3912: [release-4.21] denylist: drop rhcos.network.init-interfaces-test

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -2,7 +2,11 @@
 # coreos-assembler to automatically skip some tests. For more information,
 # see: https://github.com/coreos/coreos-assembler/pull/866.
 
-- pattern: rhcos.network.init-interfaces-test
-  tracker: https://github.com/openshift/os/issues/1852
-  arches:
-    - s390x
+# For openshift/os only kola tests tagged with the `openshift` tag
+# are tested in build-node-image job in the pipeline.
+
+##- pattern: rhcos.test.name
+##  tracker: https://github.com/openshift/os/issues/xxxx
+##  snooze: 2026-xx-xx
+##  arches:
+##    - aarch64


### PR DESCRIPTION
Co-authored-by: Dusty Mabe <dusty@dustymabe.com>
(cherry picked from commit https://github.com/openshift/os/commit/7e3a7aa939e5883e9460214f977a77a48d9f12b4)

Issue: https://github.com/openshift/os/issues/1852