### PR TITLE
OCPBUGS-105444: NetworkManager-ovs has moved to RHCOS

### DIFF
--- a/packages-openshift.yaml
+++ b/packages-openshift.yaml
@@ -47,7 +47,6 @@ packages:
   - openvswitch3.5
   # The packages below are present in CentOS Stream/RHEL,
   # and depend on one or more of the above.
-  - NetworkManager-ovs
   - ose-aws-ecr-image-credential-provider
   - ose-azure-acr-image-credential-provider
   - ose-gcp-gcr-image-credential-provider


### PR DESCRIPTION
NetworkManager-ovs was being installed in the node-image layer (openshift/os) from OCP repos. Because the base image version-locks all its packages before the node layer runs, NetworkManager-ovs could end up at a different version than NetworkManager itself. Move it to the base image so both are sourced from the same RHEL repos and stay in sync.