### PR TITLE
WIP Updates for 4.23 node image Konflux build

### DIFF
--- a/build-node-image.sh
+++ b/build-node-image.sh
@@ -14,10 +14,13 @@ if [ "${OPENSHIFT_CI}" != 0 ]; then
     /run/src/ci/get-ocp-repo.sh /etc/yum.repos.d/ocp.repo
 fi
 
-# add all the repos from the src repo into `/etc/yum.repos.d` so dnf sees them
-cat /run/src/*.repo >> /etc/yum.repos.d/git.repo
-
 source /etc/os-release
+
+# add CentOS repos from the source - only needed for CentOS/SCOS builds.
+# For RHEL builds, ART injects the correct repos via art-unsigned.repo.
+if [ $ID = centos ]; then
+    cat /run/src/*.repo >> /etc/yum.repos.d/git.repo
+fi
 
 # XXX: For SCOS, only allow certain packages to come from ART; everything else
 # should come from CentOS. We should eventually sever this.

--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -2,7 +2,7 @@ metadata:
   # This should match the /etc/os-release manipulation we do below when
   # injecting `OPENSHIFT_VERSION`. It's used by CI to determine the repos to
   # inject when building the layered image.
-  ocp_version: "4.22"
+  ocp_version: "4.23"
 
 conditional-include:
   - if:
@@ -15,11 +15,10 @@ conditional-include:
   - if: osversion == "rhel-9.8"
     include:
       repos:
-        - rhel-9.8-baseos
-        - rhel-9.8-appstream
-        - rhel-9.8-early-kernel
-        - rhel-9.8-fast-datapath
-        - rhel-9.8-server-ose-4.22
+        - rhel-98-baseos
+        - rhel-98-appstream
+        - rhel-9-fast-datapath-rpms
+        - rhel-9-server-ose-rpms
   - if: osversion == "rhel-10.2"
     include:
       repos:
@@ -120,7 +119,7 @@ postprocess:
     #!/usr/bin/env bash
     set -xeuo pipefail
     cat >> /usr/lib/os-release <<EOF
-    OPENSHIFT_VERSION="4.22"
+    OPENSHIFT_VERSION="4.23"
     EOF
 
   - |

--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -12,21 +12,9 @@ conditional-include:
     - osversion != "centos-10"
     include:
       repos: [ENOEXIST] # We want an error in this case
-  - if: osversion == "rhel-9.8"
-    include:
-      repos:
-        - rhel-98-baseos
-        - rhel-98-appstream
-        - rhel-9-fast-datapath-rpms
-        - rhel-9-server-ose-rpms
-  - if: osversion == "rhel-10.2"
-    include:
-      repos:
-        - rhel-10.2-baseos
-        - rhel-10.2-appstream
-        - rhel-10.2-early-kernel
-        - rhel-10.2-fast-datapath
-        - rhel-10.2-server-ose-4.22
+  # rhel-9.8 and rhel-10.2: no explicit repo includes needed.
+  # ART injects art-unsigned.repo with the correct arch-specific repos.
+  # build-node-image.sh ensures CentOS repos are not added for RHEL builds.
   - if: osversion == "centos-9"
     include:
       repos:


### PR DESCRIPTION
- Update ocp_version to 4.23 and switch rhel-9.8 repo IDs to match the repo names injected at build time in ocp-build-data - https://github.com/openshift-eng/ocp-build-data/pull/9978
- Drop rhel-9.8-early-kernel as the kernel is now covered by rhel-9-server-ose-rpms.

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED