### PR TITLE
Add RHEL 9.8 repository due to missing dependency

### DIFF
--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -24,6 +24,9 @@ conditional-include:
     include:
       repos:
         - rhel-10.2-baseos
+        # Runc was removed in rhel-10
+        # crio-o was not built based on crun yet
+        - rhel-9.8-appstream
         - rhel-10.2-appstream
         - rhel-10.2-early-kernel
         - rhel-10.2-fast-datapath


### PR DESCRIPTION
in RHEL 10

- runc was removed in RHEL 10 in favor of crun.
- cri-o is not yet built against crun, and still requires runc.