### PR TITLE
[release-4.23] COS-3912: denylist: drop rhcos.network.init-interfaces-test

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -2,7 +2,8 @@
 # coreos-assembler to automatically skip some tests. For more information,
 # see: https://github.com/coreos/coreos-assembler/pull/866.
 
-- pattern: rhcos.network.init-interfaces-test
-  tracker: https://github.com/openshift/os/issues/1852
-  arches:
-    - s390x
+##- pattern: rhcos.test.name
+##  tracker: https://github.com/coreos/fedora-coreos-tracker/issues/xxxx
+##  snooze: 2026-xx-xx
+##  arches:
+##    - aarch64


### PR DESCRIPTION
Fix went upstream.

Issue: https://github.com/openshift/os/issues/1852 (cherry picked from commit 2257f0a8e68ab428e6cad91b77d3e23050b24011)