### PR TITLE
NO-JIRA: extensions: Add rhel-9.8-server-ose-4.22

### DIFF
--- a/extensions/rhel-10.2.yaml
+++ b/extensions/rhel-10.2.yaml
@@ -12,6 +12,9 @@ repos:
   - rhel-10.2-appstream
   # For kata-containers (sandboxed-containers).
   # Repo placed here to respect the rule above.
+  # We do not have kata-container yet in 10.2
+  # https://github.com/openshift/os/issues/1911
+  - rhel-9.8-server-ose-4.22
   - rhel-10.2-server-ose-4.22
   # For two-node-ha extension.
   # Repo placed here to respect the rule above.


### PR DESCRIPTION
 - The kata-container package still missing in RHEL-10.2 repo, add rhel-9.8 for now until we get
it there
See: https://github.com/openshift/os/issues/1911