### PR TITLE
OCPBUGS-104572: NetworkManager-ovs has moved up to RHCOS

### DIFF
--- a/build-node-image.sh
+++ b/build-node-image.sh
@@ -40,7 +40,6 @@ dnf --repo="${YUM_REPO_NAMES}" install -y \
     cri-o cri-tools conmon-rs \
     openshift-clients openshift-kubelet \
     openvswitch3.5 \
-    NetworkManager-ovs \
     ose-aws-ecr-image-credential-provider \
     ose-azure-acr-image-credential-provider \
     ose-gcp-gcr-image-credential-provider \


### PR DESCRIPTION
NetworkManager-ovs was being installed in the node-image layer (openshift/os) from OCP repos. Because the base image version-locks all its packages before the node layer runs, NetworkManager-ovs could end up at a different version than NetworkManager itself. Move it to the base image so both are sourced from the same RHEL repos and stay in sync.

Depends on https://github.com/coreos/rhel-coreos-config/pull/296