### PR TITLE
NO-JIRA: tests: add openshift tag

### DIFF
--- a/tests/kola/files/openvswitch-hugetlbfs-groups
+++ b/tests/kola/files/openvswitch-hugetlbfs-groups
@@ -3,6 +3,7 @@
 ##   exclusive: false
 ##   architectures: "x86_64 ppc64le"
 ##   description: Verify openvswitch user is in the hugetlbfs group.
+##   tags: openshift
 
 set -xeuo pipefail
 

--- a/tests/kola/version/rhaos-pkgs-match-openshift
+++ b/tests/kola/version/rhaos-pkgs-match-openshift
@@ -4,6 +4,7 @@
 ##   description: Verify that packages coming from the rhaos
 ##     branches match the OpenShift version.
 ##     This is RHCOS only.
+##   tags: openshift
 
 set -xeuo pipefail
 


### PR DESCRIPTION
The build-node-image job only tests tags with the openshift tag and any tests still in this repo should be running so let's add the openshift tag to them.