### PR TITLE
NO-JIRA: docs/FAQ: link KCS for mixed composefs state

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -582,3 +582,7 @@ metadata, that's why it's only a few megabytes in size, and it will always repor
 Every version of the system will have its own unique composefs EROFS image.
 
 With composefs, `/` is backed by `/sysroot` and any disk monitoring tools should be updated to watch the `/sysroot` mountpoint, which is the real physical root.
+
+In some cases, after an upgrade, some nodes may have composefs enabled but not all of them. This is a known state caused by a bug in the MCO that
+cause some nodes to apply the update twice, causing them to get composefs enabled sooner than other. This has no impact and will resolve itself
+at the next update. See this [knowledge base article](https://access.redhat.com/solutions/7139041) for more details.


### PR DESCRIPTION
In some cases, after a cluster upgrades, some nodes may have composefs enabled but not others. This is due to a MCO bug [1] that triggers an extra deployment then removes it, which end up with the composefs EROFS image being created on those.
This result in the node using composefs sooner than the other nodes. This inconsistency is not causing any problem and will solve itself at the next upgrade, but we have had the questions asked enough times to link this KCS here.

[1] https://redhat.atlassian.net/browse/OCPBUGS-59958