### PR TITLE
OCPBUGS-64841: post-process: Remove workaround for openvswitch additional group

### DIFF
--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -106,32 +106,6 @@ postprocess:
 
   - |
     #!/usr/bin/env bash
-    set -xeo pipefail
-    # Add the hugetlbfs group to the openvswitch user if the openvswitch-hugetlbfs.conf
-    # sysusers fragment exists. The usermod used to happen in the RPM scriptlets but
-    # that stopped working in the sysusers conversion. We should be able to drop this
-    # when a bug gets fixed in systemd: https://github.com/openshift/os/issues/1274#issuecomment-1605507390
-    if [ -f /usr/lib/sysusers.d/openvswitch-hugetlbfs.conf ]; then
-        if [ -f /run/.containerenv ]; then
-            # We're running as part of a derivation; `usermod` will not work
-            # because it doesn't go through NSS. Hackily put the /usr/lib files
-            # in /etc temporarily then put them back
-            mv /etc/passwd /etc/passwd.bak
-            mv /etc/group /etc/group.bak
-            mv /usr/lib/passwd /etc/passwd
-            mv /usr/lib/group /etc/group
-        fi
-        usermod -a -G hugetlbfs openvswitch
-        if [ -f /run/.containerenv ]; then
-            mv /etc/passwd /usr/lib/passwd
-            mv /etc/group /usr/lib/group
-            mv /etc/passwd.bak /etc/passwd
-            mv /etc/group.bak /etc/group
-        fi
-    fi
-
-  - |
-    #!/usr/bin/env bash
     set -xeuo pipefail
     # crio should stop hardcoding things in their config file!
     # We are apparently somehow pulling in a conmon override in RHCOS


### PR DESCRIPTION
We are moving the group inclusion directly to the RHEL base image instead of working around it here in the OCP node layer.

See: https://github.com/openshift/os/pull/1917
See: https://github.com/coreos/rhel-coreos-config/pull/224
See: https://redhat.atlassian.net/browse/OCPBUGS-64841