### PR TITLE
OKD-418: Prevent cross-version package contamination in SCOS 5.0 builds

### DIFF
--- a/build-node-image.sh
+++ b/build-node-image.sh
@@ -36,9 +36,11 @@ mkdir -p /var/opt
 dnf --disablerepo=* versionlock add '*'
 
 # Install the OCP packages. Limit to appropriate repos for this stream.
+# Pin openshift-* minimum versions to prevent cross-version contamination
+# when the SIG repo contains packages from multiple OKD releases (OKD-418).
 dnf --repo="${YUM_REPO_NAMES}" install -y \
     cri-o cri-tools conmon-rs \
-    openshift-clients openshift-kubelet \
+    "openshift-clients >= ${OPENSHIFT_VERSION}" "openshift-kubelet >= ${OPENSHIFT_VERSION}" \
     openvswitch3.5 \
     NetworkManager-ovs \
     ose-aws-ecr-image-credential-provider \

--- a/c10s.repo
+++ b/c10s.repo
@@ -61,3 +61,7 @@ gpgcheck=1
 repo_gpgcheck=0
 enabled=1
 gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Cloud
+# Exclude el9 packages: the SIG okd-5.0 repo incorrectly contains el9/4.22
+# builds alongside el10s/5.0 builds. A CentOS 10 image must never install
+# el9 binaries (OKD-418).
+exclude=*.el9 *.el9.*


### PR DESCRIPTION
## Summary

The CentOS SIG `okd-5.0` repo on `mirror.stream.centos.org` contains 4.22/el9 packages (kubelet, openshift-clients) alongside the correct 5.0/el10s packages. This causes dnf to install el9 binaries into the CentOS 10 SCOS image, producing kubelet version skew (k8s 1.35 vs 1.36) and **5+ consecutive rejected OKD SCOS 5.0 nightly payloads since July 24**.

Affected packages in the failing payloads:
- `openshift-kubelet`: 5.0.0 (el10) → 4.22.0 (el9)
- `openshift-clients`: 5.0.0 (el10) → 4.22.0 (el9)
- `cri-o`: 1.36.2 (el10s) → 1.35.5 (el10s) — **not addressed by this PR** (see below)
- `cri-tools`: 1.36.0 → 1.35.0

Two defensive fixes:

- **`c10s.repo`**: Exclude el9 packages from the SIG Cloud OKD repo. A CentOS 10 image must never install el9 binaries regardless of upstream repo contents.
- **`build-node-image.sh`**: Pin `openshift-clients` and `openshift-kubelet` to `>= $OPENSHIFT_VERSION` (5.0) so dnf refuses to install 4.22 packages even if rebuilt for el10.

## What this does NOT fix

The cri-o downgrade (1.36.2 → 1.35.5, both el10s) cannot be fixed defensively here — cri-o uses a different versioning scheme (1.36 for OKD 5.0) with no derivable relationship to `OPENSHIFT_VERSION`. The upstream CBS tag for the `okd-5.0` repo needs to be cleaned by the CentOS SIG Cloud maintainers to remove the 4.22 cri-o builds.

## Jira

- [OKD-418](https://issues.redhat.com/browse/OKD-418) — OKD SCOS 5.0 nightlies broken - CentOS SIG okd-5.0 repo contains 4.22 packages causing RPM downgrades
- Related: [OKD-387](https://issues.redhat.com/browse/OKD-387) — Fixed the reverse problem (4.22 getting 5.0 packages) via #1947