### PR TITLE
Containerfile: add ostree.linux hack

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -11,3 +11,9 @@ RUN --mount=type=bind,target=/run/src /run/src/scripts/generate-metadata
 FROM build
 COPY --from=metadata /usr/share/openshift /usr/share/openshift
 LABEL io.openshift.metalayer=true
+# Add a hack to get OpenShift tests working again because a
+# revert of the new architecture happened in
+# https://github.com/openshift/machine-config-operator/pull/5703
+# because we can't add labels to the rhel-10.2 yet:
+# https://github.com/coreos/rhel-coreos-config/blob/1ba124d37b93a095bb5ec2ef5b421965b982b255/build-args-rhel-10.2.conf#L15-L18
+LABEL ostree.linux=true


### PR DESCRIPTION
Add a hack to get OpenShift tests working again because a revert of the new architecture happened in [1]. That revert happened because we can't add labels to the rhel-10.2 yet [2].

[1] https://github.com/openshift/machine-config-operator/pull/5703
[2] https://github.com/coreos/rhel-coreos-config/blob/1ba124d37b93a095bb5ec2ef5b421965b982b255/build-args-rhel-10.2.conf#L15-L18