### PR TITLE
NO-JIRA: extensions/Dockerfile: add extensions.json to last layer

### DIFF
--- a/extensions/Dockerfile
+++ b/extensions/Dockerfile
@@ -39,6 +39,15 @@ dnf repoquery --repofrompath=extensions,/usr/share/rpm-ostree/extensions/ \
 sed "$ s/,$//" >> /tmp/extensions.json && \
 echo "}" >> /tmp/extensions.json'
 
+# Also bake extensions.json into the image so it can be extracted from there
+# (e.g. via `oc image extract` or `podman run $img cat ...`). The write to
+# /tmp/extensions.json above is kept for coreos-assembler, which bind-mounts
+# that path into the build.
+RUN cp /tmp/extensions.json /usr/share/rpm-ostree/extensions.json
+
 ## Final container that has the extensions repo dir
 FROM registry.access.redhat.com/ubi9/ubi:latest
 COPY --from=builder /usr/share/rpm-ostree/extensions/ /usr/share/rpm-ostree/extensions/
+# Make this the last layer, this is similar to the metalayer trick in the node
+# image, but this one is specific to rpm-ostree extensions.
+COPY --from=builder /usr/share/rpm-ostree/extensions.json /usr/share/rpm-ostree/extensions.json


### PR DESCRIPTION
Backport of commit 31816ac from master. On release branches the extensions container is still built by coreos-assembler, which bind-mounts /tmp/extensions.json into the build to propagate the extensions metadata into the build's meta.json, so keep writing to that path.

In addition, bake extensions.json into the final container image, so that it is easy for anyone but particularly ART to query metadata about the extensions container, e.g. via `oc image extract` or `podman run $img cat /usr/share/rpm-ostree/extensions.json`.

Assisted-by: AI