### PR TITLE
postprocess: Disable empty password authentication via authselect

### DIFF
--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -86,6 +86,21 @@ postprocess:
     semanage boolean --modify --on container_use_cephfs      # RHBZ#1694045
     semanage boolean --modify --on virt_use_samba            # RHBZ#1754825
 
+  # Disable empty password authentication (HIGH severity, all compliance profiles)
+  # RHCOS nodes are managed infrastructure with no use case for empty passwords.
+  # The RHEL pam RPM ships nullok by default; authselect's without-nullok feature
+  # removes it using the supported RHEL mechanism.
+  # See: https://github.com/authselect/authselect/commit/e1fbbdc
+  - |
+    #!/usr/bin/env bash
+    set -xeuo pipefail
+    authselect select sssd without-nullok --force
+    # Verify nullok was actually removed
+    if grep -q nullok /etc/pam.d/system-auth /etc/pam.d/password-auth; then
+      echo "ERROR: nullok still present after authselect" >&2
+      exit 1
+    fi
+
   # https://gitlab.cee.redhat.com/coreos/redhat-coreos/merge_requests/812
   # https://bugzilla.redhat.com/show_bug.cgi?id=1796537
   - |


### PR DESCRIPTION
RHCOS inherits `nullok` in PAM from the RHEL defaults, which permits authentication with empty passwords. RHCOS nodes are managed infrastructure with no legitimate use case for password-based login, let alone empty passwords, so this has no functional impact on existing deployments.

This adds a postprocess step that runs:

    authselect select sssd without-nullok --force

and verifies that `nullok` was removed from `system-auth` and `password-auth`.

### Why this change

This is flagged as a HIGH severity finding across every compliance profile that applies to RHCOS: Essential 8, CIS, NIST Moderate, and PCI-DSS. Unlike many hardening recommendations where benchmarks disagree, removing `nullok` is consistent across all of them.

Today, the compliance-operator remediation for this finding is broken on RHCOS 9 — it generates RHEL 8 era PAM templates that don't apply cleanly. Fixing it at the image level eliminates the issue for all clusters without requiring per-node MachineConfig remediation.

### Why the maintenance burden is low

- Uses `authselect` with its `without-nullok` feature flag — the supported RHEL mechanism purpose-built for this ([authselect/authselect#94](https://github.com/authselect/authselect/issues/94), landed in 2018)
- No custom PAM files, no divergence from the RHEL PAM stack
- The postprocess script includes a verification step that will fail the build if it doesn't work, so regressions surface immediately
- 10 lines of script, no new packages

### Scope

This is intentionally narrow. We understand the concern about carrying hardening overrides that diverge from RHEL defaults and create ongoing maintenance. This is not the start of a campaign to upstream every compliance checklist item into RHCOS.

A small number of changes like this one — high severity, universally agreed upon across benchmarks, zero functional risk, and using existing RHEL tooling — are worth considering. We're happy to discuss which additional items (if any) would meet that bar in separate conversations.

### References

- `without-nullok` feature: https://github.com/authselect/authselect/commit/e1fbbdc
- Upstream scanner fix: https://github.com/ComplianceAsCode/content/pull/14602