### PR TITLE
[release-4.22] NO-JIRA: Containerfile: restore meta.json as last layer in image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -14,8 +14,11 @@ RUN --mount=type=bind,target=/run/src /run/src/scripts/generate-metadata
 RUN --mount=type=bind,target=/run/src /run/src/scripts/generate-labels
 
 FROM build
-COPY --from=metadata /usr/share/openshift /usr/share/openshift
 COPY --from=metadata /usr/share/buildinfo /usr/share/buildinfo
+# Copy in the meta.json. This needs to be the last operation that
+# creates a layer in the image build so that our `oc image extract img[-1]`
+# trick works. See https://github.com/coreos/fedora-coreos-pipeline/blob/80c2625b89185f8adc5568fae112484a427c5806/utils.groovy#L1004
+COPY --from=metadata /usr/share/openshift /usr/share/openshift
 ARG IMAGE_NAME
 ARG IMAGE_CPE
 ARG TARGETARCH


### PR DESCRIPTION
Backport of https://github.com/openshift/os/commit/17084e8ab842a728390edf85930c614626523ac7 to `release-4.22`.

After #1946 landed, the `COPY --from=metadata /usr/share/buildinfo` layer was added after the `COPY --from=metadata /usr/share/openshift` layer. This broke the pipeline's `oc image extract img[-1]` trick for extracting `meta.json`, since `[-1]` now selects the buildinfo layer instead.

This reorders the `COPY` instructions so `/usr/share/openshift` (containing `meta.json`) is the last layer-creating operation again, and adds a comment documenting the constraint.

First failure: [build-node-image #7767](https://jenkins-rhcos--prod-pipeline.apps.int.prod-stable-spoke1-dc-iad2.itup.redhat.com/job/build-node-image/7767/)