### PR TITLE
NO-JIRA: extensions: templatize OCP version in repo names; drop kata from extensions

### DIFF
--- a/extensions/Containerfile
+++ b/extensions/Containerfile
@@ -5,6 +5,7 @@ RUN mkdir /os
 WORKDIR /os
 ADD . .
 ARG OPENSHIFT_CI=0
+ARG OPENSHIFT_VERSION=overridden
 RUN --mount=type=secret,id=yumrepos,target=/os/secret.repo extensions/build.sh
 
 ## Creates the repo metadata for the extensions.

--- a/extensions/build.sh
+++ b/extensions/build.sh
@@ -12,5 +12,10 @@ jq 'del(.["check-passwd","check-groups"])' /usr/share/rpm-ostree/treefile.json >
 
 
 . /etc/os-release
-rpm-ostree compose extensions filtered.json "extensions/${ID}-${VERSION_ID}.yaml" \
+extensions_yaml="extensions/${ID}-${VERSION_ID}.yaml"
+# Replace the __OCP_VERSION__ placeholder with the actual OpenShift version.
+# This allows the same YAML file to be used across different OCP versions
+# (e.g. 4.23 and 5.0) without duplication.
+sed -i "s/__OCP_VERSION__/${OPENSHIFT_VERSION}/g" "$extensions_yaml"
+rpm-ostree compose extensions filtered.json "$extensions_yaml" \
     --rootfs=/ --output-dir=/usr/share/rpm-ostree/extensions/

--- a/extensions/rhel-10.2.yaml
+++ b/extensions/rhel-10.2.yaml
@@ -14,8 +14,8 @@ repos:
   # Repo placed here to respect the rule above.
   # We do not have kata-container yet in 10.2
   # https://github.com/openshift/os/issues/1911
-  - rhel-9.8-server-ose-5.0
-  - rhel-10.2-server-ose-5.0
+  - rhel-9.8-server-ose-__OCP_VERSION__
+  - rhel-10.2-server-ose-__OCP_VERSION__
   # For two-node-ha extension.
   # Repo placed here to respect the rule above.
   - rhel-10.2-highavailability

--- a/extensions/rhel-10.2.yaml
+++ b/extensions/rhel-10.2.yaml
@@ -12,9 +12,6 @@ repos:
   - rhel-10.2-appstream
   # For kata-containers (sandboxed-containers).
   # Repo placed here to respect the rule above.
-  # We do not have kata-container yet in 10.2
-  # https://github.com/openshift/os/issues/1911
-  - rhel-9.8-server-ose-__OCP_VERSION__
   - rhel-10.2-server-ose-__OCP_VERSION__
   # For two-node-ha extension.
   # Repo placed here to respect the rule above.
@@ -24,7 +21,6 @@ repos:
   - rhel-10.2-fast-datapath
 
 extensions:
-  # Uncomment when the server-ose-4.22 repo exists for RHEL 10
   ipsec:
     packages:
       - libreswan
@@ -73,15 +69,18 @@ extensions:
       - kernel-rt-modules-extra
       - kernel-rt-devel
     match-base-evr: kernel
-  # https://github.com/openshift/machine-config-operator/pull/2456
-  # https://github.com/openshift/enhancements/blob/master/enhancements/sandboxed-containers/sandboxed-containers-tech-preview.md
-  # GRPA-3123
-  sandboxed-containers:
-    architectures:
-      - x86_64
-      - s390x
-    packages:
-      - kata-containers
+### XXX: Drop kata until it can be in all the repos it needs to be in
+### for us to compose extensions.
+###
+### https://github.com/openshift/machine-config-operator/pull/2456
+### https://github.com/openshift/enhancements/blob/master/enhancements/sandboxed-containers/sandboxed-containers-tech-preview.md
+### GRPA-3123
+##sandboxed-containers:
+##  architectures:
+##    - x86_64
+##    - s390x
+##  packages:
+##    - kata-containers
   # https://issues.redhat.com/browse/COS-2402
   kernel-64k:
     architectures:

--- a/extensions/rhel-9.8.yaml
+++ b/extensions/rhel-9.8.yaml
@@ -70,15 +70,18 @@ extensions:
       - kernel-rt-modules-extra
       - kernel-rt-devel
     match-base-evr: kernel
-  # https://github.com/openshift/machine-config-operator/pull/2456
-  # https://github.com/openshift/enhancements/blob/master/enhancements/sandboxed-containers/sandboxed-containers-tech-preview.md
-  # GRPA-3123
-  sandboxed-containers:
-    architectures:
-      - x86_64
-      - s390x
-    packages:
-      - kata-containers
+### XXX: Drop kata until it can be in all the repos it needs to be in
+### for us to compose extensions.
+###
+### https://github.com/openshift/machine-config-operator/pull/2456
+### https://github.com/openshift/enhancements/blob/master/enhancements/sandboxed-containers/sandboxed-containers-tech-preview.md
+### GRPA-3123
+##sandboxed-containers:
+##  architectures:
+##    - x86_64
+##    - s390x
+##  packages:
+##    - kata-containers
   # https://issues.redhat.com/browse/COS-2402
   kernel-64k:
     architectures:

--- a/extensions/rhel-9.8.yaml
+++ b/extensions/rhel-9.8.yaml
@@ -12,7 +12,7 @@ repos:
   - rhel-9.8-appstream
   # For kata-containers (sandboxed-containers).
   # Repo placed here to respect the rule above.
-  - rhel-9.8-server-ose-5.0
+  - rhel-9.8-server-ose-__OCP_VERSION__
   # For two-node-ha extension.
   # Repo placed here to respect the rule above.
   - rhel-9.8-highavailability


### PR DESCRIPTION
Replace hardcoded OCP version in server-ose repo names with an __OCP_VERSION__ placeholder that gets substituted at build time via OPENSHIFT_VERSION (already defined in build-args-*.conf files).

This allows the same extensions YAML files to be used for building against different OCP versions (e.g. 4.23 and 5.0) without duplicating the entire file just to change a repo name.

Assisted-by: <anthropic/claude-opus-4.6>

---

extensions: drop kata containers from extensions for now

The package is rarely in the places we need it and when we open requests
to get it built for newer versions that go unanswered [1][2].
    
Drop it until someone cares enough to fix it.
    
[1] https://github.com/openshift/os/issues/1911
[2] https://issues.redhat.com/browse/KATA-4726
