### PR TITLE
CNF-25994: Blacklist unused filesystem kernel modules

### DIFF
--- a/etc/modprobe.d/blacklist-unused-filesystems.conf
+++ b/etc/modprobe.d/blacklist-unused-filesystems.conf
@@ -1,0 +1,13 @@
+# Blacklist unused filesystem kernel modules
+# These filesystem types have no legitimate use on a container host OS.
+# CIS Benchmark RHEL 9 v2.0.0, Section 1.1.1 (Level 1 Server)
+#
+# Excluded from this list:
+#   squashfs - used by CoreOS live PXE rootfs
+#   udf - used by Azure/Hyper-V for provisioning (Ignition)
+#   usb-storage - needed for BMC virtual media and bare-metal provisioning
+install cramfs /bin/true
+install freevxfs /bin/true
+install hfs /bin/true
+install hfsplus /bin/true
+install jffs2 /bin/true


### PR DESCRIPTION
**Jira:** [CNF-25994](https://redhat.atlassian.net/browse/CNF-25994)

## Summary

Add a modprobe configuration to prevent loading of 5 filesystem kernel modules
that have no legitimate use on a container host OS:

- `cramfs` — compressed ROM filesystem (embedded Linux only)
- `freevxfs` — Veritas filesystem
- `hfs` — legacy Mac filesystem
- `hfsplus` — Mac OS Extended filesystem
- `jffs2` — Journalling Flash File System v2 (raw flash devices only)

These modules represent attack surface with zero functional value on RHCOS.
Disabling them is a [CIS Benchmark RHEL 9 v2.0.0](https://www.cisecurity.org/benchmark/red_hat_linux)
Level 1 Server requirement (Section 1.1.1).

## Why openshift/os

This was originally proposed in [coreos/rhel-coreos-config#289](https://github.com/coreos/rhel-coreos-config/pull/289).
Per [reviewer feedback](https://github.com/coreos/rhel-coreos-config/pull/289#issuecomment-5144604049)
from @dustymabe, this hardening is OCP-specific and belongs at the node image
layer (`openshift/os`) rather than the base RHCOS layer (`rhel-coreos-config`).

## What is excluded

- **squashfs** — actively used by CoreOS for live PXE rootfs
- **udf** — used by Azure/Hyper-V Ignition for [provisioning config](https://github.com/coreos/ignition/blob/7feb4ce111db204d81bebd7fb5dfb8ffa5514f9e/internal/providers/azure/azure.go#L59-L62) (removed from v1 per reviewer feedback)
- **usb-storage** — needed for BMC virtual media and bare-metal provisioning

## CVE evidence

These modules are not theoretical risk — they carry demonstrated CVE exposure:

- **[CVE-2025-0927](https://nvd.nist.gov/vuln/detail/CVE-2025-0927)** (CVSS 7.8) — HFS+ slab out-of-bounds write allowing local root escalation. Exploitable via unprivileged mount through udisks2/polkit. Public exploit exists. Affected all kernels through 6.12.0. The bug existed since 2005. **Blacklisting hfsplus completely prevents this attack chain.**
- [CVE-2024-45783](https://access.redhat.com/security/cve/CVE-2024-45783) — HFS+ vulnerability in grub2 filesystem code

## Precedent

**Existing module blacklisting in RHCOS/Fedora ecosystem:**
- The [nouveau driver blacklist](https://github.com/coreos/fedora-coreos-config/pull/157) (merged 2019) uses the same modprobe.d drop-in pattern
- Fedora already ships 10 kernel module blacklists (blacklist-rare-network.conf) — RHCOS own upstream already ships default module blacklists; extending to filesystems follows the identical pattern
- [FCOS tracker #2152](https://github.com/coreos/fedora-coreos-tracker/issues/2152) — active discussion among FCOS/RHCOS maintainers on denylisting unused kernel modules by default

**Red Hat official endorsement:**
- Red Hat recommends modprobe.d blacklisting as CVE mitigation on RHCOS ([KCS 6979679](https://access.redhat.com/solutions/6979679) — kernel module blacklist via MachineConfig; [KCS 7117703](https://access.redhat.com/articles/7117703) — USB attack mitigation)

**Distribution-level precedent:**
- [openSUSE](https://github.com/openSUSE/suse-module-tools) ships 25+ filesystem module blacklists at the OS image level since 2019
- [Flatcar Container Linux](https://www.flatcar.org/docs/latest/setup/security/hardening-guide/) hardening guide recommends blacklisting these exact 5 modules
- [Bottlerocket](https://github.com/bottlerocket-os/bottlerocket) runs kernel lockdown in integrity mode — only image-included modules can load
- [Talos Linux](https://www.talos.dev/) uses a fixed module set at build time with no dynamic loading
- [secureblue](https://github.com/secureblue/secureblue) (Fedora Atomic variant, referenced by @travier) blacklists 100+ modules including all 5 targets

**Compliance frameworks:**
- CIS RHEL 9 v2.0.0 Section 1.1.1 — Level 1, automated (CCE-83853-2, CCE-86763-0, CCE-86764-8, CCE-86765-5, CCE-86766-3)
- DISA STIG V-257880 (cramfs disable requirement)
- [NIST SP 800-53 [CM-7](https://redhat.atlassian.net/browse/CM-7)](https://csf.tools/reference/nist-sp-800-53/r5/cm/cm-7/) — Least Functionality

**Customer demand:**
- Telco customers have requested CIS-compliant kernel module controls on OCP

## Testing

Verified on OCP 4.22 (MNO, 3 master + 2 worker) and OCP 4.21 (SNO) that
blacklisting these 5 modules causes no functional regressions. These modules
are not loaded by default on RHCOS and have no consumers in the container
host stack. Source code audit across 16 OCP repos confirmed zero functional
dependencies.

Assisted by: Claude (Anthropic)
