### PR TITLE
OCPBUGS-115309: Re-enable sandboxed-containers extension for 5.0

### DIFF
--- a/extensions/rhel-10.2.yaml
+++ b/extensions/rhel-10.2.yaml
@@ -46,18 +46,15 @@ extensions:
       - kernel-rt-modules-core
       - kernel-rt-modules-extra
       - kernel-rt-devel
-### XXX: Drop kata until it can be in all the repos it needs to be in
-### for us to compose extensions.
-###
-### https://github.com/openshift/machine-config-operator/pull/2456
-### https://github.com/openshift/enhancements/blob/master/enhancements/sandboxed-containers/sandboxed-containers-tech-preview.md
-### GRPA-3123
-##sandboxed-containers:
-##  architectures:
-##    - x86_64
-##    - s390x
-##  packages:
-##    - kata-containers
+  # https://github.com/openshift/machine-config-operator/pull/2456
+  # https://github.com/openshift/enhancements/blob/master/enhancements/sandboxed-containers/sandboxed-containers-tech-preview.md
+  # GRPA-3123
+  sandboxed-containers:
+    architectures:
+      - x86_64
+      - s390x
+    packages:
+      - kata-containers
   # https://issues.redhat.com/browse/COS-2402
   kernel-64k:
     architectures:

--- a/extensions/rhel-9.8.yaml
+++ b/extensions/rhel-9.8.yaml
@@ -47,18 +47,15 @@ extensions:
       - kernel-rt-modules-core
       - kernel-rt-modules-extra
       - kernel-rt-devel
-### XXX: Drop kata until it can be in all the repos it needs to be in
-### for us to compose extensions.
-###
-### https://github.com/openshift/machine-config-operator/pull/2456
-### https://github.com/openshift/enhancements/blob/master/enhancements/sandboxed-containers/sandboxed-containers-tech-preview.md
-### GRPA-3123
-##sandboxed-containers:
-##  architectures:
-##    - x86_64
-##    - s390x
-##  packages:
-##    - kata-containers
+  # https://github.com/openshift/machine-config-operator/pull/2456
+  # https://github.com/openshift/enhancements/blob/master/enhancements/sandboxed-containers/sandboxed-containers-tech-preview.md
+  # GRPA-3123
+  sandboxed-containers:
+    architectures:
+      - x86_64
+      - s390x
+    packages:
+      - kata-containers
   # https://issues.redhat.com/browse/COS-2402
   kernel-64k:
     architectures:


### PR DESCRIPTION
[KATA-4726](https://redhat.atlassian.net/browse/KATA-4726) made kata-containers available again for RHCOS 9.8 and 10.2. Restore the sandboxed-containers extension in those definitions so 5.0 builds can ship it.