### PR TITLE
[release-4.20] NO-JIRA: rhaos-pkgs-match-openshift: exclude known package mismatches

### DIFF
--- a/kola-denylist.yaml
+++ b/kola-denylist.yaml
@@ -2,5 +2,3 @@
 # coreos-assembler to automatically skip some tests. For more information,
 # see: https://github.com/coreos/coreos-assembler/pull/866.
 
-- pattern: ext.config.version.rhaos-pkgs-match-openshift
-  tracker: https://github.com/openshift/os/issues/1847

--- a/tests/kola/files/openvswitch-hugetlbfs-groups
+++ b/tests/kola/files/openvswitch-hugetlbfs-groups
@@ -3,6 +3,7 @@
 ##   exclusive: false
 ##   architectures: "x86_64 ppc64le"
 ##   description: Verify openvswitch user is in the hugetlbfs group.
+##   tags: openshift
 
 set -xeuo pipefail
 

--- a/tests/kola/version/rhaos-pkgs-match-openshift
+++ b/tests/kola/version/rhaos-pkgs-match-openshift
@@ -4,6 +4,7 @@
 ##   description: Verify that packages coming from the rhaos
 ##     branches match the OpenShift version.
 ##     This is RHCOS only.
+##   tags: openshift
 
 set -xeuo pipefail
 

--- a/tests/kola/version/rhaos-pkgs-match-openshift
+++ b/tests/kola/version/rhaos-pkgs-match-openshift
@@ -13,7 +13,21 @@ set -xeuo pipefail
 # source the environment variables to get OPENSHIFT_VERSION
 source /etc/os-release
 
-rpm -qa | grep "rhaos" > /tmp/rhaos-packages.txt
+# These are packages that are known to not match the
+# targeted version of openshift. Exlude them from the test.
+RHAOS_PACKAGE_EXCEPTIONS=(
+    # toolbox doesn't always match the target ocp version because it
+    # is included in the base-image which spans multiple versions
+    toolbox
+    # conmon currently is missing 4.19+ vesions of the package
+    conmon-rs
+)
+
+exception_pattern=$(echo ${RHAOS_PACKAGE_EXCEPTIONS[@]} | tr " " "|")
+
+# Use `|| true` here to allow situations where RHAOS_PACKAGE_EXCEPTIONS contains every
+# rhaos package in the image, which would otherwise cause `grep -Ev` to fail the test.
+rpm -qa | grep "rhaos" | grep -Ev "${exception_pattern}" > /tmp/rhaos-packages.txt || true
 
 if grep -v "rhaos${OPENSHIFT_VERSION}" /tmp/rhaos-packages.txt; then
     fatal "Error: rhaos packages do not match OpenShift version"


### PR DESCRIPTION
Introduce `RHAOS_PACKAGE_EXCEPTIONS` and build a regex from it to filter out packages that are known to not match the target version of openshift. Use a list-based structure so additional packages can be excluded in the future by appending to the exception array.

Exclude the toolbox and conmon rhaos packages, which are not expected to match.

Also remove the `rhaos-pkgs-match-openshift` test from the denylist.

See: https://github.com/openshift/os/issues/1847

This backports:
- https://github.com/openshift/os/commit/ef8a3bbd2f960958b36b64854d2ae5ad3c4b16a9
- https://github.com/openshift/os/commit/1abf0f6381b932c5b2a05bdb5d0407cfa76306cd