### PR TITLE
ART-19543: extensions: use dnf for ART builds, keep rpm-ostree for prow/local

### DIFF
--- a/extensions/build.sh
+++ b/extensions/build.sh
@@ -6,16 +6,36 @@ if [ "${OPENSHIFT_CI}" != 0 ]; then
     ci/get-ocp-repo.sh ocp.repo
 fi
 
-# just to parse the treefile, rpm-ostree still wants to read referenced "externals" (e.g. passwd, group)
-# hack around this for now by deleting the problematic bits; we should tweak rpm-ostree instead
-jq 'del(.["check-passwd","check-groups"])' /usr/share/rpm-ostree/treefile.json > filtered.json
-
-
 . /etc/os-release
 extensions_yaml="extensions/${ID}-${VERSION_ID}.yaml"
 # Replace the __OCP_VERSION__ placeholder with the actual OpenShift version.
 # This allows the same YAML file to be used across different OCP versions
 # (e.g. 4.23 and 5.0) without duplication.
 sed -i "s/__OCP_VERSION__/${OPENSHIFT_VERSION}/g" "$extensions_yaml"
-rpm-ostree compose extensions filtered.json "$extensions_yaml" \
-    --rootfs=/ --output-dir=/usr/share/rpm-ostree/extensions/
+
+# Detect if this is an ART build by checking for:
+# 1. The mounted secret.repo file (has content)
+# 2. OR the .oit directory (indicates ART rebase was done)
+# ART builds inject repos via secret.repo at rebase time OR via .oit/art-unsigned.repo
+# in the source directory, so we can use the dnf-based approach which ignores
+# the repos: section in the YAML.
+# Local/Prow builds don't have these indicators, so they need the rpm-ostree approach
+# which uses the repos: section from the YAML.
+if [ -s /os/secret.repo ] || [ -d .oit ]; then
+    echo "Detected ART build, using dnf-based approach"
+    # For ART builds, repos are already in /etc/yum.repos.d/ via secret.repo mount
+    # or via the rebase modifications to the Dockerfile
+    # Build extensions using dnf to download packages.
+    # This uses repos from /etc/yum.repos.d/ and ignores repos: sections in the YAML.
+    mkdir -p /usr/share/rpm-ostree/extensions/
+    python3 extensions/build_extensions.py "$extensions_yaml"
+else
+    echo "Detected local/Prow build (no ART indicators), using rpm-ostree approach"
+    # just to parse the treefile, rpm-ostree still wants to read referenced "externals" (e.g. passwd, group)
+    # hack around this for now by deleting the problematic bits; we should tweak rpm-ostree instead
+    jq 'del(.["check-passwd","check-groups"])' /usr/share/rpm-ostree/treefile.json > filtered.json
+
+    # Build extensions using rpm-ostree which respects repos: sections in the YAML
+    rpm-ostree compose extensions filtered.json "$extensions_yaml" \
+        --rootfs=/ --output-dir=/usr/share/rpm-ostree/extensions/
+fi

--- a/extensions/build_extensions.py
+++ b/extensions/build_extensions.py
@@ -36,6 +36,9 @@ def main() -> None:
     extensions = config.get("extensions", {})
     print(f"Found {len(extensions)} extensions")
 
+    # Get current architecture once for all extensions
+    current_arch = os.uname().machine
+
     for ext_name, ext_config in extensions.items():
         if not isinstance(ext_config, dict):
             continue
@@ -47,7 +50,6 @@ def main() -> None:
         # Check architecture filter if specified
         if "architectures" in ext_config:
             archs = ext_config["architectures"]
-            current_arch = os.uname().machine
             if current_arch not in archs:
                 print(f"Skipping {ext_name}: architecture {current_arch} not in {archs}")
                 continue
@@ -58,7 +60,7 @@ def main() -> None:
 
         # Use dnf download to get RPMs with all dependencies
         # Disable subscription-manager plugin to avoid hangs
-        cmd = ["dnf", "download", "--disableplugin=subscription-manager", "--resolve", "--alldeps", "--destdir=/usr/share/rpm-ostree/extensions/"] + packages
+        cmd = ["dnf", "download", f"--arch={current_arch}", "--arch=noarch", "--disableplugin=subscription-manager", "--resolve", "--alldeps", "--destdir=/usr/share/rpm-ostree/extensions/"] + packages
         print(f"  Running: {' '.join(cmd)}")
         sys.stdout.flush()
 

--- a/extensions/build_extensions.py
+++ b/extensions/build_extensions.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+"""
+This script builds RHCOS extensions by downloading RPM packages specified in a YAML configuration file.
+
+The script:
+1. Reads an extensions YAML file that defines extension packages
+2. Filters extensions by architecture if specified
+3. Downloads each extension's packages and dependencies using dnf
+4. Places all RPMs in /usr/share/rpm-ostree/extensions/
+
+Example usage:
+    python3 build_extensions.py extensions/rhel-10.2.yaml
+"""
+
+import yaml
+import subprocess
+import sys
+import os
+
+
+def main() -> None:
+    """
+    Main entry point for building extensions from a YAML configuration file.
+    """
+    if len(sys.argv) < 2:
+        print("Usage: build_extensions.py <extensions_yaml>", file=sys.stderr)
+        sys.exit(1)
+
+    extensions_yaml = sys.argv[1]
+
+    print(f"Loading extensions from {extensions_yaml}")
+    with open(extensions_yaml) as f:
+        config = yaml.safe_load(f)
+
+    extensions = config.get("extensions", {})
+    print(f"Found {len(extensions)} extensions")
+
+    for ext_name, ext_config in extensions.items():
+        if not isinstance(ext_config, dict):
+            continue
+
+        packages = ext_config.get("packages", [])
+        if not packages:
+            continue
+
+        # Check architecture filter if specified
+        if "architectures" in ext_config:
+            archs = ext_config["architectures"]
+            current_arch = os.uname().machine
+            if current_arch not in archs:
+                print(f"Skipping {ext_name}: architecture {current_arch} not in {archs}")
+                continue
+
+        print(f"Downloading extension: {ext_name}")
+        print(f"  Packages: {', '.join(packages)}")
+        sys.stdout.flush()
+
+        # Use dnf download to get RPMs with all dependencies
+        # Disable subscription-manager plugin to avoid hangs
+        cmd = ["dnf", "download", "--disableplugin=subscription-manager", "--resolve", "--alldeps", "--destdir=/usr/share/rpm-ostree/extensions/"] + packages
+        print(f"  Running: {' '.join(cmd)}")
+        sys.stdout.flush()
+
+        # Don't capture output so we can see dnf progress
+        result = subprocess.run(cmd)
+        if result.returncode != 0:
+            print(f"Error downloading {ext_name}", file=sys.stderr)
+            sys.exit(1)
+
+        print(f"  Downloaded successfully")
+
+    print("All extensions downloaded to /usr/share/rpm-ostree/extensions/")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Switch ART builds to use `dnf download` instead of `rpm-ostree compose extensions`
- Keep prow and local builds using `rpm-ostree compose extensions` as before
- Resolves repo naming conflicts for ART builds that inject repos via `/etc/yum.repos.d/`

## Details

ART builds inject repository configurations via `/etc/yum.repos.d/` which have different names than those defined in the extensions YAML files. This mismatch causes `rpm-ostree compose extensions` to fail because it expects exact repo name matches.

By switching to `dnf download`, we allow ART builds to use whatever repo names are present in the environment, while prow and local builds continue with the existing `rpm-ostree` workflow unchanged.