### PR TITLE
OCPBUGS-86429: Unpin libreswan version for IPsec scaling fix

### DIFF
--- a/extensions-rhel-9.6.yaml
+++ b/extensions-rhel-9.6.yaml
@@ -18,9 +18,7 @@ extensions:
   # https://github.com/coreos/fedora-coreos-tracker/issues/1504
   ipsec:
     packages:
-      # pin to 4.6-3.el9_0.3 for now for https://issues.redhat.com/browse/OCPBUGS-43498
-      # we can revert once that's fixed in latest libreswan
-      - libreswan-4.6-3.el9_0.3
+      - libreswan
       - NetworkManager-libreswan
   # https://github.com/coreos/fedora-coreos-tracker/issues/326
   usbguard:


### PR DESCRIPTION
## Summary
Unpin libreswan from version 4.6 to enable consuming libreswan 5.x from the FDP repository, which resolves IPsec pluto segfaults at 75+ node scale in 4.18.z.

## Background
At 75+ node IPsec mesh scale, libreswan 4.6 pluto crashes with a segfault in `set_larval_v2_transition()` during concurrent Child SA negotiation, causing permanent tunnel failures. Libreswan 5.x fixes this issue.

This reverts the pin added for OCPBUGS-43498, as libreswan 5.x resolves the scaling problem.

## Related Changes
This is part of a coordinated set of PRs to unpin libreswan in 4.18.z:
- **openshift/os**: this PR
- **openshift/machine-config-operator**: openshift/machine-config-operator#6310
- **openshift/cluster-network-operator**: (to be created - skip `_stackmanager` for libreswan 5.3+)
- **openshift/ovn-kubernetes**: (to be created - unpin libreswan in Dockerfile)

## References
- **Bug**: https://issues.redhat.com/browse/OCPBUGS-86429
- **Brew build**: https://brewweb.engineering.redhat.com/brew/taskinfo?taskID=66972299
- **Cherry-picked from**: openshift/os#1771 (9bb575ad1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)